### PR TITLE
feat: add Teams entry message

### DIFF
--- a/src/meeting/meet/speakersObserver.ts
+++ b/src/meeting/meet/speakersObserver.ts
@@ -79,6 +79,12 @@ export class MeetSpeakersObserver {
                 let MUTATION_OBSERVER: MutationObserver | null = null
                 let periodicCheck: any = null
 
+                // ========== MEMORY OPTIMIZATION: Track iframe content observers ==========
+                // This array stores all MutationObservers created for iframe content
+                // Without tracking, these observers leak and accumulate over time
+                const iframeContentObservers: MutationObserver[] = []
+                let observerCount = 0
+
                 // EXACT SAME freeze detection variables as extension
                 let lastValidSpeakers: SpeakerData[] = []
                 let lastValidSpeakerCheck = Date.now()
@@ -693,6 +699,7 @@ export class MeetSpeakersObserver {
                         }, checkInterval)
 
                         // Setup iframe observation
+                        // ========== MEMORY OPTIMIZATION: Track all iframe content observers ==========
                         const iframeObserver = observeIframes((iframe) => {
                             const iframeDoc = getIframeDocument(iframe)
                             if (iframeDoc) {
@@ -723,10 +730,16 @@ export class MeetSpeakersObserver {
                                     subtree: true,
                                     attributeFilter: ['class', 'aria-label'],
                                 })
+
+                                // CRITICAL: Track this observer for later cleanup
+                                iframeContentObservers.push(observer)
+                                observerCount++
+                                console.log(`[Meet-Browser] Created iframe content observer #${observerCount}`)
                             }
                         })
 
                         // Cleanup function
