### PR TITLE
fix(teams): detect verification modal as LoginRequired denial

### DIFF
--- a/src/meeting/teams-state-config.ts
+++ b/src/meeting/teams-state-config.ts
@@ -12,6 +12,16 @@ export const TEAMS_STATE_CONFIG: StateDetectionConfig = {
       reason: MeetingEndReason.BotNotAccepted,
       logPrefix: "XXXXXXXXXXXXXXXXXX Teams has denied entry",
       errorMessage: "Teams has denied entry"
+    },
+    {
+      // In-page anonymous-join verification modal. Teams renders this over the
+      // pre-join screen instead of redirecting to login.microsoft.com, so the
+      // URL-based isOnMicrosoftLoginPage check never trips and the bot would
+      // otherwise sit at pre-join until the 600s waiting-room timer fires.
+      texts: ["We need to verify your info before you can join"],
+      reason: MeetingEndReason.LoginRequired,
+      logPrefix: "XXXXXXXXXXXXXXXXXX Teams requires sign-in to join",
+      errorMessage: "Teams requires participants to be authenticated before joining"
     }
   ],
   // Teams doesn't have a distinct waiting room pattern detection

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -402,10 +402,10 @@ export class TeamsProvider implements MeetingProviderInterface {
     let inMeeting = false
 
     while (!inMeeting) {
-      // Check if we have been refused
-      const botNotAccepted = await isBotNotAccepted(page)
-      if (botNotAccepted) {
-        GLOBAL.setError(MeetingEndReason.BotNotAccepted)
+      // Check if we have been refused (or sign-in is required). isBotNotAccepted
+      // sets the precise end reason (BotNotAccepted, LoginRequired, …) from the
+      // matched denial pattern, so we just need to bail out here.
+      if (await isBotNotAccepted(page)) {
         throw new Error("Bot not accepted into Teams meeting")
       }
 
@@ -706,7 +706,11 @@ async function isBotNotAccepted(page: Page): Promise<boolean> {
   // Use unified state detector
   const result = await teamsStateDetector.isDenied(page)
   if (result.matched) {
-    console.log(`Teams denial detected: "${result.matchedText}"`)
+    const reason =
+      (result.pattern && "reason" in result.pattern ? result.pattern.reason : undefined) ??
+      MeetingEndReason.BotNotAccepted
+    console.log(`Teams denial detected: "${result.matchedText}" -> ${reason}`)
+    GLOBAL.setError(reason)
     return true
   }
 


### PR DESCRIPTION
## Summary

- Teams sometimes blocks anonymous join with an in-page verification modal (**"We need to verify your info before you can join"**) instead of redirecting to `login.microsoft.com`. The URL-based `isOnMicrosoftLoginPage` check never trips for the modal flow, so the bot would sit at pre-join until the 600 s waiting-room timer fires and end with `timeoutWaitingToStart`.
- Add the modal's header text as a second entry in `TEAMS_STATE_CONFIG.denialPatterns` mapped to `MeetingEndReason.LoginRequired`. The existing join-confirmation polling loop in `teams.ts` already calls `isBotNotAccepted` every iteration, so it picks the modal up within seconds — no new detector, no timeout shim, no short-circuit.
- Make `isBotNotAccepted` set `GLOBAL.setError` using the matched pattern's `reason` (falling back to `BotNotAccepted`) so each denial pattern can carry its own end reason. The caller in the join-confirmation loop no longer hardcodes `BotNotAccepted` — the existing "denied access" text still maps to `BotNotAccepted` via its pattern.

## Repro

Both prod runs ended with `timeoutWaitingToStart` on 2026-05-11:

- `88761419-ac72-4c06-bbed-a1f97f182230`
- `a99eb668-83c2-4411-aa57-9e17bb26f919`

Both targeted `teams.microsoft.com/meet/27101570297097` and never reached the `inCall` state. Their `error_state_dom_capture.html` snapshots contain the modal title in a visible `<h2 id="dialog-title-rr" class="fui-DialogTitle …">` inside a `role="dialog" aria-modal="true"` overlay. Screenshots from frame ~3 onward show the same modal over a grayed-out "Join now" button.

## Test plan

- [x] Run a Teams bot against an anonymous-join meeting that triggers the verification modal (Teams admin policy "Anonymous users can join a meeting" off). Expect: run ends within seconds of the modal rendering with end reason `loginRequired` instead of waiting 600 s for `timeoutWaitingToStart`.
- [x] Run a Teams bot against a normal meeting where the host denies entry. Expect: existing `BotNotAccepted` behavior unchanged (matches the "Sorry, but you were denied access to the meeting." pattern).
- [x] Sanity: Teams happy-path join still works end-to-end.