### PR TITLE
fix: preserve state-machine end_reason in ScreenRecorder error handling

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1181,12 +1181,16 @@ export class ScreenRecorder extends EventEmitter {
 
       if (error instanceof Error) {
         if (error.message.includes("FFprobe failed") || error.message.includes("FFmpeg failed")) {
-          // Check if we already have a BotNotAccepted error (higher priority)
-          if (GLOBAL.hasError() && GLOBAL.getEndReason() === MeetingEndReason.BotNotAccepted) {
+          // Preserve any terminal end_reason already set by the state machine
+          // (TimeoutWaitingToStart, BotNotAccepted, LoginRequired, ApiRequest,
+          // InvalidMeetingUrl, ExitingMeetingBeforeRecord, etc). Recording
+          // post-processing failures shouldn't clobber the real cause of the
+          // failure that the state machine already identified.
+          if (GLOBAL.hasError()) {
             console.log(
-              "Preserving existing BotNotAccepted error instead of creating BotRemovedTooEarly"
+              `Preserving existing end_reason ${GLOBAL.getEndReason()} instead of creating BotRemovedTooEarly`
             )
-            throw error // Re-throw the original error to preserve BotNotAccepted
+            throw error
           }
 
           console.log("Converting FFprobe/FFmpeg error to BotRemovedTooEarly")
@@ -1357,11 +1361,16 @@ export class ScreenRecorder extends EventEmitter {
         // since the thrown error could be a non-FFmpeg error (disk, OOM,
         // permission) that wouldn't trip that check.
         //
-        // Preserve a higher-priority BotNotAccepted error if one is
-        // already set, mirroring the precedence in the outer catch below.
+        // Preserve any terminal end_reason already set by the state
+        // machine (e.g. TimeoutWaitingToStart from waiting-room-state):
+        // post-processing failure shouldn't clobber the real cause.
         console.warn("❌ Audio-only recording produced no audio; marking bot-removed-too-early")
-        if (!(GLOBAL.hasError() && GLOBAL.getEndReason() === MeetingEndReason.BotNotAccepted)) {
+        if (!GLOBAL.hasError()) {
           GLOBAL.setError(MeetingEndReason.BotRemovedTooEarly)
+        } else {
+          console.log(
+            `Preserving existing end_reason ${GLOBAL.getEndReason()} instead of overriding with BotRemovedTooEarly`
+          )
         }
         throw error
       }


### PR DESCRIPTION
## Summary

The `BotRemovedTooEarly` precedence guards in `ScreenRecorder.ts` (both `handleSuccessfulRecording`'s outer catch and `syncAndMergeFiles`' audio-only branch — the latter introduced in #148) only preserved a pre-existing `BotNotAccepted` error. Any other terminal `end_reason` set by the state machine — `TimeoutWaitingToStart`, `LoginRequired`, `ApiRequest`, `InvalidMeetingUrl`, `ExitingMeetingBeforeRecord` — got silently clobbered to `BotRemovedTooEarly` whenever the post-processing audio extraction or FFmpeg/FFprobe step failed afterwards.

This PR broadens both guards from "preserve `BotNotAccepted`" to "preserve any existing `end_reason`". Recording post-processing failures are a downstream symptom — they shouldn't override the real cause that the state machine already identified.

## Repro: prod bot `34f136ec-7dba-4d60-a019-835d8fcd70bb`

Google Meet, audio_only mode, 2026-04-26:

- `12:08:55.770` — waiting-room timeout fires → `setError(TimeoutWaitingToStart)` (waiting-room-state.ts:192)
- `12:08:55.788` — error-state correctly emits `waiting_room_timeout`
- `12:08:55.790` — cleanup begins, stops ScreenRecorder
- `12:09:21.350` — `syncAndMergeFiles`: `meetingStartTime: 0` (bot was never admitted), but recordingDuration > 10s so the existing fallback at `ScreenRecorder.ts:1242-1248` skips the `BotNotAccepted` setError and proceeds anyway
- `12:09:28.117` — audio extraction fails with FFmpeg code 234 (raw audio 0.09 MB after 600s in the lobby, no meeting audio ever captured)
- `12:09:28.119` — **audio-only branch fires `setError(BotRemovedTooEarly)`, clobbering `TimeoutWaitingToStart`**
- Backend receives `recording_failed:botRemovedTooEarly` instead of the truthful `waiting_room_timeout` signal already emitted moments earlier

## Changes

`src/recording/ScreenRecorder.ts`:

1. **Outer FFmpeg/FFprobe catch** (`handleSuccessfulRecording`, ~line 1185): replace `BotNotAccepted`-only allowlist with `GLOBAL.hasError()` check. Logs the preserved reason for debugging.
2. **Audio-only audio-extraction branch** (`syncAndMergeFiles`, ~line 1363): same fix. Logs the preserved reason on the suppression path.

## Out of scope (follow-ups worth filing)

The pre-existing `recordingDuration > 10000` fallback at `ScreenRecorder.ts:1242-1248` assumes the bot got into the meeting briefly. For a bot that sat in the lobby for 10 minutes, recordingDuration is large but the bot was never admitted — the fallback wrongly bypasses the `BotNotAccepted` setError branch. Not fixed here because the state-machine `TimeoutWaitingToStart` reason is now preserved correctly, which addresses the user-visible miscategorization for bot 34f136ec. But the fallback heuristic is still off for "lobby-only" cases and should be tightened separately (e.g. require some signal that the bot saw meeting UI, not just elapsed time).

## Test plan

- [ ] `pnpm tsc` clean (verified locally)
- [ ] Replay bot 34f136ec scenario in preprod (Meet bot stuck in lobby until waiting_room_timeout, audio_only mode) and confirm final reported reason is `timeoutWaitingToStart`, not `botRemovedTooEarly`
- [ ] Confirm the original `BotNotAccepted` precedence path still works (Meet denial → audio-extract failure should still report `botNotAccepted`, not get overridden)
- [ ] Confirm a genuine post-record failure with no prior end_reason still maps to `botRemovedTooEarly` (existing happy path)