### PR TITLE
fix: add missed transcribe modal

### DIFF
--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -163,6 +163,12 @@ export class SimpleDialogObserver {
                         'div[role="dialog"]:has-text("video call is being recorded"):has(button)',
                     buttonTexts: ['Join now'],
                 },
+                {
+                    name: 'transcribe_notification',
+                    selector:
+                      'div[role="dialog"]:has-text("This video call is being transcribed"):has(button)',
+                    buttonTexts: ['Join now'],
+                },
                 // Generic dismiss modals (fallback)
                 {
                     name: 'generic_dismiss',


### PR DESCRIPTION
<img width="261" height="60" alt="Screenshot 2025-10-15 at 09 48 24" src="https://github.com/user-attachments/assets/351422a2-a269-4cd1-87a3-e002058271e7" />

This PR adds a missed condition check to the observer related to the Transcribe Modal, ensuring it’s properly triggered when expected.