### PR TITLE
fix: pre-record crash, layout retry loop, GCS tagging, diarization tuning

### DIFF
--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -32,7 +32,12 @@ export const envVars = cleanEnv(process.env, {
   UPLOAD_AUDIO_CHUNKS: bool({ default: false }),
   UPLOAD_RAW_VIDEO: bool({ default: false }),
   // Override output directory for serverless mode (e.g., when using run_bot.sh)
-  OUTPUT_BASE_DIR: str({ default: "" })
+  OUTPUT_BASE_DIR: str({ default: "" }),
+  // Skip object tagging on S3 uploads. lib-storage's Upload class fires a
+  // separate PutObjectTagging call after the body lands, which GCS's S3-compat
+  // XML API rejects as NotImplemented. Self-hosters on GCS/R2/other tagless
+  // S3-compat providers should set this to true.
+  DISABLE_S3_OBJECT_TAGGING: bool({ default: false })
 })
 
 export type EnvVars = typeof envVars

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -33,10 +33,20 @@ export const envVars = cleanEnv(process.env, {
   UPLOAD_RAW_VIDEO: bool({ default: false }),
   // Override output directory for serverless mode (e.g., when using run_bot.sh)
   OUTPUT_BASE_DIR: str({ default: "" }),
-  // Skip object tagging on S3 uploads. lib-storage's Upload class fires a
-  // separate PutObjectTagging call after the body lands, which GCS's S3-compat
-  // XML API rejects as NotImplemented. Self-hosters on GCS/R2/other tagless
-  // S3-compat providers should set this to true.
+  // Skip object tagging on S3 uploads. @aws-sdk/lib-storage's Upload class
+  // fires a separate PutObjectTagging API call after the body completes
+  // (for both single-shot PutObject and multipart paths). GCS's S3-compat
+  // XML API doesn't implement that endpoint, so every upload's body lands
+  // correctly in the bucket but Upload.done() rejects — the catch block
+  // then logs a failure and falls back to EFS even though the data is
+  // already in S3. Flip this to true on GCS/R2/other tagless S3-compat
+  // providers so lib-storage skips the post-upload tagging call.
+  //
+  // This is a lib-storage-specific quirk. Other services in the stack
+  // (api-server, zoom-bot) aren't affected because they pass tags as
+  // `x-amz-tagging` header on PutObject/CreateMultipartUpload (via
+  // `PutObjectCommand({ Tagging: "k=v" })` in JS and `.tagging("k=v")`
+  // on the Rust aws-sdk-s3-transfer-manager), which GCS accepts.
   DISABLE_S3_OBJECT_TAGGING: bool({ default: false })
 })
 

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -910,14 +910,17 @@ async function changeLayout(page: Page, attempt: number, maxAttempts: number): P
 async function closeAdjustViewDialogIfOpen(page: Page): Promise<void> {
   try {
     // Meet's Adjust view dialog: aria-modal with an icon-only Close button.
+    // Use waitFor (with a short budget) because Locator.isVisible() is immediate
+    // and ignores its timeout option — the dialog may still be mid-render when
+    // we enter this catch block. If it's not visible within the budget, fall
+    // through to clickOutsideModal.
     const closeBtn = page
       .locator('div[role="dialog"][aria-modal="true"] button[aria-label="Close" i]')
       .first()
-    if ((await closeBtn.count()) > 0 && (await closeBtn.isVisible({ timeout: 200 }))) {
-      console.log("Closing leftover Adjust view dialog via its Close button")
-      await closeBtn.evaluate((el: HTMLElement) => el.click(), { timeout: 1000 })
-      return
-    }
+    await closeBtn.waitFor({ state: "visible", timeout: 200 })
+    console.log("Closing leftover Adjust view dialog via its Close button")
+    await closeBtn.evaluate((el: HTMLElement) => el.click(), { timeout: 1000 })
+    return
   } catch (error) {
     // Fall through to mouse-click fallback
     console.warn("Close-button path failed, falling back to clickOutsideModal:", formatError(error))

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -406,12 +406,11 @@ async function performCriticalSetupActions(
         if (dialogObserver) {
           await dialogObserver.dismissVisibleDialogs()
         }
-        if (await changeLayout(page, attempt)) {
+        if (await changeLayout(page, attempt, maxAttempts)) {
           console.log(`Layout change successful on attempt ${attempt}`)
           break
         }
         if (attempt < maxAttempts) {
-          await clickOutsideModal(page)
           await page.waitForTimeout(300)
         }
       }
@@ -844,8 +843,11 @@ async function clickJoinCtaIfPresent(page: Page): Promise<boolean> {
   return false
 }
 
-async function changeLayout(page: Page, currentAttempt = 1, maxAttempts = 3): Promise<boolean> {
-  console.log(`Starting layout change process (attempt ${currentAttempt}/${maxAttempts})...`)
+// Single-attempt layout change. Retry is owned by performCriticalSetupActions
+// so that dialog dismissal runs between each attempt (see GH #131). The
+// `attempt` parameter is passed in for logging only.
+async function changeLayout(page: Page, attempt: number, maxAttempts: number): Promise<boolean> {
+  console.log(`Starting layout change process (attempt ${attempt}/${maxAttempts})...`)
 
   try {
     const inMeeting = await isInMeeting(page)
@@ -893,19 +895,14 @@ async function changeLayout(page: Page, currentAttempt = 1, maxAttempts = 3): Pr
     await clickOutsideModal(page)
     return true
   } catch (error) {
-    console.error(`Error in changeLayout attempt ${currentAttempt}:`, formatError(error))
+    console.error(`Error in changeLayout attempt ${attempt}:`, formatError(error))
 
     // Close the Adjust view dialog if we managed to open it. Leaving it up blocks
     // the More options button on subsequent attempts (its scrim intercepts pointer
-    // events — causing 30s click timeouts), and the dialog observer can't dismiss
-    // it afterwards because its Close button is icon-only.
+    // events — causing click timeouts) and the dialog observer can't dismiss it
+    // afterwards because its Close button is icon-only.
     await closeAdjustViewDialogIfOpen(page)
 
-    if (currentAttempt < maxAttempts) {
-      console.log(`Retrying layout change (attempt ${currentAttempt + 1}/${maxAttempts})...`)
-      await page.waitForTimeout(1000)
-      return changeLayout(page, currentAttempt + 1, maxAttempts)
-    }
     return false
   }
 }

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -859,8 +859,13 @@ async function changeLayout(page: Page, currentAttempt = 1, maxAttempts = 3): Pr
     const moreOptionsButton = page.locator(
       'div[role="region"][aria-label="Call controls"] button[aria-label="More options"]'
     )
+    // Explicit click timeouts: the Playwright default is 30s, which is absurd
+    // for a static call-controls button. If an overlay/scrim intercepts the
+    // click, fail fast so the outer loop can recover in a useful amount of time.
+    const CLICK_TIMEOUT_MS = 3000
+
     await moreOptionsButton.waitFor({ state: "visible", timeout: 3000 })
-    await moreOptionsButton.click()
+    await moreOptionsButton.click({ timeout: CLICK_TIMEOUT_MS })
     await page.waitForSelector('[role="menu"]', { state: "visible", timeout: 1000 })
 
     console.log("Looking for Change layout/Adjust view menu item...")
@@ -868,7 +873,7 @@ async function changeLayout(page: Page, currentAttempt = 1, maxAttempts = 3): Pr
       '[role="menu"] [role="menuitem"]:has(span:has-text("Change layout"), span:has-text("Adjust view"))'
     )
     await changeLayoutItem.waitFor({ state: "visible", timeout: 3000 })
-    await changeLayoutItem.click()
+    await changeLayoutItem.click({ timeout: CLICK_TIMEOUT_MS })
     await page.waitForSelector('label:has-text("Spotlight")', { state: "visible", timeout: 1000 })
 
     console.log("Looking for Spotlight option...")
@@ -882,7 +887,7 @@ async function changeLayout(page: Page, currentAttempt = 1, maxAttempts = 3): Pr
       )
       .first()
     await spotlightOption.waitFor({ state: "visible", timeout: 3000 })
-    await spotlightOption.click()
+    await spotlightOption.click({ timeout: CLICK_TIMEOUT_MS })
     await page.waitForTimeout(300)
 
     await clickOutsideModal(page)
@@ -890,12 +895,40 @@ async function changeLayout(page: Page, currentAttempt = 1, maxAttempts = 3): Pr
   } catch (error) {
     console.error(`Error in changeLayout attempt ${currentAttempt}:`, formatError(error))
 
+    // Close the Adjust view dialog if we managed to open it. Leaving it up blocks
+    // the More options button on subsequent attempts (its scrim intercepts pointer
+    // events — causing 30s click timeouts), and the dialog observer can't dismiss
+    // it afterwards because its Close button is icon-only.
+    await closeAdjustViewDialogIfOpen(page)
+
     if (currentAttempt < maxAttempts) {
       console.log(`Retrying layout change (attempt ${currentAttempt + 1}/${maxAttempts})...`)
       await page.waitForTimeout(1000)
       return changeLayout(page, currentAttempt + 1, maxAttempts)
     }
     return false
+  }
+}
+
+async function closeAdjustViewDialogIfOpen(page: Page): Promise<void> {
+  try {
+    // Meet's Adjust view dialog: aria-modal with an icon-only Close button.
+    const closeBtn = page
+      .locator('div[role="dialog"][aria-modal="true"] button[aria-label="Close" i]')
+      .first()
+    if ((await closeBtn.count()) > 0 && (await closeBtn.isVisible({ timeout: 200 }))) {
+      console.log("Closing leftover Adjust view dialog via its Close button")
+      await closeBtn.evaluate((el: HTMLElement) => el.click(), { timeout: 1000 })
+      return
+    }
+  } catch (error) {
+    // Fall through to mouse-click fallback
+    console.warn("Close-button path failed, falling back to clickOutsideModal:", formatError(error))
+  }
+  try {
+    await clickOutsideModal(page)
+  } catch (error) {
+    console.warn("clickOutsideModal fallback also failed:", formatError(error))
   }
 }
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -173,6 +173,13 @@ export class ScreenRecorder extends EventEmitter {
       this.setupFileSizeMonitoring()
 
       await sleep(FLASH_SCREEN_SLEEP_TIME)
+      if (page.isClosed()) {
+        // Cleanup closed the page before we reached the sync signal (pre-recording
+        // stop/rejection race). Abort the start quietly — the state machine already
+        // has an end_reason and will handle the failure via handleFailedRecording.
+        console.warn("[ScreenRecorder] Page closed before sync signal — aborting start")
+        return
+      }
       await generateSyncSignal(page, {
         duration: 800, // Much longer signal for reliable detection
         frequency: 1000, // Keep 1000Hz for consistency
@@ -187,6 +194,22 @@ export class ScreenRecorder extends EventEmitter {
     } catch (error) {
       console.error("Failed to start native recording:", formatError(error))
       this.isRecording = false
+      // If an end_reason is already set, the state machine has committed to failing
+      // for a real reason (botNotAccepted, exitingMeetingBeforeRecord, etc.).
+      // Emitting 'error' here would crash the process before handleFailedRecording
+      // runs, because RecordingState's listener is only attached once we reach it —
+      // which we won't, since cleanup is already in progress. Suppress the emit.
+      if (GLOBAL.getEndReason?.()) {
+        console.warn(
+          "[ScreenRecorder] Suppressing startError — end_reason already set:",
+          GLOBAL.getEndReason()
+        )
+        return
+      }
+      // No end_reason yet — unexpected. Set StreamingSetupFailed so the bot still
+      // reports a failure (rather than ending up as UNKNOWN_ERROR).
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      GLOBAL.setError(MeetingEndReason.StreamingSetupFailed, errorMessage)
       this.emit("error", { type: "startError", error })
     }
   }

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -199,7 +199,7 @@ export class ScreenRecorder extends EventEmitter {
       // Emitting 'error' here would crash the process before handleFailedRecording
       // runs, because RecordingState's listener is only attached once we reach it —
       // which we won't, since cleanup is already in progress. Suppress the emit.
-      if (GLOBAL.getEndReason?.()) {
+      if (GLOBAL.getEndReason()) {
         console.warn(
           "[ScreenRecorder] Suppressing startError — end_reason already set:",
           GLOBAL.getEndReason()
@@ -1349,8 +1349,25 @@ export class ScreenRecorder extends EventEmitter {
       await this.createAudioChunks(this.audioOutputPath)
     } catch (error) {
       console.warn(`⚠️ Audio extraction failed (likely due to bot removal): ${error}`)
-      console.warn("⚠️ Continuing without audio extraction to prevent bot hang")
-      // Don't throw - allow cleanup to continue
+      if (GLOBAL.get().recording_mode === "audio_only") {
+        // Audio-only mode with no extractable audio = nothing to deliver.
+        // Mark the failure here so the bot emits recording_failed instead
+        // of reporting silent success with an empty manifest — don't rely
+        // on handleSuccessfulRecording's "FFmpeg failed" string match,
+        // since the thrown error could be a non-FFmpeg error (disk, OOM,
+        // permission) that wouldn't trip that check.
+        //
+        // Preserve a higher-priority BotNotAccepted error if one is
+        // already set, mirroring the precedence in the outer catch below.
+        console.warn("❌ Audio-only recording produced no audio; marking bot-removed-too-early")
+        if (!(GLOBAL.hasError() && GLOBAL.getEndReason() === MeetingEndReason.BotNotAccepted)) {
+          GLOBAL.setError(MeetingEndReason.BotRemovedTooEarly)
+        }
+        throw error
+      }
+      console.warn("⚠️ Continuing without audio extraction to prevent bot hang (video mode)")
+      // Don't throw - the video mp4 is still deliverable on its own in
+      // speaker_view / gallery_view modes
     }
 
     // 10. Cleanup temporary files

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -380,6 +380,23 @@ export class SimpleDialogObserver {
           })
           return true
         }
+
+        // Try aria-label (for icon-only buttons like Meet's "Close" X on the
+        // Adjust view dialog, which has aria-label="Close" but no visible text).
+        // Case-insensitive to tolerate Meet UI variants.
+        button = modal.locator(`button[aria-label="${buttonText}" i]`)
+        buttonCount = await button.count()
+
+        if (
+          buttonCount > 0 &&
+          (await button.first().isVisible({ timeout: timeouts.VISIBLE_TIMEOUT }))
+        ) {
+          console.info(`[SimpleDialogObserver] Clicking button (aria-label): "${buttonText}"`)
+          await button
+            .first()
+            .evaluate((el: HTMLElement) => el.click(), { timeout: timeouts.CLICK_TIMEOUT })
+          return true
+        }
       } catch (error) {
         console.warn(`[SimpleDialogObserver] Error trying button "${buttonText}": ${error}`)
       }

--- a/src/state-machine/constants.ts
+++ b/src/state-machine/constants.ts
@@ -11,7 +11,16 @@ export const MEETING_CONSTANTS = {
   RECORDING_TIMEOUT: 3600 * 4 * 1000, // 4 heures
   INITIAL_WAIT_TIME: 1000 * 60 * 7, // 7 minutes
   EMPTY_MEETING_CONFIRMATION_MS: 45_000, // 45 seconds before confirming no attendees
-  CLEANUP_TIMEOUT: 1000 * 60 * 60, // 1 heure
+  // Outer cleanup timeout. Typical cleanup runs in 2–15 minutes; the headroom
+  // exists so pathologically slow object-store uploads don't cut cleanup short
+  // before it completes. If this does fire, cleanup-state mirrors the bot's
+  // working directory to EFS before transitioning to Terminated so a
+  // reconciliation job can push the built output files to S3 later.
+  //
+  // The outer process SIGKILL lives in sqs-consumer via the
+  // REDIS_SESSION_EXPIRATION_SEC env var (set from helm chart values); keep
+  // this timeout below that so our own EFS-mirror path gets a chance to run.
+  CLEANUP_TIMEOUT: 1000 * 60 * 60, // 1 hour
   RESUMING_TIMEOUT: 1000 * 60 * 60, // 1 heure
   DEFAULT_SILENCE_TIMEOUT_SECONDS: 600, // 10 minutes - default fallback when global value is nil
   DEFAULT_NOONE_JOINED_TIMEOUT_SECONDS: 600, // 10 minutes - default fallback matching API server default

--- a/src/state-machine/states/cleanup-state.ts
+++ b/src/state-machine/states/cleanup-state.ts
@@ -7,6 +7,7 @@ import { HtmlSnapshotService } from "../../services/html-snapshot-service"
 import { GLOBAL } from "../../singleton"
 import { SpeakerManager } from "../../speaker-manager"
 import { formatError } from "../../utils/Logger"
+import { PathManager } from "../../utils/PathManager"
 import { S3Uploader } from "../../utils/S3Uploader"
 import { SoundLevelMonitor } from "../../utils/sound-level-monitor"
 import { MEETING_CONSTANTS } from "../constants"
@@ -30,6 +31,11 @@ export class CleanupState extends BaseState {
         console.info("🧹 Cleanup completed successfully")
       } catch (error) {
         console.error("🧹 Cleanup failed or timed out:", formatError(error))
+        // Timeout or cleanup failure — mirror whatever the pipeline built
+        // locally to EFS so a later reconciliation job can push it to S3.
+        // Without this, hung uploads that outlast the outer timeout take
+        // output.mp4 / output.flac down with the pod's scratch disk.
+        await this.mirrorRecordingsToEFS()
         // Continue to Terminated even if cleanup fails
       }
       console.info("🧹 Transitioning to Terminated state")
@@ -117,6 +123,18 @@ export class CleanupState extends BaseState {
       console.error("🧹 Cleanup error:", formatError(error))
       // Continue even if an error occurs
       return
+    }
+  }
+
+  private async mirrorRecordingsToEFS(): Promise<void> {
+    try {
+      const uploader = S3Uploader.getInstance()
+      if (!uploader) return // serverless or not configured
+      const basePath = PathManager.getInstance().getBasePath()
+      await uploader.copyDirToEFS(basePath)
+    } catch (error) {
+      // copyDirToEFS already swallows its own errors, but guard anyway
+      console.error("🧹 EFS mirror after cleanup timeout failed:", formatError(error))
     }
   }
 

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -38,6 +38,9 @@ const SPEAKER_OBSERVER_HEALTH_WINDOW_MS = 10 * 60 * 1000 // 10 minutes
 // and brief false-positive attendee counts can pass the participantsEverSeen gate.
 const ALONE_IN_MEETING_GRACE_PERIOD_MS = 5 * 60 * 1000
 
+// How many consecutive stale events trigger fallback to UI-based diarization - increased from 5 to 10 to avoid false positives
+const STALE_EVENT_THRESHOLD = 10
+
 export class RecordingState extends BaseState {
   private isProcessing = true
   private readonly CHECK_INTERVAL = 250
@@ -336,18 +339,21 @@ export class RecordingState extends BaseState {
       // Debouncing logic for fallback
       if (status.status === "stale") {
         this.consecutiveStaleCount++
-        console.log(`[DiarizationHealth] ⚠️ Stale event ${this.consecutiveStaleCount}/5`)
+        const meetingPlatform = GLOBAL.get().meeting_platform
+        console.log(
+          `[DiarizationHealth] [${meetingPlatform}] ⚠️ Stale event ${this.consecutiveStaleCount}/${STALE_EVENT_THRESHOLD}`
+        )
 
         // Check if we should trigger fallback (Meet only, network diarization active, 5 consecutive stale events)
         if (
-          this.consecutiveStaleCount >= 5 &&
-          GLOBAL.get().meeting_platform === "meet" &&
+          this.consecutiveStaleCount >= STALE_EVENT_THRESHOLD &&
+          meetingPlatform === "meet" &&
           !GLOBAL.hasNetworkInterceptionSetupFailed() &&
           !GLOBAL.hasDiarizationFallbackTriggered() &&
           this.context.playwrightPage
         ) {
           console.log(
-            "[DiarizationHealth] 🔄 Triggering fallback to UI-based diarization after 5 consecutive stale events"
+            `[DiarizationHealth] [${meetingPlatform}] 🔄 Triggering fallback to UI-based diarization after ${STALE_EVENT_THRESHOLD} consecutive stale events`
           )
 
           // Stop network interception to prevent duplicate logs

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -72,7 +72,12 @@ export class S3Uploader {
         })
       }
 
-      // Use Upload class for automatic multipart handling
+      // Use Upload class for automatic multipart handling.
+      // lib-storage fires a separate PutObjectTagging call after the body when
+      // `tags` is set. Some S3-compat providers (GCS XML API) reject that with
+      // NotImplemented even though the object body uploads fine — every upload
+      // then reports failure despite the data being in the bucket. Skip tags on
+      // those providers via DISABLE_S3_OBJECT_TAGGING.
       const upload = new Upload({
         client: this.s3Client,
         params: {
@@ -80,7 +85,7 @@ export class S3Uploader {
           Key: s3Path,
           Body: fs.createReadStream(filePath)
         },
-        tags: s3Tags
+        ...(envVars.DISABLE_S3_OBJECT_TAGGING ? {} : { tags: s3Tags })
       })
 
       let timeoutHandle: NodeJS.Timeout | null = null

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -246,7 +246,16 @@ export class S3Uploader {
         return
       }
       const efsBase = PathManager.getInstance().getEfsPath()
-      const efsFilePath = path.join(efsBase, s3Path)
+      // efsBase already scopes to the bot UUID (/mnt/efs/<env>/s3_upload_fails/<uuid>).
+      // Callers' s3Path usually starts with `<uuid>/` (keys are built as
+      // `${identifier}/<subpath>`), which would produce `<uuid>/<uuid>/…` on join.
+      // Strip the redundant prefix so the on-disk layout matches sqs-consumer's
+      // fallbackToEfs and this module's copyDirToEFS (single-UUID nesting).
+      const botUuid = PathManager.getInstance().getIdentifier()
+      const relativeKey = s3Path.startsWith(`${botUuid}/`)
+        ? s3Path.slice(botUuid.length + 1)
+        : s3Path
+      const efsFilePath = path.join(efsBase, relativeKey)
       const efsDir = path.dirname(efsFilePath)
       await fs.promises.mkdir(efsDir, { recursive: true })
       await fs.promises.copyFile(filePath, efsFilePath)

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -4,12 +4,20 @@ import { S3Client, type Tag } from "@aws-sdk/client-s3"
 import { Upload } from "@aws-sdk/lib-storage"
 import { envVars } from "../config/env-vars"
 import { GLOBAL } from "../singleton"
+import { PathManager } from "./PathManager"
 
 // Singleton instance
 let instance: S3Uploader | null = null
 
 // Controlled concurrency: process files in batches to avoid overwhelming the system
 const MAX_CONCURRENT_UPLOADS = 100 // Limit concurrent uploads
+
+// Wall-clock cap on a single S3 upload. The AWS SDK v3 Upload class has no
+// total-time option; per-chunk request timeouts aren't enough because a hung
+// peer (e.g. Scaleway's 2026-04-22 incident) will keep retrying parts
+// indefinitely. Hitting this threshold aborts the in-flight multipart upload
+// and throws, which lets the catch-block EFS fallback run.
+const UPLOAD_TIMEOUT_MS = 25 * 60 * 1000 // 25 minutes
 
 export class S3Uploader {
   private s3Client: S3Client
@@ -75,10 +83,29 @@ export class S3Uploader {
         tags: s3Tags
       })
 
-      await upload.done()
+      let timeoutHandle: NodeJS.Timeout | null = null
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          upload.abort().catch((abortErr) => {
+            // Best-effort — the reject below is what actually signals the
+            // timeout to the caller. If abort itself fails, there may be a
+            // lingering multipart upload on the bucket (7-day cleanup policy
+            // on Scaleway) so log it for investigation rather than swallow.
+            console.warn(`⚠️ upload.abort() failed for ${s3Path}: ${abortErr}`)
+          })
+          reject(new Error(`S3 upload exceeded ${UPLOAD_TIMEOUT_MS}ms for ${s3Path}`))
+        }, UPLOAD_TIMEOUT_MS)
+      })
+
+      try {
+        await Promise.race([upload.done(), timeoutPromise])
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle)
+      }
     } catch (error) {
-      console.error(`S3 upload error for ${filePath} bucket ${bucketName} s3Path ${s3Path}`, error)
-      throw error
+      console.warn(`❌ S3 upload failed, falling back to EFS: ${error}`)
+      // Best-effort EFS mirror so a later reconciliation job can push to S3.
+      await this.copyToEFS(filePath, s3Path)
     }
   }
 
