### PR TITLE
feat: bot stop request revamp

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -74,6 +74,36 @@ export class Api {
     }
   }
 
+  /**
+   * Lightweight check to see if a stop request has been issued for this bot.
+   * Called on startup before joining the meeting.
+   * Returns true if the bot should stop, false otherwise.
+   * Failures are non-fatal — if the server is unreachable, returns false to let the bot proceed.
+   */
+  public async checkStopRequest(): Promise<boolean> {
+    try {
+      const resp = await axios({
+        method: "GET",
+        url: "/bot-process/check-stop-request",
+        timeout: 10000,
+        params: { bot_id: GLOBAL.get().bot_id }
+      })
+      const isStopped = resp.data?.is_stopped === true
+      if (isStopped) {
+        console.log(
+          `Bot ${GLOBAL.get().bot_uuid} has a pending stop request — will not join meeting`
+        )
+      }
+      return isStopped
+    } catch (error) {
+      console.warn(
+        "check-stop-request failed (proceeding with join):",
+        error instanceof Error ? error.message : error
+      )
+      return false
+    }
+  }
+
   // Handle end meeting with retry logic
   public async handleEndMeetingWithRetry(): Promise<void> {
     if (GLOBAL.isServerless()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,8 @@ import { Api } from "./api/methods"
 import { Events } from "./events"
 import { server } from "./server"
 import { GLOBAL } from "./singleton"
-import { SpeakerManager } from "./speaker-manager"
 import { MeetingStateMachine } from "./state-machine/machine"
-import { getErrorMessageFromCode } from "./state-machine/types"
+import { getErrorMessageFromCode, MeetingEndReason } from "./state-machine/types"
 import type { MeetingParams } from "./types"
 import {
   formatError,
@@ -200,6 +199,21 @@ async function handleFailedRecording(): Promise<void> {
     // Create API instance for non-serverless mode
     if (!GLOBAL.isServerless()) {
       new Api()
+    }
+
+    // Check if a stop request was issued while the bot was scaling up.
+    // This is a lightweight DB check — failures are non-fatal (bot proceeds normally).
+    if (!GLOBAL.isServerless() && Api.instance) {
+      const shouldStop = await Api.instance.checkStopRequest()
+      if (shouldStop) {
+        console.log("Stop request detected on startup — aborting before joining meeting")
+        GLOBAL.setError(
+          MeetingEndReason.ExitingMeetingBeforeRecord,
+          "Bot was stopped before recording started"
+        )
+        await handleFailedRecording()
+        return
+      }
     }
 
     // Start the meeting recording

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -206,6 +206,13 @@ export class MeetProvider implements MeetingProviderInterface {
         await deactivateCamera(page)
       }
 
+      // Final stop check before the irreversible join button click
+      if (cancelCheck()) {
+        console.log("Stop request detected before clicking Join — aborting")
+        GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
+        throw new Error("Bot stopped before joining meeting")
+      }
+
       // Try to click join button - will retry continuously while waiting
       let lastJoinClickAt = 0
       const joinRetryCooldownMs = 2000
@@ -226,7 +233,10 @@ export class MeetProvider implements MeetingProviderInterface {
       let leftWaitingRoomAt: number | null = null
       while (true) {
         if (cancelCheck()) {
-          GLOBAL.setError(MeetingEndReason.ApiRequest)
+          // Only set error if not already set by stopMeeting()
+          if (!GLOBAL.getEndReason()) {
+            GLOBAL.setError(MeetingEndReason.ApiRequest)
+          }
           throw new Error("API request to stop recording")
         }
 
@@ -496,7 +506,9 @@ export async function findShowEveryOne(page: Page, click: boolean, cancelCheck: 
       }
 
       if (cancelCheck()) {
-        GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
+        if (!GLOBAL.getEndReason()) {
+          GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
+        }
         throw new Error("Timeout waiting to start")
       }
 

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -369,6 +369,13 @@ export class TeamsProvider implements MeetingProviderInterface {
       }
     }
 
+    // Final stop check before the irreversible "Join now" click
+    if (cancelCheck()) {
+      console.log('Stop request detected before clicking Join now — aborting')
+      GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
+      throw new Error("Bot stopped before joining meeting")
+    }
+
     try {
       await typeBotName(page, GLOBAL.get().bot_name, 20)
       await clickWithInnerText(page, "button", "Join now", 20)
@@ -391,7 +398,10 @@ export class TeamsProvider implements MeetingProviderInterface {
 
       // Check if we should cancel
       if (cancelCheck()) {
-        GLOBAL.setError(MeetingEndReason.ApiRequest)
+        // Only set error if not already set by stopMeeting()
+        if (!GLOBAL.getEndReason()) {
+          GLOBAL.setError(MeetingEndReason.ApiRequest)
+        }
         throw new Error("API request to stop Teams recording")
       }
 

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -103,10 +103,12 @@ class Global {
   }
 
   public setError(reason: MeetingEndReason, message?: string): void {
-    // ApiRequest is a special case where we don't want to override an existing error
+    // Don't override these end reasons — they represent a definitive decision
+    // about why the bot is stopping and shouldn't be clobbered during cleanup
     if (
       this.endReason === MeetingEndReason.ApiRequest ||
-      this.endReason === MeetingEndReason.LoginRequired
+      this.endReason === MeetingEndReason.LoginRequired ||
+      this.endReason === MeetingEndReason.ExitingMeetingBeforeRecord
     ) {
       console.log(`🔴 not setting global error, already set to: ${this.endReason}`)
       return

--- a/src/state-machine/machine.ts
+++ b/src/state-machine/machine.ts
@@ -142,6 +142,29 @@ export class MeetingStateMachine {
 
   public async stopMeeting(reason: MeetingEndReason): Promise<void> {
     console.info(`Stop meeting requested with reason: ${reason}`)
+
+    // If the bot hasn't started recording yet, use ExitingMeetingBeforeRecord
+    // instead of ApiRequest so the exit path correctly reflects that no
+    // recording was produced.
+    const preRecordingStates = [
+      MeetingStateType.Initialization,
+      MeetingStateType.WaitingRoom,
+      MeetingStateType.InCall
+    ]
+    if (
+      reason === MeetingEndReason.ApiRequest &&
+      preRecordingStates.includes(this.currentState)
+    ) {
+      console.info(
+        `Bot is in pre-recording state (${this.currentState}) — using ExitingMeetingBeforeRecord instead of ApiRequest`
+      )
+      GLOBAL.setError(
+        MeetingEndReason.ExitingMeetingBeforeRecord,
+        "Bot was stopped before recording started"
+      )
+      return
+    }
+
     GLOBAL.setEndReason(reason)
   }
 

--- a/src/state-machine/states/cleanup-state.ts
+++ b/src/state-machine/states/cleanup-state.ts
@@ -1,10 +1,9 @@
 import * as fs from "node:fs"
+import { ChatManager } from "../../chat-manager"
 import { envVars } from "../../config/env-vars"
 import { SoundContext, VideoContext } from "../../media_context"
-import { stopNetworkInterception } from "../../meeting/meet/network-interception"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { HtmlSnapshotService } from "../../services/html-snapshot-service"
-import { ChatManager } from "../../chat-manager"
 import { GLOBAL } from "../../singleton"
 import { SpeakerManager } from "../../speaker-manager"
 import { formatError } from "../../utils/Logger"
@@ -34,7 +33,7 @@ export class CleanupState extends BaseState {
         // Continue to Terminated even if cleanup fails
       }
       console.info("🧹 Transitioning to Terminated state")
-      return this.transition(MeetingStateType.Terminated) // État final
+      return this.transition(MeetingStateType.Terminated)
     } catch (error) {
       console.error("🧹 Error during cleanup:", formatError(error))
       // Always transition to Terminated to avoid infinite loops
@@ -45,201 +44,78 @@ export class CleanupState extends BaseState {
 
   private async performCleanup(): Promise<void> {
     try {
-      // 1. Stop the dialog observer
-      console.info("🧹 Step 1/8: Stopping dialog observer. It would not block the cleanup")
+      // Step 0: Stop dialog observer (runs in Node, not in the page)
+      console.info("🧹 Step 0: Stopping dialog observer")
       try {
         this.stopDialogObserver()
       } catch (error) {
         console.warn("🧹 Dialog observer stop failed, continuing cleanup:", error)
       }
 
-      // 2. Finalize diarization BEFORE stopping ScreenRecorder (which uploads files)
-      console.info("🧹 Step 2/8: Finalizing diarization tracking")
+      // Step 1: Finalize diarization BEFORE stopping ScreenRecorder (which uploads files)
+      console.info("🧹 Step 1/6: Finalizing diarization tracking")
       await this.finalizeDiarization()
 
-      // 2b. Stop network interception early to silence the 5s broadcast timer.
-      // This is a lightweight page.evaluate() that sets a flag — no need to wait
-      // for ScreenRecorder upload to finish before silencing it.
-      if (GLOBAL.get().meeting_platform === "meet" && this.context.playwrightPage) {
-        try {
-          console.info("🧹 Stopping network interception (early, before ScreenRecorder)")
-          await stopNetworkInterception(this.context.playwrightPage)
-        } catch (error) {
-          console.warn(
-            "🧹 Early network interception stop failed, will retry later:",
-            formatError(error)
-          )
-        }
-      }
-
-      // 🎬 PRIORITY 3: Stop video recording immediately to avoid data loss
-      console.info("🧹 Step 3/8: Stopping ScreenRecorder (PRIORITY)")
-      await this.stopScreenRecorder()
-
-      // 4. Capture final DOM state before cleanup
+      // Step 2: Capture final DOM state while page is still alive
       if (this.context.playwrightPage) {
-        console.info("🧹 Step 4/8: Capturing final DOM state")
+        console.info("🧹 Step 2/6: Capturing final DOM state")
         const htmlSnapshot = HtmlSnapshotService.getInstance()
         await htmlSnapshot.captureSnapshot(this.context.playwrightPage, "cleanup_final_dom_state")
       }
 
-      // 🚀 PARALLEL CLEANUP: Independent steps that can run simultaneously
-      console.info(
-        "🧹 Steps 5-9: Running parallel cleanup (streaming + sound monitor + speakers + HTML + network interception)"
-      )
+      // Step 3: Close meeting page — bot leaves the meeting instantly.
+      // All injected JS (speakers observer, HTML cleaner, chat observer, network interception)
+      // dies with the page. No need to stop them separately with timeout wrappers.
+      // FFmpeg keeps recording the now-blank Xvfb display until we stop it.
+      console.info("🧹 Step 3/6: Closing meeting page (bot leaves meeting)")
+      try {
+        await this.context.playwrightPage?.close().catch(() => {})
+        this.context.playwrightPage = null
+      } catch (error) {
+        console.warn("🧹 Failed to close meeting page:", formatError(error))
+        this.context.playwrightPage = null
+      }
+
+      // Step 4: Stop Node-side services (streaming + sound monitor) + upload chat messages
+      console.info("🧹 Step 4/6: Stopping Node services and uploading chat messages")
       await Promise.allSettled([
-        // 5. Stop the streaming (waits for debug audio file finalization)
         (async () => {
-          console.info("🧹 Step 5/9: Stopping streaming service")
           if (this.context.streamingService) {
             await this.context.streamingService.stop()
           }
         })(),
-
-        // 6. Stop sound level monitor (critical for automatic leave)
         (async () => {
-          console.info("🧹 Step 6/9: Stopping sound level monitor")
-          // Use stopIfStarted to avoid instantiating if never used
           SoundLevelMonitor.stopIfStarted()
         })(),
-
-        // 7. Stop speakers observer (with 3s timeout)
         (async () => {
-          console.info("🧹 Step 7/9: Stopping speakers observer")
-          await this.stopSpeakersObserver()
-        })(),
-
-        // 8. Stop HTML cleaner (with 3s timeout)
-        (async () => {
-          console.info("🧹 Step 8/10: Stopping HTML cleaner")
-          await this.stopHtmlCleaner()
-        })(),
-
-        // 8b. Stop chat observer (with 3s timeout)
-        (async () => {
-          console.info("🧹 Step 8b/10: Stopping chat observer")
-          await this.stopChatObserver()
-        })(),
-
-        // 9. Stop network interception (Meet only)
-        (async () => {
-          console.info("🧹 Step 9/9: Stopping network interception")
-          if (GLOBAL.get().meeting_platform === "meet" && this.context.playwrightPage) {
-            try {
-              await stopNetworkInterception(this.context.playwrightPage)
-            } catch (error) {
-              console.error("🧹 Failed to stop network interception:", formatError(error))
-              // Don't throw - continue cleanup even if this fails
-            }
-          }
+          await this.uploadChatMessagesArtifact()
         })()
       ])
 
-      console.info("🧹 Parallel cleanup completed")
+      // Step 5: Stop ScreenRecorder (SIGINT FFmpeg → grace period → file processing)
+      console.info("🧹 Step 5/6: Stopping ScreenRecorder")
+      await this.stopScreenRecorder()
 
-      console.info("🧹 Step 10/10: Cleaning up browser resources")
-      // 10. Clean up browser resources (must be sequential after others)
+      // Step 6: Close browser context and remaining resources
+      console.info("🧹 Step 6/6: Cleaning up browser resources")
       await this.cleanupBrowserResources()
 
       console.info("🧹 All cleanup steps completed")
     } catch (error) {
       console.error("🧹 Cleanup error:", formatError(error))
       // Continue even if an error occurs
-      // Don't re-throw - errors are already handled
       return
     }
   }
 
-  private async stopSpeakersObserver(): Promise<void> {
+  private async finalizeDiarization(): Promise<void> {
     try {
-      if (this.context.speakersObserver) {
-        console.log("Stopping speakers observer from cleanup state...")
-
-        // Add 3-second timeout to prevent hanging
-        await Promise.race([
-          (async () => {
-            this.context.speakersObserver.stopObserving()
-            this.context.speakersObserver = null
-          })(),
-          new Promise((_, reject) =>
-            setTimeout(() => reject(new Error("Speakers observer stop timeout")), 3000)
-          )
-        ])
-
-        console.log("Speakers observer stopped successfully")
-      } else {
-        console.log("Speakers observer not active, nothing to stop")
-      }
+      await SpeakerManager.finalize()
+      console.log("Diarization tracking finalized successfully")
     } catch (error) {
-      if (error instanceof Error && error.message?.includes("timeout")) {
-        console.warn("Speakers observer stop timed out after 3s, continuing cleanup")
-        // Force cleanup
-        this.context.speakersObserver = null
-      } else {
-        console.error("Error stopping speakers observer:", formatError(error))
-      }
-      // Don't throw as this is non-critical
+      console.error("Failed to finalize diarization:", formatError(error))
+      // Don't throw - continue cleanup even if diarization finalization fails
     }
-  }
-
-  private async stopHtmlCleaner(): Promise<void> {
-    try {
-      if (this.context.htmlCleaner) {
-        console.log("Stopping HTML cleaner from cleanup state...")
-
-        // Add 3-second timeout to prevent hanging
-        await Promise.race([
-          this.context.htmlCleaner.stop(),
-          new Promise((_, reject) =>
-            setTimeout(() => reject(new Error("HTML cleaner stop timeout")), 3000)
-          )
-        ])
-
-        this.context.htmlCleaner = undefined
-        console.log("HTML cleaner stopped successfully")
-      } else {
-        console.log("HTML cleaner not active, nothing to stop")
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message?.includes("timeout")) {
-        console.warn("HTML cleaner stop timed out after 3s, continuing cleanup")
-        // Force cleanup
-        this.context.htmlCleaner = undefined
-      } else {
-        console.error("Error stopping HTML cleaner:", formatError(error))
-      }
-      // Don't throw as this is non-critical
-    }
-  }
-
-  private async stopChatObserver(): Promise<void> {
-    try {
-      if (this.context.chatObserver) {
-        console.log("Stopping chat observer from cleanup state...")
-
-        await Promise.race([
-          (async () => {
-            this.context.chatObserver!.stopObserving()
-            this.context.chatObserver = undefined
-          })(),
-          new Promise((_, reject) =>
-            setTimeout(() => reject(new Error("Chat observer stop timeout")), 3000)
-          )
-        ])
-
-        console.log("Chat observer stopped successfully")
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message?.includes("timeout")) {
-        console.warn("Chat observer stop timed out after 3s, continuing cleanup")
-        this.context.chatObserver = undefined
-      } else {
-        console.error("Error stopping chat observer:", formatError(error))
-      }
-    }
-
-    // Upload chat messages artifact to S3
-    await this.uploadChatMessagesArtifact()
   }
 
   private async uploadChatMessagesArtifact(): Promise<void> {
@@ -284,16 +160,6 @@ export class CleanupState extends BaseState {
     }
   }
 
-  private async finalizeDiarization(): Promise<void> {
-    try {
-      await SpeakerManager.finalize()
-      console.log("Diarization tracking finalized successfully")
-    } catch (error) {
-      console.error("Failed to finalize diarization:", formatError(error))
-      // Don't throw - continue cleanup even if diarization finalization fails
-    }
-  }
-
   private async stopScreenRecorder(): Promise<void> {
     try {
       if (ScreenRecorderManager.getInstance().isCurrentlyRecording()) {
@@ -306,8 +172,6 @@ export class CleanupState extends BaseState {
     } catch (error) {
       console.error("Error stopping ScreenRecorder:", formatError(error))
 
-      // Don't re-throw - errors are already handled
-
       // Don't throw error if recording was already stopped
       if (error instanceof Error && error.message && error.message.includes("not recording")) {
         console.log("ScreenRecorder was already stopped, continuing cleanup")
@@ -316,6 +180,16 @@ export class CleanupState extends BaseState {
       }
     }
   }
+
+  private stopDialogObserver() {
+    if (this.context.dialogObserver) {
+      console.info(`Stopping global dialog observer in state ${this.constructor.name}`)
+      this.context.dialogObserver.stopGlobalDialogObserver()
+    } else {
+      console.warn(`Global dialog observer not available in state ${this.constructor.name}`)
+    }
+  }
+
   private async cleanupBrowserResources(): Promise<void> {
     try {
       // 1. Stop branding
@@ -327,22 +201,10 @@ export class CleanupState extends BaseState {
       VideoContext.instance?.stop()
       SoundContext.instance?.stop()
 
-      // 3. Close pages and clean the browser
-      await Promise.all([
-        this.context.playwrightPage?.close().catch(() => {}),
-        this.context.browserContext?.close().catch(() => {})
-      ])
+      // 3. Close browser context (page already closed in step 4)
+      await this.context.browserContext?.close().catch(() => {})
     } catch (error) {
       console.error("Failed to cleanup browser resources:", formatError(error))
-    }
-  }
-
-  private stopDialogObserver() {
-    if (this.context.dialogObserver) {
-      console.info(`Stopping global dialog observer in state ${this.constructor.name}`)
-      this.context.dialogObserver.stopGlobalDialogObserver()
-    } else {
-      console.warn(`Global dialog observer not available in state ${this.constructor.name}`)
     }
   }
 }

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -12,7 +12,7 @@ import { GLOBAL } from "../../singleton"
 import { SpeakerManager } from "../../speaker-manager"
 import { formatError } from "../../utils/Logger"
 import { MEETING_CONSTANTS } from "../constants"
-import { MeetingStateType, type StateExecuteResult } from "../types"
+import { MeetingEndReason, MeetingStateType, type StateExecuteResult } from "../types"
 import { BaseState } from "./base-state"
 
 export class InCallState extends BaseState {
@@ -23,6 +23,12 @@ export class InCallState extends BaseState {
     console.info(`[InCallState] Starting execute() at ${new Date(startTime).toISOString()}`)
 
     try {
+      // Quick check: if stop was already requested before entering InCall, skip setup entirely
+      if (GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord) {
+        console.info("[InCallState] Stop already requested — skipping setup")
+        return this.handleError(new Error("Stop requested before recording setup"))
+      }
+
       // Start with global timeout for setup
       await Promise.race([this.setupRecording(), this.createTimeout()])
 
@@ -127,6 +133,12 @@ export class InCallState extends BaseState {
     // Switch branding to recording image if bot_status mode
     if (GLOBAL.get().bot_image_config?.loop_mode === "bot_status") {
       switchToRecordingBranding()
+    }
+
+    // Final gate: if a stop request arrived during setup, bail out
+    // before firing the recording event and transitioning to Recording state
+    if (GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord) {
+      throw new Error("Stop requested during recording setup — exiting before record")
     }
 
     // Notify that recording has started

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -99,6 +99,8 @@ export class WaitingRoomState extends BaseState {
           case MeetingEndReason.ApiRequest:
             Events.apiRequestStop()
             return this.handleError(error as Error)
+          case MeetingEndReason.ExitingMeetingBeforeRecord:
+            return this.handleError(error as Error)
         }
       }
 
@@ -197,7 +199,8 @@ export class WaitingRoomState extends BaseState {
       const checkStopSignal = setInterval(() => {
         if (
           GLOBAL.getEndReason() === MeetingEndReason.ApiRequest ||
-          GLOBAL.getEndReason() === MeetingEndReason.LoginRequired
+          GLOBAL.getEndReason() === MeetingEndReason.LoginRequired ||
+          GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord
         ) {
           clearInterval(checkStopSignal)
           clearTimeout(timeout)
@@ -208,7 +211,9 @@ export class WaitingRoomState extends BaseState {
       this.context.provider
         .joinMeeting(
           this.context.playwrightPage,
-          () => GLOBAL.getEndReason() === MeetingEndReason.ApiRequest,
+          () =>
+            GLOBAL.getEndReason() === MeetingEndReason.ApiRequest ||
+            GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord,
           // Add a callback to notify that the join succeeded
           () => {
             joinSuccessful = true

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -26,6 +26,9 @@ export enum MeetingEndReason {
   RecordingTimeout = "recordingTimeout",
   ApiRequest = "apiRequest",
 
+  // Pre-recording stop (bot exited before recording started)
+  ExitingMeetingBeforeRecord = "exitingMeetingBeforeRecord",
+
   // Error end reasons
   BotRemovedTooEarly = "botRemovedTooEarly",
   BotNotAccepted = "botNotAccepted",
@@ -52,6 +55,8 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "Recording timeout reached."
     case MeetingEndReason.ApiRequest:
       return "Recording stopped via API request."
+    case MeetingEndReason.ExitingMeetingBeforeRecord:
+      return "Bot exited before recording started."
     case MeetingEndReason.BotRemovedTooEarly:
       return "Bot was removed too early; the video is too short."
     case MeetingEndReason.BotNotAccepted:


### PR DESCRIPTION
## Summary
- Add `ExitingMeetingBeforeRecord` end reason for pre-recording stops
- Add `checkStopRequest()` API method called on startup before joining meeting
- State-aware rewrite in `stopMeeting()`: rewrites `ApiRequest` → `ExitingMeetingBeforeRecord` when bot is in pre-recording state (Initialization, WaitingRoom, InCall)
- Add stop checks throughout the bot lifecycle: pre-join-click gates in meet.ts/teams.ts, entry + post-setup gates in in-call-state, ExitingMeetingBeforeRecord handling in waiting-room-state
- Guard `setError()` so ExitingMeetingBeforeRecord cannot be overwritten during cleanup
- Simplify cleanup-state: close meeting page first (kills all injected JS instantly), remove timeout wrappers for speakers/HTML/chat observers, reorder steps for faster bot departure

## Test plan
- [x] Leave bot in queued status → startup check catches is_stopped, exits with ExitingMeetingBeforeRecord
- [x] Leave bot in in_call_recording → stops with ApiRequest (recording was active)
- [x] Leave bot in joining_call → ExitingMeetingBeforeRecord
- [x] Leave bot in waiting_room → ExitingMeetingBeforeRecord
- [x] Stop arrives before join click on Meet → bot never joins
- [x] Stop arrives before join click on Teams → bot never joins
- [x] Stop arrives during in-call setup → post-setup gate catches it
- [x] Normal recording lifecycle unchanged (regression)
- [x] Cleanup completes without hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)