### PR TITLE
Enabling ability for Bot to run multiple instance at once

### DIFF
--- a/test_port_allocation.sh
+++ b/test_port_allocation.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Test script to verify port allocation for multiple bot instances
+# This script simulates multiple concurrent bot launches
+
+echo "Testing port allocation for multiple bot instances..."
+echo "======================================================="
+
+# Source the run_bot.sh to get access to the port functions
+source ./run_bot.sh > /dev/null 2>&1
+
+# Test 1: Sequential port allocation
+echo "Test 1: Sequential port allocation"
+echo "-----------------------------------"
+
+for i in {1..5}; do
+    echo "Instance $i:"
+    ports=$(get_next_bot_ports)
+    if [ $? -eq 0 ]; then
+        main_port=$(echo $ports | cut -d' ' -f1)
+        vnc_port=$(echo $ports | cut -d' ' -f2)
+        echo "  Main port: $main_port, VNC port: $vnc_port"
+        
+        # Simulate some work time
+        sleep 1
+        
+        # Release the ports
+        release_port_lock $main_port
+        release_port_lock $vnc_port
+    else
+        echo "  Failed to allocate ports"
+    fi
+done
+
+echo ""
+
+# Test 2: Concurrent port allocation (background processes)
+echo "Test 2: Concurrent port allocation"
+echo "-----------------------------------"
+
+# Function to allocate and hold ports for a short time
+allocate_and_hold() {
+    local instance_id=$1
+    local hold_time=$2
+    
+    ports=$(get_next_bot_ports)
+    if [ $? -eq 0 ]; then
+        main_port=$(echo $ports | cut -d' ' -f1)
+        vnc_port=$(echo $ports | cut -d' ' -f2)
+        echo "Instance $instance_id: Main port: $main_port, VNC port: $vnc_port"
+        
+        # Hold the ports for specified time
+        sleep $hold_time
+        
+        # Release the ports
+        release_port_lock $main_port
+        release_port_lock $vnc_port
+        echo "Instance $instance_id: Released ports $main_port and $vnc_port"
+    else
+        echo "Instance $instance_id: Failed to allocate ports"
+    fi
+}
+
+# Launch multiple instances concurrently
+for i in {1..3}; do
+    allocate_and_hold $i 3 &
+done
+
+# Wait for all background processes to complete
+wait
+
+echo ""
+echo "Port allocation test completed!"
+echo "Check /tmp/baas_port_locks/ for any remaining lock files:"
+ls -la /tmp/baas_port_locks/ 2>/dev/null || echo "No lock files remaining (good!)"


### PR DESCRIPTION
i am having problem with #58 and why not to adding an ability to run multiple bot instance at the same time?

so in this PR i added an ability to run multiple bot instance at once.

the changes is so simple, before this PR each bot instance is running in the port 3000 hardcoded. but in this PR i changes it to dynamic port so each bot will never bind the same port again.

i provide a test for port allocation in my commits. 

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Unit tests pass
- [x] Manual testing completed
- [ ] Integration tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] Tests added/updated