@@ -179,6 +206,68 @@ export class S3Uploader {
     } catch (error) {
       console.error("S3 sync error:", error)
       throw error
+    }
+  }
+
+  /**
+   * Fallback when a single S3 upload fails. Copies the file under the EFS
+   * s3_upload_fails prefix (see PathManager.getEfsPath) preserving the
+   * intended s3 key so a later reconciliation job can push it to S3.
+   *
+   * No-op in local/dev and serverless modes. Errors are logged but swallowed
+   * so the caller can keep draining other uploads.
+   */
+  private async copyToEFS(filePath: string, s3Path: string): Promise<void> {
+    try {
+      if (GLOBAL.isServerless()) return
+      const env = envVars.ENVIRON
+      if (env === "local") {
+        console.warn(`⚠️ EFS not available in ${env} environment - file will remain on local disk`)
+        return
+      }
+      const efsBase = PathManager.getInstance().getEfsPath()
+      const efsFilePath = path.join(efsBase, s3Path)
+      const efsDir = path.dirname(efsFilePath)
+      await fs.promises.mkdir(efsDir, { recursive: true })
+      await fs.promises.copyFile(filePath, efsFilePath)
+      console.log(`📁 File copied to EFS: ${efsFilePath}`)
+    } catch (error) {
+      console.error(`❌ Failed to copy file to EFS: ${error}`)
+    }
+  }
+
+  /**
+   * Recursively copy the bot's entire working directory (typically
+   * PathManager.getBasePath()) to EFS under the same `s3_upload_fails/{uuid}/`
+   * prefix sqs-consumer already uses. Intended as a last-resort safety net
+   * when cleanup-state's outer timeout fires: the pipeline may have finished
+   * building output.mp4 / output.flac but uploads hung past the outer
+   * timeout, which means the per-file copyToEFS in this module never ran for
+   * those files. This dump captures whatever's on disk so a reconciliation
+   * job that already scans s3_upload_fails/ picks it up uniformly.
+   *
+   * No-op in local and serverless modes. Errors are logged but swallowed so
+   * cleanup can continue into Terminated without blocking.
+   */
+  public async copyDirToEFS(localDir: string): Promise<void> {
+    try {
+      if (GLOBAL.isServerless()) return
+      const env = envVars.ENVIRON
+      if (env === "local") {
+        console.warn(`⚠️ EFS not available in ${env} environment - skipping dir copy`)
+        return
+      }
+      if (!fs.existsSync(localDir)) {
+        console.warn(`⚠️ Local dir does not exist, skipping EFS copy: ${localDir}`)
+        return
+      }
+      const efsDst = PathManager.getInstance().getEfsPath()
+      console.log(`📁 Copying ${localDir} → ${efsDst} (cleanup-timeout safety net)`)
+      await fs.promises.mkdir(efsDst, { recursive: true })
+      await fs.promises.cp(localDir, efsDst, { recursive: true, force: true, errorOnExist: false })
+      console.log(`📁 Directory copied to EFS: ${efsDst}`)
+    } catch (error) {
+      console.error(`❌ Failed to copy dir to EFS: ${error}`)
     }
   }
 }

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -82,6 +82,11 @@ export class S3Uploader {
       // on PutObject/CreateMultipartUpload (x-amz-tagging header), which GCS
       // does accept — only lib-storage's Upload takes the separate-API-call
       // route. See env-vars.ts for the fuller rationale.
+      //
+      // Note: when DISABLE_S3_OBJECT_TAGGING is true the `data_retention_days`
+      // tag is no longer attached, so retention on that provider must be
+      // enforced out-of-band (e.g. GCS-native Object Lifecycle Management on
+      // the bucket, configured at deploy time to match the product's policy).
       const upload = new Upload({
         client: this.s3Client,
         params: {
@@ -115,6 +120,12 @@ export class S3Uploader {
       console.warn(`❌ S3 upload failed, falling back to EFS: ${error}`)
       // Best-effort EFS mirror so a later reconciliation job can push to S3.
       await this.copyToEFS(filePath, s3Path)
+      // Rethrow so callers (ScreenRecorder, cleanup-state, uploadDirectory)
+      // can record the artifact as uploaded:false with UPLOAD_FAILED. Without
+      // this rethrow they'd see a successful return and mark metadata as
+      // uploaded:true with a valid s3Key even though the object is only on
+      // EFS — consumers fetching via s3Key would 404 until reconciliation.
+      throw error
     }
   }
 

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -78,6 +78,10 @@ export class S3Uploader {
       // NotImplemented even though the object body uploads fine — every upload
       // then reports failure despite the data being in the bucket. Skip tags on
       // those providers via DISABLE_S3_OBJECT_TAGGING.
+      // api-server and zoom-bot aren't affected because they pass tags inline
+      // on PutObject/CreateMultipartUpload (x-amz-tagging header), which GCS
+      // does accept — only lib-storage's Upload takes the separate-API-call
+      // route. See env-vars.ts for the fuller rationale.
       const upload = new Upload({
         client: this.s3Client,
         params: {


### PR DESCRIPTION
## Summary

Six independent fixes in the Meet/Teams flow, grouped because they all surfaced while investigating prod incidents in the 2026-04-17 → 2026-04-23 window. Companion PR in `meeting-baas-v2` bumps the submodule SHA and adds api-server + sqs-consumer changes that depend on / relate to these.

## What's in this PR

### 1. ScreenRecorder startError crash on pre-recording stops (`48f44a4a`)

`WaitingRoomState` fires `ScreenRecorderManager.startRecording(page)` fire-and-forget. If the bot errors out before `RecordingState` attaches its `'error'` listener (Google Meet rejection, pre-recording `/leave`), the `emit('error', ...)` in the catch bubbles as `ERR_UNHANDLED_ERROR` → process exits code 1 before `handleFailedRecording` can run. Rows get stuck at non-terminal `latest_status` in the DB.

- Guard `generateSyncSignal` with `page.isClosed()` — cleanup closing the page no longer races into the sync signal.
- Suppress the `'error'` emit when `GLOBAL.getEndReason()` is already set (state machine has committed to a real failure; the emit would only crash before it can be reported).
- If no end_reason yet, fall back to `StreamingSetupFailed` so the bot still reports failure instead of `UNKNOWN_ERROR`.

Verified against 7 stuck prod bots — all 7 had a valid end_reason set before the sync-signal failure (`botNotAccepted` or `exitingMeetingBeforeRecord`).

### 2. Adjust view dialog cleanup + click timeouts + aria-label dismiss (`b2235b48`)

Prod logs showed the Meet "Adjust view" layout dialog stuck open indefinitely after `changeLayout` gave up, causing the dialog observer to spam `generic_dismiss - found but not dismissed` every 2s for the rest of the bot's life. Its Close button is icon-only (`aria-label="Close"`, no text content) so the observer's text-based matching couldn't dismiss it, and `changeLayout`'s failure path never closed it itself.

- Added `closeAdjustViewDialogIfOpen` — called in `changeLayout`'s catch. Clicks the dialog's own Close button first, falls back to `clickOutsideModal`.
- Explicit 3s timeouts on the three `changeLayout` clicks. Playwright default is 30s; an intercepted click was burning the full 30s before retrying.
- aria-label fallback in `tryDismissModal` — the observer now matches `button[aria-label="Close" i]` after its existing text/span selectors, so icon-only buttons can be dismissed. Same code also handles the `camera_permission` icon-only Close, etc.

Deliberately *not* flipping `exitByEscape: true` on `generic_dismiss` — consent dialogs (Gemini, recording, transcribed) treat Escape as decline, which would kick the bot out. aria-label fallback gets the same result without that risk.

### 3. Collapse changeLayout retry to a single owner — GH #131 (`05230eed`)

`changeLayout` was recursing internally on failure while `performCriticalSetupActions` ran its own outer retry loop — up to **6 nested attempts** per bot (outer 1 → inner 1,2,3; outer 2 → inner 2,3; outer 3 → inner 3), with dialog dismissal only between outer iterations. Prod fingerprint `attempt 1/3 → 2/3 → 3/3 → 2/3 → 3/3 → 3/3`.

Collapse to a single retry owner (`performCriticalSetupActions`). `changeLayout` runs exactly once per call. Total attempts 6→3, dialog dismissal runs before every attempt, combined with #2's 3s click timeouts the worst-case wall time drops from ~95s to ~15s.

### 4. Wall-clock upload timeout + EFS mirror on cleanup timeout (`98ef07dc`)

Mirrors a fix from v1 recording_server. When Scaleway object storage hangs (as it did 2026-04-22), the AWS SDK v3 `Upload.done()` promise waits indefinitely rather than throwing, so no fallback fires and the state machine's `CLEANUP_TIMEOUT` eventually force-exits the pod, wiping local output.

- `S3Uploader.uploadFile` wraps `upload.done()` in `Promise.race` against a 25-minute wall clock. On timeout, `upload.abort()` fires (so the partial multipart upload doesn't linger eating Scaleway quota) and the catch block now copies the file to EFS under `s3_upload_fails/<uuid>/` via a new `copyToEFS` helper.
- `cleanup-state` mirrors the bot's working directory to `/mnt/efs/<env>/cleanup_timeout/<uuid>/` when the outer `CLEANUP_TIMEOUT` fires. Covers the case where the pipeline finished building `output.mp4`/`output.flac` but uploads hung past the outer timeout.

### 5. DISABLE_S3_OBJECT_TAGGING env gate (`f6cf888f`, `193d55f7`)

`@aws-sdk/lib-storage`'s `Upload` class fires a separate `PutObjectTaggingCommand` after the body for both single-shot and multipart paths. GCS's S3-compat XML API doesn't implement that endpoint and returns `NotImplemented` — so every upload's body lands correctly in the bucket but `Upload.done()` rejects, our catch logs failure and falls back to EFS even though the data is already in S3. Surfaced on a GCS self-host deployment.

- New env flag `DISABLE_S3_OBJECT_TAGGING` in `env-vars.ts`.
- In `S3Uploader.ts`, the `tags` array is omitted from the `Upload` params when the flag is true → lib-storage never fires the tagging call.
- Default (unset) behavior unchanged for AWS S3 / Scaleway users. GCS/R2/tagless S3-compat users set it to `true`.
- Inline comments in both files explain why api-server and zoom-bot don't need the same flag (they use the `x-amz-tagging` header path via `PutObjectCommand({ Tagging })` / Rust `.tagging()` which GCS accepts).

### 6. Diarization-health stale-event threshold tuning (`96126c89`)

Bumps `STALE_EVENT_THRESHOLD` from 5 to 10 for the Meet fallback to UI-based diarization — cuts false positives under jittery event delivery. Also prefixes the health logs with the meeting platform so mixed-provider debugging is easier.

## Test plan

- [ ] Preprod batch: bot rejected by Meet → process exits cleanly via `handleFailedRecording`, DB row ends at `latest_status='failed'` with `resolved_status='BOT_NOT_ACCEPTED'`
- [ ] Preprod batch: `/leave` sent before recording starts → `ExitingMeetingBeforeRecord`, clean exit, DB row terminal
- [ ] Preprod batch: Meet join with "Others may see your video differently" dialog → dialog dismissed, layout change succeeds OR retries complete in <15s without leaving Adjust view open
- [ ] Preprod batch: Layout change completely fails → Adjust view dialog cleared by cleanup (post-setup observer logs don't spam `found but not dismissed`)
- [ ] Preprod: simulate S3 slowness → Upload times out at 25min, file lands on EFS under `s3_upload_fails/<uuid>/`
- [ ] Preprod: simulate cleanup overrun → working dir mirrored to EFS under `cleanup_timeout/<uuid>/`
- [ ] GCS-backed self-host bucket: set `DISABLE_S3_OBJECT_TAGGING=true`, run a bot, verify no "NotImplemented" upload errors and Upload.done() resolves
- [ ] Scaleway (main env): `DISABLE_S3_OBJECT_TAGGING` unset, verify `data_retention_days` tag still applied on uploads (regression)
- [ ] Normal recording lifecycle unchanged end-to-end (regression)