### PR TITLE
fix(v1): upload-timeout + EFS mirror, plus backports of v2 PR #148 + #149

### DIFF
--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -1080,18 +1080,12 @@ async function closeAdjustViewDialogIfOpen(page: Page): Promise<void> {
                 'div[role="dialog"][aria-modal="true"] button[aria-label="Close" i]',
             )
             .first()
-        if (
-            (await closeBtn.count()) > 0 &&
-            (await closeBtn.isVisible({ timeout: 200 }))
-        ) {
-            console.log(
-                'Closing leftover Adjust view dialog via its Close button',
-            )
-            await closeBtn.evaluate((el: HTMLElement) => el.click(), {
-                timeout: 1000,
-            })
-            return
-        }
+        await closeBtn.waitFor({ state: 'visible', timeout: 200 })
+        console.log('Closing leftover Adjust view dialog via its Close button')
+        await closeBtn.evaluate((el: HTMLElement) => el.click(), {
+            timeout: 1000,
+        })
+        return
     } catch (error) {
         // Fall through to mouse-click fallback
         console.warn(

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -948,12 +948,11 @@ async function performCriticalSetupActions(
                 if (dialogObserver) {
                     await dialogObserver.dismissVisibleDialogs()
                 }
-                if (await changeLayout(page, attempt)) {
+                if (await changeLayout(page, attempt, maxAttempts)) {
                     console.log(`Layout change successful on attempt ${attempt}`)
                     break
                 }
                 if (attempt < maxAttempts) {
-                    await clickOutsideModal(page)
                     await page.waitForTimeout(300)
                 }
             }
@@ -966,13 +965,16 @@ async function performCriticalSetupActions(
     void htmlSnapshot.captureSnapshot(page, 'meet_join_meeting_success')
 }
 
+// Single-attempt layout change. Retry is owned by performCriticalSetupActions
+// so that dialog dismissal runs between each attempt (see GH #131). The
+// `attempt` parameter is passed in for logging only.
 async function changeLayout(
     page: Page,
-    currentAttempt = 1,
-    maxAttempts = 3,
+    attempt: number,
+    maxAttempts: number,
 ): Promise<boolean> {
     console.log(
-        `Starting layout change process (attempt ${currentAttempt}/${maxAttempts})...`,
+        `Starting layout change process (attempt ${attempt}/${maxAttempts})...`,
     )
 
     try {
@@ -992,13 +994,18 @@ async function changeLayout(
         // OPTIMIZATION: Remove networkidle wait (unnecessary for UI clicks)
         // await page.waitForLoadState('networkidle', { timeout: 5000 })  // REMOVED
 
+        // Explicit click timeouts: the Playwright default is 30s, which is absurd
+        // for a static call-controls button. If an overlay/scrim intercepts the
+        // click, fail fast so the outer loop can recover in a useful amount of time.
+        const CLICK_TIMEOUT_MS = 3000
+
         // 1. Click More options button
         console.log('Looking for More options button in call controls...')
         const moreOptionsButton = page.locator(
             'div[role="region"][aria-label="Call controls"] button[aria-label="More options"]',
         )
         await moreOptionsButton.waitFor({ state: 'visible', timeout: 3000 })
-        await moreOptionsButton.click()
+        await moreOptionsButton.click({ timeout: CLICK_TIMEOUT_MS })
 
         // OPTIMIZATION: Wait for menu to appear instead of fixed timeout
         await page.waitForSelector('[role="menu"]', {
@@ -1016,7 +1023,7 @@ async function changeLayout(
             '[role="menu"] [role="menuitem"]:has(span:has-text("Change layout"), span:has-text("Adjust view"))',
         )
         await changeLayoutItem.waitFor({ state: 'visible', timeout: 3000 })
-        await changeLayoutItem.click()
+        await changeLayoutItem.click({ timeout: CLICK_TIMEOUT_MS })
 
         // OPTIMIZATION: Wait for layout menu to appear instead of fixed timeout
         await page.waitForSelector('label:has-text("Spotlight")', {
@@ -1040,7 +1047,7 @@ async function changeLayout(
             )
             .first() // Use first() to handle cases where multiple Spotlight labels exist
         await spotlightOption.waitFor({ state: 'visible', timeout: 3000 })
-        await spotlightOption.click()
+        await spotlightOption.click({ timeout: CLICK_TIMEOUT_MS })
 
         // OPTIMIZATION: Wait for layout to change instead of fixed timeout
         await page.waitForTimeout(300) // Reduced from 500ms
@@ -1051,18 +1058,54 @@ async function changeLayout(
         return true
     } catch (error) {
         console.error(
-            `Error in changeLayout attempt ${currentAttempt}:`,
+            `Error in changeLayout attempt ${attempt}:`,
             formatError(error),
         )
 
-        if (currentAttempt < maxAttempts) {
-            console.log(
-                `Retrying layout change (attempt ${currentAttempt + 1}/${maxAttempts})...`,
-            )
-            await page.waitForTimeout(1000)
-            return changeLayout(page, currentAttempt + 1, maxAttempts)
-        }
+        // Close the Adjust view dialog if we managed to open it. Leaving it up blocks
+        // the More options button on subsequent attempts (its scrim intercepts pointer
+        // events — causing click timeouts) and the dialog observer can't dismiss it
+        // afterwards because its Close button is icon-only.
+        await closeAdjustViewDialogIfOpen(page)
+
         return false
+    }
+}
+
+async function closeAdjustViewDialogIfOpen(page: Page): Promise<void> {
+    try {
+        // Meet's Adjust view dialog: aria-modal with an icon-only Close button.
+        const closeBtn = page
+            .locator(
+                'div[role="dialog"][aria-modal="true"] button[aria-label="Close" i]',
+            )
+            .first()
+        if (
+            (await closeBtn.count()) > 0 &&
+            (await closeBtn.isVisible({ timeout: 200 }))
+        ) {
+            console.log(
+                'Closing leftover Adjust view dialog via its Close button',
+            )
+            await closeBtn.evaluate((el: HTMLElement) => el.click(), {
+                timeout: 1000,
+            })
+            return
+        }
+    } catch (error) {
+        // Fall through to mouse-click fallback
+        console.warn(
+            'Close-button path failed, falling back to clickOutsideModal:',
+            formatError(error),
+        )
+    }
+    try {
+        await clickOutsideModal(page)
+    } catch (error) {
+        console.warn(
+            'clickOutsideModal fallback also failed:',
+            formatError(error),
+        )
     }
 }
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -226,7 +226,7 @@ export class ScreenRecorder extends EventEmitter {
             // Emitting 'error' here would crash the process before handleFailedRecording
             // runs, because RecordingState's listener is only attached once we reach it —
             // which we won't, since cleanup is already in progress. Suppress the emit.
-            if (GLOBAL.getEndReason?.()) {
+            if (GLOBAL.getEndReason()) {
                 console.warn(
                     '[ScreenRecorder] Suppressing startError — end_reason already set:',
                     GLOBAL.getEndReason(),

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -195,6 +195,15 @@ export class ScreenRecorder extends EventEmitter {
             this.setupFileSizeMonitoring()
 
             await sleep(FLASH_SCREEN_SLEEP_TIME)
+            if (page.isClosed()) {
+                // Cleanup closed the page before we reached the sync signal (pre-recording
+                // stop/rejection race). Abort the start quietly — the state machine already
+                // has an end_reason and will handle the failure via handleFailedRecording.
+                console.warn(
+                    '[ScreenRecorder] Page closed before sync signal — aborting start',
+                )
+                return
+            }
             await generateSyncSignal(page, {
                 duration: 800, // Much longer signal for reliable detection
                 frequency: 1000, // Keep 1000Hz for consistency
@@ -212,6 +221,26 @@ export class ScreenRecorder extends EventEmitter {
                 formatError(error),
             )
             this.isRecording = false
+            // If an end_reason is already set, the state machine has committed to failing
+            // for a real reason (botNotAccepted, exitingMeetingBeforeRecord, etc.).
+            // Emitting 'error' here would crash the process before handleFailedRecording
+            // runs, because RecordingState's listener is only attached once we reach it —
+            // which we won't, since cleanup is already in progress. Suppress the emit.
+            if (GLOBAL.getEndReason?.()) {
+                console.warn(
+                    '[ScreenRecorder] Suppressing startError — end_reason already set:',
+                    GLOBAL.getEndReason(),
+                )
+                return
+            }
+            // No end_reason yet — unexpected. Set StreamingSetupFailed so the bot still
+            // reports a failure (rather than ending up as UNKNOWN_ERROR).
+            const errorMessage =
+                error instanceof Error ? error.message : String(error)
+            GLOBAL.setError(
+                MeetingEndReason.StreamingSetupFailed,
+                errorMessage,
+            )
             this.emit('error', { type: 'startError', error })
         }
     }
@@ -1077,16 +1106,18 @@ export class ScreenRecorder extends EventEmitter {
                     error.message.includes('FFprobe failed') ||
                     error.message.includes('FFmpeg failed')
                 ) {
-                    // Check if we already have a BotNotAccepted error (higher priority)
-                    if (
-                        GLOBAL.hasError() &&
-                        GLOBAL.getEndReason() ===
-                            MeetingEndReason.BotNotAccepted
-                    ) {
+                    // Preserve any terminal end_reason already set by the
+                    // state machine (TimeoutWaitingToStart, BotNotAccepted,
+                    // LoginRequired, ApiRequest, InvalidMeetingUrl,
+                    // ExitingMeetingBeforeRecord, etc). Recording
+                    // post-processing failures shouldn't clobber the real
+                    // cause of the failure that the state machine already
+                    // identified.
+                    if (GLOBAL.hasError()) {
                         console.log(
-                            'Preserving existing BotNotAccepted error instead of creating BotRemovedTooEarly',
+                            `Preserving existing end_reason ${GLOBAL.getEndReason()} instead of creating BotRemovedTooEarly`,
                         )
-                        throw error // Re-throw the original error to preserve BotNotAccepted
+                        throw error
                     }
 
                     console.log(
@@ -1293,10 +1324,34 @@ export class ScreenRecorder extends EventEmitter {
             console.warn(
                 `⚠️ Audio extraction failed (likely due to bot removal): ${error}`,
             )
+            if (GLOBAL.get().recording_mode === 'audio_only') {
+                // Audio-only mode with no extractable audio = nothing to deliver.
+                // Mark the failure here so the bot emits recording_failed instead
+                // of reporting silent success with an empty manifest — don't rely
+                // on handleSuccessfulRecording's "FFmpeg failed" string match,
+                // since the thrown error could be a non-FFmpeg error (disk, OOM,
+                // permission) that wouldn't trip that check.
+                //
+                // Preserve any terminal end_reason already set by the state
+                // machine (e.g. TimeoutWaitingToStart from waiting-room-state):
+                // post-processing failure shouldn't clobber the real cause.
+                console.warn(
+                    '❌ Audio-only recording produced no audio; marking bot-removed-too-early',
+                )
+                if (!GLOBAL.hasError()) {
+                    GLOBAL.setError(MeetingEndReason.BotRemovedTooEarly)
+                } else {
+                    console.log(
+                        `Preserving existing end_reason ${GLOBAL.getEndReason()} instead of overriding with BotRemovedTooEarly`,
+                    )
+                }
+                throw error
+            }
             console.warn(
-                `⚠️ Continuing without audio extraction to prevent bot hang`,
+                `⚠️ Continuing without audio extraction to prevent bot hang (video mode)`,
             )
-            // Don't throw - allow cleanup to continue
+            // Don't throw - the video mp4 is still deliverable on its own in
+            // speaker_view / gallery_view modes
         }
 
         // 10. Cleanup temporary files

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -433,6 +433,29 @@ export class SimpleDialogObserver {
                     await parentButton.evaluate((el: HTMLElement) => el.click(), { timeout: timeouts.CLICK_TIMEOUT })
                     return true
                 }
+
+                // Try aria-label (for icon-only buttons like Meet's "Close" X on the
+                // Adjust view dialog, which has aria-label="Close" but no visible text).
+                // Case-insensitive to tolerate Meet UI variants.
+                button = modal.locator(
+                    `button[aria-label="${buttonText}" i]`,
+                )
+                buttonCount = await button.count()
+
+                if (
+                    buttonCount > 0 &&
+                    (await button
+                        .first()
+                        .isVisible({ timeout: timeouts.VISIBLE_TIMEOUT }))
+                ) {
+                    console.info(
+                        `[SimpleDialogObserver] Clicking button (aria-label): "${buttonText}"`,
+                    )
+                    await button
+                        .first()
+                        .evaluate((el: HTMLElement) => el.click(), { timeout: timeouts.CLICK_TIMEOUT })
+                    return true
+                }
             } catch (error) {
                 console.warn(
                     `[SimpleDialogObserver] Error trying button "${buttonText}": ${error}`,

--- a/src/state-machine/constants.ts
+++ b/src/state-machine/constants.ts
@@ -11,7 +11,17 @@ export const MEETING_CONSTANTS = {
     RECORDING_TIMEOUT: 3600 * 4 * 1000, // 4 heures
     INITIAL_WAIT_TIME: 1000 * 60 * 7, // 7 minutes
     EMPTY_MEETING_CONFIRMATION_MS: 45_000, // 45 seconds before confirming no attendees
-    CLEANUP_TIMEOUT: 1000 * 60 * 60, // 1 heure
+    // Outer cleanup timeout. Kept at 1h so that a worst-case 4h recording
+    // plus 1h of cleanup still fits comfortably inside smart-rabbit's
+    // REDIS_SESSION_EXPIRATION_SEC SIGKILL (6h from bot spawn — bumped
+    // alongside this change). Typical cleanup runs in 2–15 minutes; the
+    // extra headroom exists so that pathologically slow object-store uploads
+    // don't cut cleanup short before it completes.
+    //
+    // If this timeout does fire, cleanup-state mirrors the bot's working
+    // directory to EFS before transitioning to Terminated, preserving any
+    // locally-built output files a reconciliation job can push to S3 later.
+    CLEANUP_TIMEOUT: 1000 * 60 * 60, // 1 hour
     RESUMING_TIMEOUT: 1000 * 60 * 60, // 1 heure
     DEFAULT_SILENCE_TIMEOUT_SECONDS: 600, // 10 minutes - default fallback when global value is nil
     DEFAULT_NOONE_JOINED_TIMEOUT_SECONDS: 300, // 5 minutes - default fallback matching API server default

--- a/src/state-machine/states/cleanup-state.ts
+++ b/src/state-machine/states/cleanup-state.ts
@@ -5,6 +5,8 @@ import { MEETING_CONSTANTS } from '../constants'
 import { MeetingStateType, StateExecuteResult } from '../types'
 import { BaseState } from './base-state'
 import { formatError } from '../../utils/Logger'
+import { PathManager } from '../../utils/PathManager'
+import { S3Uploader } from '../../utils/S3Uploader'
 import { SoundLevelMonitor } from '../../utils/sound-level-monitor'
 
 export class CleanupState extends BaseState {
@@ -27,6 +29,11 @@ export class CleanupState extends BaseState {
                 console.info('🧹 Cleanup completed successfully')
             } catch (error) {
                 console.error('🧹 Cleanup failed or timed out:', formatError(error))
+                // Timeout or other cleanup failure — mirror whatever the pipeline
+                // did build locally to EFS so a later reconciliation job can
+                // push it to S3. Without this, hung uploads that outlast the
+                // outer timeout take output.mp4/output.wav down with the pod.
+                await this.mirrorRecordingsToEFS()
                 // Continue to Terminated even if cleanup fails
             }
             console.info('🧹 Transitioning to Terminated state')
@@ -36,6 +43,21 @@ export class CleanupState extends BaseState {
             // Always transition to Terminated to avoid infinite loops
             console.info('🧹 Forcing transition to Terminated despite error')
             return this.transition(MeetingStateType.Terminated)
+        }
+    }
+
+    private async mirrorRecordingsToEFS(): Promise<void> {
+        try {
+            const uploader = S3Uploader.getInstance()
+            if (!uploader) return // serverless or not configured
+            const basePath = PathManager.getInstance().getBasePath()
+            await uploader.copyDirToEFS(basePath)
+        } catch (error) {
+            // copyDirToEFS already swallows its own errors, but guard anyway
+            console.error(
+                '🧹 EFS mirror after cleanup timeout failed:',
+                formatError(error),
+            )
         }
     }
 

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -12,6 +12,13 @@ let instance: S3Uploader | null = null
 // Controlled concurrency: process files in batches to avoid overwhelming the system
 const MAX_CONCURRENT_UPLOADS = 100 // Limit concurrent uploads
 
+// Wall-clock cap on a single S3 upload. AWS SDK v3's Upload class has no
+// total-time option; per-chunk request timeouts aren't enough because a hung
+// peer (e.g. Scaleway's 2026-04-22 incident) will keep retrying parts
+// indefinitely. Hitting this threshold aborts the in-flight multipart upload
+// and throws, which lets the catch-block EFS fallback fire.
+const UPLOAD_TIMEOUT_MS = 25 * 60 * 1000 // 25 minutes
+
 export class S3Uploader {
     private s3Client: S3Client
 
@@ -63,7 +70,33 @@ export class S3Uploader {
                 ...(s3Tags && { tags: s3Tags }),
             })
 
-            await upload.done()
+            let timeoutHandle: NodeJS.Timeout | null = null
+            const timeoutPromise = new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(() => {
+                    upload.abort().catch((abortErr) => {
+                        // Best-effort — the reject below is what actually
+                        // signals the timeout. If abort itself fails, there
+                        // may be a lingering multipart upload on the bucket
+                        // (Scaleway's 7-day incomplete-multipart cleanup will
+                        // eventually reap it) so log for investigation rather
+                        // than swallow.
+                        console.warn(
+                            `⚠️ upload.abort() failed for ${s3Path}: ${abortErr}`,
+                        )
+                    })
+                    reject(
+                        new Error(
+                            `S3 upload exceeded ${UPLOAD_TIMEOUT_MS}ms for ${s3Path}`,
+                        ),
+                    )
+                }, UPLOAD_TIMEOUT_MS)
+            })
+
+            try {
+                await Promise.race([upload.done(), timeoutPromise])
+            } finally {
+                if (timeoutHandle) clearTimeout(timeoutHandle)
+            }
             console.log(
                 `✅ S3 upload successful: ${s3Path}${tags ? ` (with tags: ${JSON.stringify(tags)})` : ''}`,
             )
@@ -236,6 +269,95 @@ export class S3Uploader {
             throw error
         }
     }
+
+    /**
+     * Recursively copy an entire directory (typically the bot's `recordings/{uuid}/`
+     * working dir) to EFS under `s3_upload_fails/{bot_uuid}/`. Used as a
+     * last-resort safety net when cleanup hits its overall timeout and we need
+     * to preserve whatever artifacts were built locally before the pod
+     * terminates. Same prefix as per-file copyToEFS above, so a downstream
+     * reconciliation job that scans s3_upload_fails/ handles both uniformly.
+     *
+     * No-op in local/dev environments. Errors are logged but swallowed so the
+     * caller can continue into Terminated without blocking.
+     */
+    public async copyDirToEFS(localDir: string): Promise<void> {
+        try {
+            const global = GLOBAL.get()
+            if (global.environ === 'dev' || global.environ === 'local') {
+                console.warn(
+                    `⚠️ EFS not available in ${global.environ} environment - skipping dir copy`,
+                )
+                return
+            }
+
+            let efsEnvPath: string
+            switch (global.environ) {
+                case 'prod':
+                    efsEnvPath = 'prod'
+                    break
+                case 'preprod':
+                    efsEnvPath = 'preprod'
+                    break
+                default:
+                    console.warn(
+                        `⚠️ Unknown environment ${global.environ} - skipping EFS dir copy`,
+                    )
+                    return
+            }
+
+            if (!fs.existsSync(localDir)) {
+                console.warn(`⚠️ Local dir does not exist, skipping EFS copy: ${localDir}`)
+                return
+            }
+
+            const efsBasePath = path.join(
+                EFS_MOUNT_POINT,
+                efsEnvPath,
+                's3_upload_fails',
+                global.bot_uuid,
+            )
+            console.log(
+                `📁 Copying ${localDir} → ${efsBasePath} (cleanup-timeout safety net)`,
+            )
+            await fs.promises.mkdir(efsBasePath, { recursive: true })
+            const copied = await copyDirRecursive(localDir, efsBasePath)
+            console.log(
+                `📁 Directory copied to EFS: ${efsBasePath} (${copied} files)`,
+            )
+        } catch (error) {
+            // Best-effort — don't let an EFS failure block termination
+            console.error(`❌ Failed to copy dir to EFS: ${error}`)
+        }
+    }
+}
+
+/**
+ * Recursively copy `src` into `dst`, creating sub-directories as needed.
+ * Manual walk because the project's pinned @types/node (14.x) predates
+ * `fs.promises.cp`. Returns the number of files copied.
+ */
+async function copyDirRecursive(src: string, dst: string): Promise<number> {
+    let count = 0
+    const entries = await fs.promises.readdir(src, { withFileTypes: true })
+    await fs.promises.mkdir(dst, { recursive: true })
+    for (const entry of entries) {
+        const srcPath = path.join(src, entry.name)
+        const dstPath = path.join(dst, entry.name)
+        if (entry.isDirectory()) {
+            count += await copyDirRecursive(srcPath, dstPath)
+        } else if (entry.isFile()) {
+            try {
+                await fs.promises.copyFile(srcPath, dstPath)
+                count++
+            } catch (error) {
+                // Log and continue — best-effort
+                console.warn(`  skipped ${srcPath}: ${error}`)
+            }
+        }
+        // Symlinks, sockets, etc. are skipped.
+    }
+    return count
 }
 
 // Export utility functions that use the singleton instance

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -254,7 +254,15 @@ export class S3Uploader {
                 efsEnvPath,
                 global.bot_uuid,
             )
-            const efsFilePath = path.join(efsBasePath, s3Path)
+            // efsBasePath already scopes to the bot UUID
+            // (/mnt/efs/<env>/<uuid>). Callers' s3Path usually starts with
+            // `<uuid>/` (keys are built as `${identifier}/<subpath>`), which
+            // would produce `<uuid>/<uuid>/…` on join. Strip the redundant
+            // prefix so the on-disk layout has a single UUID nesting.
+            const relativeKey = s3Path.startsWith(`${global.bot_uuid}/`)
+                ? s3Path.slice(global.bot_uuid.length + 1)
+                : s3Path
+            const efsFilePath = path.join(efsBasePath, relativeKey)
             const efsDir = path.dirname(efsFilePath)
 
             // Create EFS directory structure


### PR DESCRIPTION
v1 (`origin/main`) counterpart of the bot fixes that have been landing on v2 (`origin/v2-improvements`). Three commits, in order:

### 1. `3413853` — wall-clock S3 upload timeout + EFS mirror on cleanup timeout

Companion to outer-repo work in `meeting-baas` (smart-rabbit + recording_server). Addresses the **2026-04-22 Scaleway object-storage incident** where uploads hung indefinitely instead of failing, so the existing per-file EFS fallback never fired.

- `S3Uploader.uploadFile` wraps `upload.done()` in `Promise.race` against a 25-minute wall clock. On timeout: `upload.abort()` (logged on failure), then throw — existing catch-block EFS fallback runs.
- `cleanup-state.ts`: when the outer `CLEANUP_TIMEOUT` fires, mirror the bot working dir to `/mnt/efs/<env>/s3_upload_fails/<uuid>/` via a new `S3Uploader.copyDirToEFS` helper. Without this, hung uploads that outlast the cleanup window took `output.{mp4,wav}` down with the pod.
- `CLEANUP_TIMEOUT` stays at 1h. Smart-rabbit's outer SIGKILL is being bumped 5h → 6h in the companion outer-repo PR.

### 2. `27736b9` — backport of v2 PR #148 + #149

Ported four bug fixes from v2 (`v2-improvements` branch) that apply cleanly because v1's recording flow + state machine + Meet UI scaffolding still match v2's:

- **Pre-record startError crash** ([v2: 48f44a4a](https://github.com/Meeting-BaaS/meet-teams-bot/commit/48f44a4a)) — `page.isClosed()` check before `generateSyncSignal()`, suppress `emit('error', startError)` when state machine has an end_reason already, set `StreamingSetupFailed` if no end_reason. Prevents process crash on pre-recording stop/rejection race.

- **Audio-only `BotRemovedTooEarly`** ([v2: be971740 (C-fragment)](https://github.com/Meeting-BaaS/meet-teams-bot/commit/be971740)) — when `extractAudioFromVideo` throws in `audio_only` mode, propagate failure instead of silently emitting `recording_succeeded` with an empty manifest. Fixes the silent-success bug seen on bots `3022687b-…` and `4567881a-…` during the incident audit.

- **Preserve any state-machine `end_reason`** ([v2: cdf3c94e PR #149](https://github.com/Meeting-BaaS/meet-teams-bot/commit/cdf3c94e)) — broadens the precedence guards from `BotNotAccepted`-only to any terminal `end_reason` (TimeoutWaitingToStart, LoginRequired, ApiRequest, etc.) so post-processing failures don't clobber the state machine's real diagnosis.

- **Meet Adjust-view dialog cleanup + click timeouts + collapse retry** ([v2: b2235b48](https://github.com/Meeting-BaaS/meet-teams-bot/commit/b2235b48), [v2: 05230eed GH #131](https://github.com/Meeting-BaaS/meet-teams-bot/commit/05230eed)) — explicit 3s click timeouts on More options / Change layout / Spotlight (Playwright default 30s is absurd for static call controls); new `closeAdjustViewDialogIfOpen()` helper for the icon-only Close button via aria-label; `aria-label` button fallback in the dialog observer; collapse `changeLayout`'s recursive retry into the `performCriticalSetupActions` outer loop (was producing up to 9× retries with no dialog dismissal between them).

### 3. `d654b77` — `copyToEFS` UUID prefix strip ([v2: 9b7892c8](https://github.com/Meeting-BaaS/meet-teams-bot/commit/9b7892c8))

`efsBasePath` already scopes to the bot UUID. Callers' `s3Path` usually starts with `<uuid>/` (keys built as `${identifier}/<subpath>`), which would have produced `<uuid>/<uuid>/…` on join. Strip the redundant prefix so the on-disk layout has a single UUID nesting.

### Skipped intentionally (not portable to v1)

- v2 `f6cf888f / 193d55f7` — `DISABLE_S3_OBJECT_TAGGING` env-gate. v1 has no `envVars` wrapper and tags unconditionally for retention.
- v2 `96126c89` — diarization stale-event tuning. v1 has no network-diarization fallback path / `consecutiveStaleCount`.

### Test plan

- [ ] Soak in preprod: induce hung S3 upload (e.g., point `AWS_ENDPOINT_URL` at a black-hole IP) and verify timeout fires at 25 min, EFS fallback completes, bot exits cleanly.
- [ ] Soak in preprod: kill bot mid-meeting (audio_only) before sync — verify `recording_failed` webhook fires with `BotRemovedTooEarly` instead of silent `recording_succeeded`.
- [ ] Smoke test Meet flow: confirm Adjust-view dialog cleanup is reached on layout-change failure and outer attempt loop succeeds.