### PR TITLE
fix: re-enable camera/mic after Google Meet waiting room auto-disable

### DIFF
--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -901,6 +901,18 @@ async function performCriticalSetupActions(
     page: Page,
     dialogObserver?: SimpleDialogObserver,
 ): Promise<void> {
+    // Re-enforce camera/mic state — Google Meet resets devices if the bot has been in the waiting room for a while
+    if (GLOBAL.get().custom_branding_bot_path) {
+        await ensureCameraOn(page)
+    } else {
+        await ensureCameraOff(page)
+    }
+    if (GLOBAL.get().streaming_input) {
+        await ensureMicrophoneOn(page)
+    } else {
+        await ensureMicrophoneOff(page)
+    }
+
     const htmlSnapshot = HtmlSnapshotService.getInstance()
 
     // 1. Open People Panel FIRST (keyboard shortcut - fastest)
@@ -1135,6 +1147,103 @@ async function deactivateCamera(page: Page): Promise<boolean> {
         return false
     }
 }
+
+// --- In-meeting device state helpers (use button[data-is-muted] selectors, only valid after joining) ---
+
+async function isCameraOff(page: Page): Promise<boolean> {
+    const btn = page.locator(
+        'button[aria-label="Turn on camera"][data-is-muted="true"]',
+    )
+    return (await btn.count()) > 0
+}
+
+async function isMicrophoneOff(page: Page): Promise<boolean> {
+    const btn = page.locator(
+        'button[aria-label="Turn on microphone"][data-is-muted="true"]',
+    )
+    return (await btn.count()) > 0
+}
+
+async function toggleCameraWithShortcut(page: Page): Promise<void> {
+    await page.keyboard.press('Control+KeyE')
+}
+
+async function toggleMicrophoneWithShortcut(page: Page): Promise<void> {
+    await page.keyboard.press('Control+KeyD')
+}
+
+async function ensureCameraOn(page: Page): Promise<void> {
+    try {
+        if (!(await isCameraOff(page))) return // already on
+        console.log(
+            '[Meet] Camera is off, enabling via keyboard shortcut (Ctrl+E)...',
+        )
+        await toggleCameraWithShortcut(page)
+        console.log('[Meet] Camera enable shortcut sent')
+    } catch (error) {
+        console.error(
+            '[Meet] Failed to enable camera via shortcut, trying DOM click:',
+            error,
+        )
+        const btn = page.locator('button[aria-label="Turn on camera"]')
+        if ((await btn.count()) > 0) await btn.click()
+    }
+}
+
+async function ensureCameraOff(page: Page): Promise<void> {
+    try {
+        if (await isCameraOff(page)) return // already off
+        console.log(
+            '[Meet] Camera is on, disabling via keyboard shortcut (Ctrl+E)...',
+        )
+        await toggleCameraWithShortcut(page)
+        console.log('[Meet] Camera disable shortcut sent')
+    } catch (error) {
+        console.error(
+            '[Meet] Failed to disable camera via shortcut, trying DOM click:',
+            error,
+        )
+        const btn = page.locator('button[aria-label="Turn off camera"]')
+        if ((await btn.count()) > 0) await btn.click()
+    }
+}
+
+async function ensureMicrophoneOn(page: Page): Promise<void> {
+    try {
+        if (!(await isMicrophoneOff(page))) return // already on
+        console.log(
+            '[Meet] Microphone is off, enabling via keyboard shortcut (Ctrl+D)...',
+        )
+        await toggleMicrophoneWithShortcut(page)
+        console.log('[Meet] Microphone enable shortcut sent')
+    } catch (error) {
+        console.error(
+            '[Meet] Failed to enable mic via shortcut, trying DOM click:',
+            error,
+        )
+        const btn = page.locator('button[aria-label="Turn on microphone"]')
+        if ((await btn.count()) > 0) await btn.click()
+    }
+}
+
+async function ensureMicrophoneOff(page: Page): Promise<void> {
+    try {
+        if (await isMicrophoneOff(page)) return // already off
+        console.log(
+            '[Meet] Microphone is on, disabling via keyboard shortcut (Ctrl+D)...',
+        )
+        await toggleMicrophoneWithShortcut(page)
+        console.log('[Meet] Microphone disable shortcut sent')
+    } catch (error) {
+        console.error(
+            '[Meet] Failed to disable mic via shortcut, trying DOM click:',
+            error,
+        )
+        const btn = page.locator('button[aria-label="Turn off microphone"]')
+        if ((await btn.count()) > 0) await btn.click()
+    }
+}
+
 // async function MuteMicrophone(page: Page) {
 //     try {
 //         await page.evaluate(() => {


### PR DESCRIPTION
Google Meet automatically turns off camera and microphone for participants sitting in the waiting room for ~3 minutes. This causes bots with bot_image to join without their camera feed, and bots with streaming_input to join without their microphone active.

Replace the old activate/deactivate functions with state-aware ensure* helpers that check data-is-muted attribute, toggle via keyboard shortcuts (Ctrl+E for camera, Ctrl+D for mic), and fall back to DOM click. Add a post-admission re-enable step in performCriticalSetupActions.