### PR TITLE
fix: update SpeechToTextProvider type to match v2 provider list

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { BrowserContext, Page } from '@playwright/test'
 import { SimpleDialogObserver } from './services/dialog-observer/simple-dialog-observer'
 
-type SpeechToTextProvider = 'Default' | 'Gladia' | 'RunPod'
+type SpeechToTextProvider = 'gladia' | 'deepgram' | 'assemblyai' | 'speechmatics' | 'soniox' | 'none'
 
 // Support both PascalCase and snake_case for recording_mode
 export type RecordingMode =


### PR DESCRIPTION
The type was stale from v1 ('Default' | 'Gladia' | 'RunPod') and didn't include the providers the API server can now send (deepgram, assemblyai, speechmatics, soniox).