+                        // ========== MEMORY OPTIMIZATION: Clean up ALL observers ==========
                         ;(window as any).meetObserverCleanup = () => {
                             console.log('[Meet-Browser] Cleaning up observer')
                             if (MUTATION_OBSERVER) {
@@ -741,6 +754,14 @@ export class MeetSpeakersObserver {
                             if (iframeObserver) {
                                 iframeObserver.disconnect()
                             }
+
+                            // CRITICAL: Disconnect ALL iframe content observers
+                            // Without this, observers accumulate and leak memory
+                            console.log(`[Meet-Browser] Disconnecting ${iframeContentObservers.length} iframe content observers`)
+                            for (const obs of iframeContentObservers) {
+                                obs.disconnect()
+                            }
+                            iframeContentObservers.length = 0
                         }
 
                         // CRITICAL: Initial check

--- a/src/meeting/shared/audio-capture.ts
+++ b/src/meeting/shared/audio-capture.ts
@@ -221,18 +221,41 @@ function generateAudioCaptureScript(config: AudioCaptureConfig): string {
                 // Expose stop function globally for cleanup
                 window.${stopFunctionName} = stopMixedStreamProcessor
 
-                // Auto-cleanup on page unload
-                window.addEventListener('beforeunload', () => {
-                    stopMixedStreamProcessor()
-                })
+                // ========== MEMORY OPTIMIZATION: Named event handlers for proper cleanup ==========
+                // Anonymous functions cannot be removed, so we use named functions
+                let beforeUnloadHandler = null
+                let visibilityChangeHandler = null
+                let listenersAttached = false
 
-                // Auto-cleanup on visibility change
-                document.addEventListener('visibilitychange', () => {
+                // Named handler for beforeunload
+                beforeUnloadHandler = function handleBeforeUnload() {
+                    console.log('${logPrefix} beforeunload event, stopping processor...')
+                    stopMixedStreamProcessor()
+                }
+
+                // Named handler for visibility change
+                visibilityChangeHandler = function handleVisibilityChange() {
                     if (document.visibilityState === 'hidden') {
                         console.log('${logPrefix} Page hidden, stopping processor...')
                         stopMixedStreamProcessor()
                     }
-                })
+                }
+
+                // Attach event listeners
+                window.addEventListener('beforeunload', beforeUnloadHandler)
+                document.addEventListener('visibilitychange', visibilityChangeHandler)
+                listenersAttached = true
+                console.log('${logPrefix} Event listeners attached')
+
+                // Expose cleanup function to remove event listeners
+                window.${stopFunctionName}Cleanup = function() {
+                    if (listenersAttached && beforeUnloadHandler && visibilityChangeHandler) {
+                        window.removeEventListener('beforeunload', beforeUnloadHandler)
+                        document.removeEventListener('visibilitychange', visibilityChangeHandler)
+                        listenersAttached = false
+                        console.log('${logPrefix} Event listeners removed')
+                    }
+                }
 
                 // Connect a track to the mixer
                 function connectTrackToMixer(track) {
@@ -405,10 +428,20 @@ export function createAudioCapture(config: AudioCaptureConfig) {
         stop: async (page: Page): Promise<void> => {
             try {
                 await page.evaluate((stopFn) => {
+                    // Stop the audio processor
                     if (typeof (window as any)[stopFn] === 'function') {
                         return (window as any)[stopFn]()
                     }
                 }, stopFunctionName)
+
+                // Also clean up event listeners (MEMORY OPTIMIZATION)
+                await page.evaluate((stopFn) => {
+                    const cleanupFn = stopFn + 'Cleanup'
+                    if (typeof (window as any)[cleanupFn] === 'function') {
+                        return (window as any)[cleanupFn]()
+                    }
+                }, stopFunctionName)
+
                 console.log(`${logPrefix} Audio capture stopped from Node.js`)
             } catch (error) {
                 console.error(`${logPrefix} Failed to stop audio capture:`, formatError(error))

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -15,6 +15,11 @@ import { enableTeamsAudioCapture, verifyTeamsAudioCapture } from './teams/audio-
 // Create a singleton detector instance for Microsoft Teams
 const teamsStateDetector = createStateDetector(TEAMS_STATE_CONFIG)
 
+// Entry message retry constants
+const MAX_CHAT_RETRIES = 5
+const CHAT_RETRY_INTERVAL_MS = 5000
+const CHAT_ACTION_TIMEOUT_MS = 3000
+
 export class TeamsProvider implements MeetingProviderInterface {
     constructor() {}
     async parseMeetingUrl(meeting_url: string) {
@@ -879,4 +884,78 @@ async function isInTeamsMeeting(page: Page): Promise<boolean> {
         console.error('Error checking if in Teams meeting:', formatError(error))
         return false
     }
+}
+
+// Export for use in InCallState (non-blocking entry message)
+export async function sendTeamsEntryMessage(
+    page: Page,
+    enterMessage: string,
+): Promise<boolean> {
+    console.log('[Teams] Attempting to send entry message...')
+
+    // Truncate to 500 characters
+    enterMessage = enterMessage.substring(0, 500)
+
+    for (let attempt = 1; attempt <= MAX_CHAT_RETRIES; attempt++) {
+        // Check if bot is leaving/removed before each attempt
+        if (GLOBAL.getEndReason()) {
+            console.log('[Teams] Bot is ending, aborting entry message')
+            return false
+        }
+
+        try {
+            // Chat button can take 10-20s to appear after joining — retries handle this
+            const chatButton = page.locator('button#chat-button[aria-label="Chat"]')
+            if ((await chatButton.count()) === 0) {
+                console.log(`[Teams] Chat button not found, attempt ${attempt}/${MAX_CHAT_RETRIES}`)
+                if (attempt < MAX_CHAT_RETRIES) {
+                    await sleep(CHAT_RETRY_INTERVAL_MS)
+                }
+                continue
+            }
+
+            // Use evaluate() for all clicks — header is hidden (opacity:0) and main area
+            // has z-index:900000, so normal Playwright clicks would fail visibility checks
+            await chatButton.evaluate((el: HTMLElement) => el.click())
+            console.log('[Teams] Chat button clicked')
+
+            await page.waitForSelector('div[data-tid="ckeditor"][role="textbox"]', {
+                timeout: CHAT_ACTION_TIMEOUT_MS,
+            })
+
+            await page.$eval('div[data-tid="ckeditor"][role="textbox"]', (el: HTMLElement) => el.focus())
+
+            // CKEditor ignores programmatic value changes — real keyboard events are required
+            await page.keyboard.type(enterMessage)
+            await page.waitForTimeout(200)
+
+            const sendButton = page.locator('button[data-tid="newMessageCommands-send"]')
+            if ((await sendButton.count()) > 0) {
+                await sendButton.evaluate((el: HTMLElement) => el.click())
+                console.log('[Teams] Entry message sent successfully')
+            } else {
+                console.warn('[Teams] Send button not found, trying Enter key')
+                await page.keyboard.press('Enter')
+            }
+
+            await page.waitForTimeout(200)
+
+            // Close chat panel so it doesn't linger in the recording
+            const closeButton = page.locator('button[data-tid="rail-header-close-button"]')
+            if ((await closeButton.count()) > 0) {
+                await closeButton.evaluate((el: HTMLElement) => el.click())
+                console.log('[Teams] Chat panel closed')
+            }
+
+            return true
+        } catch (error) {
+            console.warn(`[Teams] Entry message attempt ${attempt}/${MAX_CHAT_RETRIES} failed:`, formatError(error))
+            if (attempt < MAX_CHAT_RETRIES) {
+                await sleep(CHAT_RETRY_INTERVAL_MS)
+            }
+        }
+    }
+
+    console.log('[Teams] Failed to send entry message after all attempts')
+    return false
 }

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -904,26 +904,32 @@ export async function sendTeamsEntryMessage(
         }
 
         try {
-            // Chat button can take 10-20s to appear after joining — retries handle this
-            const chatButton = page.locator('button#chat-button[aria-label="Chat"]')
-            if ((await chatButton.count()) === 0) {
-                console.log(`[Teams] Chat button not found, attempt ${attempt}/${MAX_CHAT_RETRIES}`)
-                if (attempt < MAX_CHAT_RETRIES) {
-                    await sleep(CHAT_RETRY_INTERVAL_MS)
+            // Check if CKEditor is already visible (chat panel already open from previous attempt)
+            const editorSelector = 'div[data-tid="ckeditor"][role="textbox"]'
+            const editorAlreadyVisible = (await page.locator(editorSelector).count()) > 0
+
+            if (!editorAlreadyVisible) {
+                // Chat button can take 10-20s to appear after joining — retries handle this
+                const chatButton = page.locator('button#chat-button[aria-label="Chat"]')
+                if ((await chatButton.count()) === 0) {
+                    console.log(`[Teams] Chat button not found, attempt ${attempt}/${MAX_CHAT_RETRIES}`)
+                    if (attempt < MAX_CHAT_RETRIES) {
+                        await sleep(CHAT_RETRY_INTERVAL_MS)
+                    }
+                    continue
                 }
-                continue
+
+                // Use evaluate() for all clicks — header is hidden (opacity:0) and main area
+                // has z-index:900000, so normal Playwright clicks would fail visibility checks
+                await chatButton.evaluate((el: HTMLElement) => el.click())
+                console.log('[Teams] Chat button clicked')
+
+                await page.waitForSelector(editorSelector, {
+                    timeout: CHAT_ACTION_TIMEOUT_MS,
+                })
             }
 
-            // Use evaluate() for all clicks — header is hidden (opacity:0) and main area
-            // has z-index:900000, so normal Playwright clicks would fail visibility checks
-            await chatButton.evaluate((el: HTMLElement) => el.click())
-            console.log('[Teams] Chat button clicked')
-
-            await page.waitForSelector('div[data-tid="ckeditor"][role="textbox"]', {
-                timeout: CHAT_ACTION_TIMEOUT_MS,
-            })
-
-            await page.$eval('div[data-tid="ckeditor"][role="textbox"]', (el: HTMLElement) => el.focus())
+            await page.$eval(editorSelector, (el: HTMLElement) => el.focus())
 
             // CKEditor ignores programmatic value changes — real keyboard events are required
             await page.keyboard.type(enterMessage)

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -894,7 +894,7 @@ export async function sendTeamsEntryMessage(
     console.log('[Teams] Attempting to send entry message...')
 
     // Truncate to 500 characters
-    enterMessage = enterMessage.substring(0, 500)
+    const truncatedMessage = enterMessage.substring(0, 500)
 
     for (let attempt = 1; attempt <= MAX_CHAT_RETRIES; attempt++) {
         // Check if bot is leaving/removed before each attempt
@@ -929,10 +929,14 @@ export async function sendTeamsEntryMessage(
                 })
             }
 
+            // Ensure editor is still present before interacting (avoids race if panel closed)
+            await page.waitForSelector(editorSelector, {
+                timeout: CHAT_ACTION_TIMEOUT_MS,
+            })
             await page.$eval(editorSelector, (el: HTMLElement) => el.focus())
 
             // CKEditor ignores programmatic value changes — real keyboard events are required
-            await page.keyboard.type(enterMessage)
+            await page.keyboard.type(truncatedMessage)
             await page.waitForTimeout(200)
 
             const sendButton = page.locator('button[data-tid="newMessageCommands-send"]')

--- a/src/meeting/teams/htmlCleaner.ts
+++ b/src/meeting/teams/htmlCleaner.ts
@@ -90,6 +90,8 @@ export class TeamsHtmlCleaner {
                     if (mainArea instanceof HTMLElement) {
                         mainArea.style.height = '100vh'
                         mainArea.style.width = '100vw'
+                        mainArea.style.position = 'relative'
+                        mainArea.style.zIndex = '900000'
                     }
                 } catch (e) {
                     console.error('[Teams] Failed to modify main area', e)
@@ -146,6 +148,8 @@ export class TeamsHtmlCleaner {
                     if (mainArea instanceof HTMLElement) {
                         mainArea.style.height = '100vh'
                         mainArea.style.width = '100vw'
+                        mainArea.style.position = 'relative'
+                        mainArea.style.zIndex = '900000'
                     }
                 } catch (e) {
                     console.error('[Teams] Failed to modify main area', e)

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -10,6 +10,7 @@ import { BaseState } from './base-state'
 import { formatError } from '../../utils/Logger'
 import { sendEntryMessage } from '../../meeting/meet'
 import { verifyMeetAudioCapture } from '../../meeting/meet/audio-capture'
+import { sendTeamsEntryMessage } from '../../meeting/teams'
 
 export class InCallState extends BaseState {
     async execute(): StateExecuteResult {
@@ -145,13 +146,8 @@ export class InCallState extends BaseState {
             return
         }
 
-        // Only for Meet provider
-        if (GLOBAL.get().meetingProvider !== 'Meet') {
-            return
-        }
-
-        // 1. Verify audio capture (if streaming enabled)
-        if (GLOBAL.get().streaming_output) {
+        // Meet-specific: Verify audio capture (if streaming enabled)
+        if (GLOBAL.get().meetingProvider === 'Meet' && GLOBAL.get().streaming_output) {
             try {
                 await verifyMeetAudioCapture(this.context.playwrightPage)
             } catch (error) {
@@ -162,18 +158,30 @@ export class InCallState extends BaseState {
             }
         }
 
-        // 2. Send entry message (if configured) - non-blocking
+        // Send entry message (if configured) - non-blocking, works for both Meet and Teams
         if (GLOBAL.get().enter_message) {
-            console.log('Sending entry message (non-blocking)...')
-            sendEntryMessage(
-                this.context.playwrightPage,
-                GLOBAL.get().enter_message,
-            ).catch((error) => {
-                console.error(
-                    'Failed to send entry message:',
-                    formatError(error),
-                )
-            })
+            console.log(`Sending entry message (non-blocking) for ${GLOBAL.get().meetingProvider}...`)
+            if (GLOBAL.get().meetingProvider === 'Meet') {
+                sendEntryMessage(
+                    this.context.playwrightPage,
+                    GLOBAL.get().enter_message,
+                ).catch((error) => {
+                    console.error(
+                        'Failed to send entry message:',
+                        formatError(error),
+                    )
+                })
+            } else if (GLOBAL.get().meetingProvider === 'Teams') {
+                sendTeamsEntryMessage(
+                    this.context.playwrightPage,
+                    GLOBAL.get().enter_message,
+                ).catch((error) => {
+                    console.error(
+                        '[Teams] Failed to send entry message:',
+                        formatError(error),
+                    )
+                })
+            }
         }
     }
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -10,6 +10,15 @@ import { formatError } from './utils/Logger'
 
 const DEFAULT_SAMPLE_RATE: number = 24_000
 
+// Memory monitoring thresholds (in MB)
+const MEMORY_WARNING_THRESHOLD_MB = 1200 // 1.2 GB - warn
+const MEMORY_CRITICAL_THRESHOLD_MB = 1600 // 1.6 GB - critical alert
+const MEMORY_CHECK_INTERVAL_MS = 30000 // Check every 30 seconds
+
+// Connection buffer limits
+const MAX_CONNECTION_BUFFER_SIZE = 500 // ~20 seconds of audio at 25 chunks/sec
+const MAX_CONNECTION_BUFFER_DURATION_MS = 30000 // Max 30 seconds of buffered audio
+
 /**
  * Streaming class for real-time audio output to external services
  * 
@@ -49,8 +58,9 @@ export class Streaming {
     private lastBrowserStatsLogTime: number = 0
 
     // WebSocket connection buffer (for chunks received before WS is ready)
+    // Now with size limit and FIFO behavior to prevent memory leaks
     private connectionBuffer: Float32Array[] = []
-    private readonly MAX_CONNECTION_BUFFER_SIZE: number = 100 // ~4 seconds at 24kHz
+    private connectionBufferStartTime: number = 0 // Track when buffering started
     private wsConnectionStartTime: number = 0
 
     // WebSocket reconnection with exponential backoff
@@ -60,13 +70,26 @@ export class Streaming {
     private reconnectTimeoutId: NodeJS.Timeout | null = null
     private readonly INITIAL_RECONNECT_DELAY_MS: number = 1000 // 1 second
     private readonly MAX_RECONNECT_DELAY_MS: number = 60000 // 1 minute
-    private lastWsNotReadyLogTime: number = 0
     private readonly WS_NOT_READY_LOG_INTERVAL_MS: number = 10000 // Log at most every 10 seconds
+    private lastWsNotReadyLogTime: number = 0
 
     // Debug: Save streamed audio to file
     private debugAudioStream: fs.WriteStream | null = null
     private debugAudioBytesWritten: number = 0
     private readonly debugAudioEnabled: boolean = process.env.DEBUG_AUDIO === 'true'
+
+    // ========== MEMORY OPTIMIZATION: Reusable buffers ==========
+    // Pre-allocated buffers to reduce GC pressure during audio processing
+    private reusableNormalizedBuffer: Float32Array | null = null
+    private reusableResampledBuffer: Float32Array | null = null
+    private reusableInt16Buffer: Int16Array | null = null
+
+    // Memory monitoring
+    private memoryCheckIntervalId: NodeJS.Timeout | null = null
+    private lastMemoryWarningTime: number = 0
+    private readonly MEMORY_WARNING_COOLDOWN_MS: number = 60000 // Don't spam warnings
+    private droppedChunksCount: number = 0
+    private lastDroppedChunksLogTime: number = 0
 
     constructor(
         input: string | undefined,
@@ -92,6 +115,115 @@ export class Streaming {
         this.start()
 
         Streaming.instance = this
+    }
+
+    // ========== MEMORY MONITORING METHODS ==========
+
+    /**
+     * Start periodic memory monitoring
+     */
+    private startMemoryMonitoring(): void {
+        if (this.memoryCheckIntervalId) {
+            return // Already running
+        }
+
+        console.log('📊 [Memory] Starting memory monitoring (check every 30s)')
+        this.memoryCheckIntervalId = setInterval(() => {
+            this.checkMemoryUsage()
+        }, MEMORY_CHECK_INTERVAL_MS)
+    }
+
+    /**
+     * Stop memory monitoring
+     */
+    private stopMemoryMonitoring(): void {
+        if (this.memoryCheckIntervalId) {
+            clearInterval(this.memoryCheckIntervalId)
+            this.memoryCheckIntervalId = null
+            console.log('📊 [Memory] Stopped memory monitoring')
+        }
+    }
+
+    /**
+     * Check current memory usage and log warnings if needed
+     */
+    private checkMemoryUsage(): void {
+        const memUsage = this.getMemoryUsage()
+        const now = Date.now()
+
+        // Log memory stats
+        console.log(
+            `📊 [Memory] RSS: ${memUsage.rss.toFixed(1)}MB, Heap: ${memUsage.heapUsed.toFixed(1)}/${memUsage.heapTotal.toFixed(1)}MB, ` +
+            `External: ${memUsage.external.toFixed(1)}MB, ConnectionBuffer: ${this.connectionBuffer.length} chunks`
+        )
+
+        // Check thresholds (with cooldown to avoid spam)
+        if (now - this.lastMemoryWarningTime >= this.MEMORY_WARNING_COOLDOWN_MS) {
+            if (memUsage.rss >= MEMORY_CRITICAL_THRESHOLD_MB) {
+                console.error(
+                    `🚨 [Memory] CRITICAL: RSS ${memUsage.rss.toFixed(1)}MB exceeds ${MEMORY_CRITICAL_THRESHOLD_MB}MB threshold! ` +
+                    `Consider reducing buffer sizes or investigating leaks.`
+                )
+                this.lastMemoryWarningTime = now
+            } else if (memUsage.rss >= MEMORY_WARNING_THRESHOLD_MB) {
+                console.warn(
+                    `⚠️ [Memory] WARNING: RSS ${memUsage.rss.toFixed(1)}MB exceeds ${MEMORY_WARNING_THRESHOLD_MB}MB threshold`
+                )
+                this.lastMemoryWarningTime = now
+            }
+        }
+
+        // Log dropped chunks count periodically
+        if (this.droppedChunksCount > 0 && now - this.lastDroppedChunksLogTime >= 30000) {
+            console.warn(`📊 [Memory] Dropped ${this.droppedChunksCount} chunks due to buffer overflow in last 30s`)
+            this.droppedChunksCount = 0
+            this.lastDroppedChunksLogTime = now
+        }
+    }
+
+    /**
+     * Get current memory usage in MB
+     */
+    private getMemoryUsage(): { rss: number; heapUsed: number; heapTotal: number; external: number } {
+        const mem = process.memoryUsage()
+        return {
+            rss: mem.rss / 1024 / 1024,
+            heapUsed: mem.heapUsed / 1024 / 1024,
+            heapTotal: mem.heapTotal / 1024 / 1024,
+            external: mem.external / 1024 / 1024
+        }
+    }
+
+    // ========== REUSABLE BUFFER METHODS ==========
+
+    /**
+     * Get or create reusable normalized buffer
+     */
+    private getNormalizedBuffer(size: number): Float32Array {
+        if (!this.reusableNormalizedBuffer || this.reusableNormalizedBuffer.length < size) {
+            this.reusableNormalizedBuffer = new Float32Array(size)
+        }
+        return this.reusableNormalizedBuffer.subarray(0, size)
+    }
+
+    /**
+     * Get or create reusable resampled buffer
+     */
+    private getResampledBuffer(size: number): Float32Array {
+        if (!this.reusableResampledBuffer || this.reusableResampledBuffer.length < size) {
+            this.reusableResampledBuffer = new Float32Array(size)
+        }
+        return this.reusableResampledBuffer.subarray(0, size)
+    }
+
+    /**
+     * Get or create reusable Int16 buffer
+     */
+    private getInt16Buffer(size: number): Int16Array {
+        if (!this.reusableInt16Buffer || this.reusableInt16Buffer.length < size) {
+            this.reusableInt16Buffer = new Int16Array(size)
+        }
+        return this.reusableInt16Buffer.subarray(0, size)
     }
 
     /**
@@ -121,6 +253,9 @@ export class Streaming {
         this.isInitialized = true
         this.isPaused = false
 
+        // Start memory monitoring
+        this.startMemoryMonitoring()
+
         console.log('✅ Streaming service ready for direct audio processing')
     }
 
@@ -141,12 +276,39 @@ export class Streaming {
         }
 
         if (!this.output_ws || this.output_ws.readyState !== WebSocket.OPEN) {
-            // Throttle warning logs to avoid spam
+            // ========== MEMORY OPTIMIZATION: FIFO buffer with size limit ==========
             const now = Date.now()
+
+            // Initialize buffer start time on first chunk
+            if (this.connectionBuffer.length === 0) {
+                this.connectionBufferStartTime = now
+            }
+
+            // Check if buffer is too old (> 30 seconds) - clear it to prevent stale audio
+            const bufferAge = now - this.connectionBufferStartTime
+            if (bufferAge > MAX_CONNECTION_BUFFER_DURATION_MS && this.connectionBuffer.length > 0) {
+                console.warn(`[Streaming] ⚠️ Connection buffer too old (${(bufferAge / 1000).toFixed(1)}s), clearing ${this.connectionBuffer.length} chunks`)
+                this.connectionBuffer = []
+                this.connectionBufferStartTime = now
+            }
+
+            // FIFO: If buffer is full, remove oldest chunks to make room
+            if (this.connectionBuffer.length >= MAX_CONNECTION_BUFFER_SIZE) {
+                const chunksToRemove = Math.max(1, Math.floor(MAX_CONNECTION_BUFFER_SIZE * 0.1)) // Remove 10% of buffer
+                this.connectionBuffer.splice(0, chunksToRemove)
+                this.droppedChunksCount += chunksToRemove
+            }
+
+            // Store the audio chunk for later (create a copy to avoid reference issues)
+            const float32Data = new Float32Array(audioChunk.audioData)
+            this.connectionBuffer.push(float32Data)
+
+            // Throttle warning logs to avoid spam
             if (now - this.lastWsNotReadyLogTime >= this.WS_NOT_READY_LOG_INTERVAL_MS) {
-                console.warn('[Streaming] ⚠️ WebSocket not ready, discarding audio chunks (state:', this.output_ws?.readyState, ')')
+                console.warn(`[Streaming] ⚠️ WebSocket not ready, buffering audio chunks (state: ${this.output_ws?.readyState}, buffered: ${this.connectionBuffer.length})`)
                 this.lastWsNotReadyLogTime = now
             }
+
             // Trigger reconnection if not already reconnecting
             this.scheduleReconnect()
             return
@@ -187,8 +349,9 @@ export class Streaming {
      * Process and send a single audio chunk immediately
      */
     private processAndSendAudioChunk(audioData: Float32Array): void {
-        // Simple clipping protection
-        const normalized = new Float32Array(audioData.length)
+        // ========== MEMORY OPTIMIZATION: Use reusable buffers ==========
+        // Simple clipping protection - use reusable buffer
+        const normalized = this.getNormalizedBuffer(audioData.length)
         for (let i = 0; i < audioData.length; i++) {
             normalized[i] = Math.max(-1, Math.min(1, audioData[i]))
         }
@@ -197,11 +360,13 @@ export class Streaming {
         const sourceRate = this.sourceSampleRate
         const targetRate = this.sample_rate
         let finalBuffer = normalized
+        let finalLength = audioData.length
 
         if (sourceRate !== targetRate) {
             const ratio = sourceRate / targetRate
             const newLength = Math.round(normalized.length / ratio)
-            const resampled = new Float32Array(newLength)
+            // Use reusable resampled buffer
+            const resampled = this.getResampledBuffer(newLength)
 
             for (let i = 0; i < newLength; i++) {
                 const sourceIndex = i * ratio
@@ -214,22 +379,26 @@ export class Streaming {
                 resampled[i] = p0 + (p1 - p0) * decimal
             }
             finalBuffer = resampled
+            finalLength = newLength
         }
 
-        // Convert to Int16 for WebSocket transmission
-        const s16Array = new Int16Array(finalBuffer.length)
-        for (let i = 0; i < finalBuffer.length; i++) {
+        // Convert to Int16 for WebSocket transmission - use reusable buffer
+        const s16Array = this.getInt16Buffer(finalLength)
+        for (let i = 0; i < finalLength; i++) {
             s16Array[i] = Math.round(
                 Math.max(-32768, Math.min(32767, finalBuffer[i] * 32768)),
             )
         }
 
         // Send to WebSocket
+        // Note: We need to create a copy for sending because s16Array is a subarray of reusable buffer
         if (this.output_ws && this.output_ws.readyState === WebSocket.OPEN) {
-            this.output_ws.send(s16Array.buffer)
+            // Create a properly sized buffer for sending (subarray.buffer would send the entire underlying buffer)
+            const sendBuffer = new Int16Array(s16Array).buffer
+            this.output_ws.send(sendBuffer)
             this.browserAudioChunksSent++
 
-            // Write to debug file
+            // Write to debug file (pass the subarray, writeDebugAudioChunk will handle it)
             this.writeDebugAudioChunk(s16Array)
         }
     }
@@ -444,6 +613,9 @@ export class Streaming {
         }
 
         console.log('🛑 Stopping simplified streaming service...')
+
+        // Stop memory monitoring
+        this.stopMemoryMonitoring()
 
         // Finalize debug audio file (wait for WAV header to be written)
         await this.finalizeDebugAudioFile()


### PR DESCRIPTION
Add position:relative and z-index:900000 to Teams main area so the chat panel never appears in the recording. Add sendTeamsEntryMessage() with retry logic (5 attempts, 5s intervals) using evaluate() for all DOM interactions to bypass visual stacking. Update in-call-state to dispatch entry messages for both Meet and Teams providers.