### PR TITLE
Feat/meet residential proxy and detection signal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,5 +69,19 @@ XDG_RUNTIME_DIR=/tmp/pulse
 # Boolean (true/false) - Whether the bot should create and upload audio chunks for the recording (2 hour long chunks) - This is useful if the transcription provider has a duration limit
 UPLOAD_AUDIO_CHUNKS=true
 
-# Boolean (true/false) - Whether the bot should upload the raw video captured in the logs bucket. This is useful for debugging  
+# Boolean (true/false) - Whether the bot should upload the raw video captured in the logs bucket. This is useful for debugging
 UPLOAD_RAW_VIDEO=false
+
+# Decodo (or similar) backconnect residential proxy used only for Google Meet
+# during the join phase. After the bot is admitted the proxy switches off and
+# the session goes direct (see src/proxy/toggle-proxy.ts).
+#
+# The {SESSION} placeholder is substituted at runtime with the bot's UUID
+# (hyphens stripped). Each bot pod gets a sticky residential IP while
+# different bots naturally land on different IPs from the pool.
+#
+# Example (Decodo, EU continent):
+# RESIDENTIAL_PROXY_TEMPLATE=http://user-<USER>-continent-eu-session-{SESSION}:<PASS>@gate.decodo.com:7000
+#
+# Leave empty to disable residential proxy (bot joins direct from the pod IP).
+RESIDENTIAL_PROXY_TEMPLATE=

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.0",
         "pako": "^2.1.0",
         "protobufjs": "^7.5.4",
+        "proxy-chain": "^2.7.1",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "winston": "^3.17.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "pako": "^2.1.0",
         "protobufjs": "^7.5.4",
         "proxy-chain": "^2.7.1",
+        "https-proxy-agent": "^9.0.0",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "winston": "^3.17.0",

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -2,7 +2,7 @@ import { type BrowserContext, chromium } from "@playwright/test"
 import { envVars } from "../config/env-vars"
 import { formatError } from "../utils/Logger"
 
-export async function openBrowser(): Promise<{ browser: BrowserContext }> {
+export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: BrowserContext }> {
   // Resolution configuration from environment variable
   // Defaults to 720p if RESOLUTION is not set or invalid
   const resolution = envVars.RESOLUTION
@@ -79,7 +79,10 @@ export async function openBrowser(): Promise<{ browser: BrowserContext }> {
         // Additional audio debugging (remove in production)
         "--enable-logging=stderr",
         "--log-level=1",
-        "--vmodule=*audio*=3" // Enable audio debug logging
+        "--vmodule=*audio*=3", // Enable audio debug logging
+
+        // Proxy configuration (added dynamically if proxy is active)
+        ...(proxyUrl ? [`--proxy-server=${proxyUrl}`] : [])
       ],
       permissions: ["microphone", "camera"],
       ignoreHTTPSErrors: true,

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -47,7 +47,15 @@ export const envVars = cleanEnv(process.env, {
   // `x-amz-tagging` header on PutObject/CreateMultipartUpload (via
   // `PutObjectCommand({ Tagging: "k=v" })` in JS and `.tagging("k=v")`
   // on the Rust aws-sdk-s3-transfer-manager), which GCS accepts.
-  DISABLE_S3_OBJECT_TAGGING: bool({ default: false })
+  DISABLE_S3_OBJECT_TAGGING: bool({ default: false }),
+  // Decodo (and similar) backconnect-style residential proxy template. The
+  // {SESSION} placeholder is substituted at runtime with the bot's UUID
+  // (hyphens stripped) so each bot pod gets a sticky residential IP while
+  // different bots naturally land on different IPs from the pool.
+  // Format example:
+  //   http://user-<USER>-continent-eu-session-{SESSION}:<PASS>@gate.decodo.com:7000
+  // Leave empty to disable residential proxy.
+  RESIDENTIAL_PROXY_TEMPLATE: str({ default: "" })
 })
 
 export type EnvVars = typeof envVars

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -79,7 +79,9 @@ export class MeetProvider implements MeetingProviderInterface {
       // Setup network interception scripts BEFORE navigation
       // addInitScript must be called before page.goto() to work properly
       try {
-        const { setupNetworkInterceptionScripts } = await import("./meet/network-interception")
+        const { setupNetworkInterceptionScripts, setupBotDetectionRoute } = await import(
+          "./meet/network-interception"
+        )
         const success = await setupNetworkInterceptionScripts(page)
         if (success) {
           console.log("[Meet] ✅ Network interception scripts set up")
@@ -89,6 +91,20 @@ export class MeetProvider implements MeetingProviderInterface {
           )
           GLOBAL.setNetworkInterceptionSetupFailed()
         }
+        // Wire the Meet bot-detection observer (page.on('response') on the
+        // CreateMeetingDevice RPC). Must be installed before page.goto so the
+        // response listener is in place when the join handshake fires.
+        await setupBotDetectionRoute(page, (signal) => {
+          if (signal.detectedAsBot) {
+            console.error(
+              `[Meet] 🚨 Meet flagged this bot — detectedAsBot=${signal.detectedAsBot} (raw field 36 = ${signal.rawField})`
+            )
+          } else {
+            console.log(
+              `[Meet] ✅ Meet did NOT flag this bot — detectedAsBot=${signal.detectedAsBot} (raw field 36 = ${signal.rawField})`
+            )
+          }
+        })
       } catch (error) {
         console.warn(
           "[Meet] ⚠️ Failed to setup network interception scripts, will fallback to UI-based detection:",

--- a/src/meeting/meet/network-interception/index.ts
+++ b/src/meeting/meet/network-interception/index.ts
@@ -3,13 +3,31 @@
 
 import path from "node:path"
 import type { Page } from "@playwright/test"
+import protobuf from "protobufjs"
 import { browserInterceptionLogic } from "./browser-bundle"
 import { PROTO_SCHEMA } from "./schema"
+
+// Node-side reflection for the single field we read off Meet's
+// CreateMeetingDeviceResponse. protobufjs Type.decode skips unknown fields
+// automatically, so we don't have to spell out the rest of the message —
+// the full proto has dozens of fields we don't care about.
+const CreateMeetingDeviceResponseType = new protobuf.Type("CreateMeetingDeviceResponse").add(
+  new protobuf.Field("detectedAsBot", 36, "uint32")
+)
 
 // Re-export types
 export type { ChatMessage, NetworkPayload, NetworkUser } from "./types"
 
 import type { ChatMessage, NetworkPayload } from "./types"
+
+// Signal payload emitted when Meet's CreateMeetingDevice response is decoded.
+// Field 36 of the response is a varint that's set when Meet has classified
+// the bot as suspected.
+export type MeetBotDetectionSignal = {
+  detectedAsBot: boolean
+  rawField: number | string | null
+  timestamp: number
+}
 
 // Extend Window interface for network interception functions
 declare global {
@@ -137,6 +155,67 @@ export async function setupChatMessageCallback(
   } catch (error) {
     console.error("[NetworkInterceptor] Failed to expose chat callback:", error)
     return false
+  }
+}
+
+/**
+ * Setup the Meet bot-detection signal observer. Must be called BEFORE
+ * page.goto() so the response listener is in place when the first
+ * CreateMeetingDevice request fires during the join handshake.
+ *
+ * Uses page.on("response", ...) as a passive observer — fires after the
+ * browser has fully received the response and lets us read the body from
+ * Playwright's buffer. The request itself is never touched: Chrome's TLS
+ * handshake, HTTP/2 settings, header order all stay genuine.
+ *
+ * History: the previous implementation used page.route() + route.fetch() +
+ * route.fulfill(). That worked for capturing the signal but caused Meet to
+ * flag the bot because route.fetch() re-issues the request from Node's HTTP
+ * stack (page.request context), producing a node-fetch JA3/JA4 fingerprint
+ * that doesn't match Chrome. Two consecutive runs returned detectedAsBot=2
+ * because of this. Pure observation has no such side-effect.
+ *
+ * page.on("response") is dispatched via the Network CDP domain, not Runtime,
+ * so rebrowser-playwright's Runtime.enable patch doesn't suppress it (the
+ * same reason page.on("request") still works under rebrowser).
+ */
+export async function setupBotDetectionRoute(
+  page: Page,
+  onSignal: (signal: MeetBotDetectionSignal) => void
+): Promise<boolean> {
+  page.on("response", async (response) => {
+    try {
+      const url = response.url()
+      if (!url.includes("MeetingDeviceService/CreateMeetingDevice")) return
+      if (!response.ok()) return
+      const text = await response.text()
+      // Response body is base64-encoded protobuf.
+      const bytes = Uint8Array.from(Buffer.from(text, "base64"))
+      const raw = decodeDetectedAsBotField(bytes)
+      onSignal({
+        detectedAsBot: Boolean(raw),
+        rawField: raw,
+        timestamp: Date.now()
+      })
+    } catch (err) {
+      // Body might not be available (e.g. response stream already consumed
+      // by Meet's own JS reading it twice via clone) or decode could fail.
+      // Don't break the join flow over a telemetry hiccup.
+      console.error("[BotDetection] response handler failed:", err)
+    }
+  })
+  console.log("[BotDetection] ✅ page.on('response') observer installed for CreateMeetingDevice")
+  return true
+}
+
+function decodeDetectedAsBotField(bytes: Uint8Array): number | null {
+  try {
+    const msg = CreateMeetingDeviceResponseType.decode(bytes) as unknown as {
+      detectedAsBot?: number
+    }
+    return msg.detectedAsBot ?? null
+  } catch {
+    return null
   }
 }
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -48,12 +48,13 @@ let server: Server | null = null
 let useUpstream = true
 let exitIp: string | null = null
 
-// Accumulated byte counts from closed connections, reset on each startToggleProxy call.
-// srcTx/srcRx = bytes between Chrome and local proxy; trgTx/trgRx = bytes between local
-// proxy and the upstream residential proxy (or target when in direct mode).
+// Set of connectionIds that were routed through the residential upstream.
+// Used to filter stats so only Decodo-billed traffic is counted.
+const proxiedConnectionIds = new Set<number>()
+
+// Accumulated byte counts from closed upstream-proxied connections only.
+// trgTxBytes/trgRxBytes are the bytes over the Decodo link (what Decodo bills).
 const stats = {
-  srcTxBytes: 0,
-  srcRxBytes: 0,
   trgTxBytes: 0,
   trgRxBytes: 0,
   connectionCount: 0
@@ -66,21 +67,17 @@ function formatBytes(bytes: number): string {
 }
 
 function logStats(label: string): void {
-  // Start with bytes from already-closed connections
-  let srcTx = stats.srcTxBytes
-  let srcRx = stats.srcRxBytes
+  // Start with bytes from already-closed proxied connections
   let trgTx = stats.trgTxBytes
   let trgRx = stats.trgRxBytes
   let count = stats.connectionCount
 
-  // Add bytes from connections still open at log time — these are long-lived
-  // keep-alive/H2 tunnels that carry most of the traffic but haven't closed yet.
+  // Add bytes from proxied connections still open at log time — long-lived
+  // keep-alive/H2 tunnels carry most traffic but may not have closed yet.
   if (server) {
-    for (const id of server.getConnectionIds()) {
+    for (const id of proxiedConnectionIds) {
       const cs = server.getConnectionStats(id)
       if (cs) {
-        srcTx += cs.srcTxBytes
-        srcRx += cs.srcRxBytes
         trgTx += cs.trgTxBytes ?? 0
         trgRx += cs.trgRxBytes ?? 0
         count++
@@ -88,15 +85,14 @@ function logStats(label: string): void {
     }
   }
 
+  // trgTx + trgRx = bytes over the Decodo residential link — matches dashboard billing
   const ipSuffix = exitIp ? ` | exit IP: ${exitIp}` : ""
   console.log(
     `[ToggleProxy] 📊 ${label} | ` +
-      `connections: ${count} | ` +
-      `client→proxy: ${formatBytes(srcTx)} | ` +
-      `proxy→client: ${formatBytes(srcRx)} | ` +
-      `proxy→target: ${formatBytes(trgTx)} | ` +
-      `target→proxy: ${formatBytes(trgRx)} | ` +
-      `total: ${formatBytes(srcTx + srcRx)}` +
+      `proxied connections: ${count} | ` +
+      `→ Decodo: ${formatBytes(trgTx)} | ` +
+      `← Decodo: ${formatBytes(trgRx)} | ` +
+      `total (Decodo billed): ${formatBytes(trgTx + trgRx)}` +
       ipSuffix
   )
 }
@@ -110,18 +106,17 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
   const session = sessionId.replace(/-/g, "")
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
 
-  // Reset stats and exit IP for this new session
-  stats.srcTxBytes = 0
-  stats.srcRxBytes = 0
+  // Reset stats, proxied-connection tracking, and exit IP for this new session
   stats.trgTxBytes = 0
   stats.trgRxBytes = 0
   stats.connectionCount = 0
+  proxiedConnectionIds.clear()
   exitIp = null
 
   try {
     server = new Server({
       port: 0,
-      prepareRequestFunction: ({ request }) => {
+      prepareRequestFunction: ({ connectionId, request }) => {
         // CONNECT requests use "host:port" format, not a full URL
         const target = request.url.includes("://")
           ? new URL(request.url).hostname
@@ -131,6 +126,7 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
           return {}
         }
         if (useUpstream) {
+          proxiedConnectionIds.add(connectionId)
           console.log(`[ToggleProxy] PROXIED → ${target}`)
           return { upstreamProxyUrl: upstreamUrl }
         }
@@ -143,10 +139,10 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
     // The local proxy server must stay running after joining (Chrome was launched
     // with --proxy-server pointing here), but setDirectMode() stops routing through
     // the upstream residential proxy — so stats at that point reflect residential usage.
-    server.on("connectionClosed", ({ stats: cs }: { connectionId: number; stats: ConnectionStats }) => {
+    server.on("connectionClosed", ({ connectionId, stats: cs }: { connectionId: number; stats: ConnectionStats }) => {
+      if (!proxiedConnectionIds.has(connectionId)) return
+      proxiedConnectionIds.delete(connectionId)
       stats.connectionCount++
-      stats.srcTxBytes += cs.srcTxBytes
-      stats.srcRxBytes += cs.srcRxBytes
       stats.trgTxBytes += cs.trgTxBytes ?? 0
       stats.trgRxBytes += cs.trgRxBytes ?? 0
     })

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -8,18 +8,42 @@ import { HttpsProxyAgent } from "https-proxy-agent"
 import { Server } from "proxy-chain"
 import { envVars } from "../config/env-vars"
 
-// Chrome background services & static-asset CDNs that aren't needed for Meet
-// but consume disproportionate residential bandwidth. Always go direct, even
-// while the rest of the session is proxied. Exact hostname match — add hosts
-// here as Decodo dashboard reveals them.
-const PROXY_BYPASS_HOSTS = new Set([
-  "optimizationguide-pa.googleapis.com", // Chrome ML model downloads
-  "fonts.gstatic.com", // Google Fonts CDN
-  "gstatic.com", // Google static asset CDN
-  "play.google.com" // Chrome Play Store / extension chatter
+// Allowlist of hosts that route through the residential upstream. Everything
+// else goes direct from the pod IP. Default-direct is intentional: if Google
+// adds a new asset CDN tomorrow, it goes direct automatically and doesn't
+// surprise us with a residential bandwidth balloon. The trade-off vs a
+// deny-list is that a missing entry here costs detection rate rather than
+// money — re-check the Decodo dashboard + the [Meet] 🚨/✅ signal after
+// adjusting this list.
+//
+// Suffix matches cover the host itself AND any subdomain. Exact matches do
+// not — `google.com` exact is intentional so we don't pull `play.google.com`
+// or `mtalk.google.com` into the proxied set.
+const PROXY_ALLOWLIST_SUFFIXES: readonly string[] = [
+  "meet.google.com", // SPA + the $rpc scoring endpoints
+  "accounts.google.com", // OAuth / login flow
+  "apis.google.com", // Google APIs the Meet client calls during join
+  "clients6.google.com" // Meet signaling — hangouts., feedback-pa., scone-pa.
+]
+
+const PROXY_ALLOWLIST_EXACT: ReadonlySet<string> = new Set([
+  "google.com",
+  "www.google.com",
+  "ip.decodo.com" // our own residential-IP probe
 ])
 
+function shouldProxy(target: string): boolean {
+  if (PROXY_ALLOWLIST_EXACT.has(target)) return true
+  return PROXY_ALLOWLIST_SUFFIXES.some(
+    (suffix) => target === suffix || target.endsWith(`.${suffix}`)
+  )
+}
+
 let server: Server | null = null
+// Proxy is on from startup. Lazy-enable (SPA loads direct, flip on at join)
+// was tested and increased flag rate — Google appears to correlate
+// page-load IP with RPC-IP — so we keep upstream active the whole pre-join
+// window. setDirectMode() flips it off post-admission.
 let useUpstream = true
 
 export async function startToggleProxy(sessionId: string): Promise<string | null> {
@@ -39,15 +63,15 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
         const target = request.url.includes("://")
           ? new URL(request.url).hostname
           : request.url.split(":")[0]
-        if (PROXY_BYPASS_HOSTS.has(target)) {
-          console.log(`[ToggleProxy] BYPASS  → ${target}`)
+        if (!shouldProxy(target)) {
+          console.log(`[ToggleProxy] DIRECT  → ${target} (not allowlisted)`)
           return {}
         }
         if (useUpstream) {
           console.log(`[ToggleProxy] PROXIED → ${target}`)
           return { upstreamProxyUrl: upstreamUrl }
         }
-        console.log(`[ToggleProxy] DIRECT  → ${target}`)
+        console.log(`[ToggleProxy] DIRECT  → ${target} (post-admission)`)
         return {}
       }
     })
@@ -56,11 +80,10 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
     const port = server.port
     const proxyUrl = `http://127.0.0.1:${port}`
     console.log(`[ToggleProxy] ✅ Started on ${proxyUrl}`)
-    // One-shot exit-IP probe so each bot's log includes the residential IP
-    // (and its ISP/country) it will use for the join. Goes through the local
-    // toggle proxy on purpose — same path Chrome takes, so the IP we observe
-    // here is what Google will see. Fails soft if the upstream is unreachable.
-    await logExitIp(proxyUrl)
+    // One-shot exit-IP probe. Goes straight to the residential upstream
+    // (bypasses our local toggle) so we always see the IP regardless of
+    // useUpstream state. Fails soft if the upstream is unreachable.
+    await logExitIp(upstreamUrl)
     return proxyUrl
   } catch (error) {
     console.error(
@@ -72,25 +95,25 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
 }
 
 /**
- * Probes the exit IP that the upstream residential proxy has assigned to this
- * bot's session and logs the result. Goes through the local toggle proxy — same
- * path Chrome takes, so the IP we observe is what Google will see. Bounded
- * to 5s so a slow/stuck residential link doesn't delay bot startup; fails
- * soft (log a warning, return) on any error.
+ * Probes the residential exit IP via the Decodo upstream and logs it
+ * (country/city/ISP/ASN). Talks to the upstream URL directly, NOT via our
+ * local toggle proxy — that way the probe works regardless of useUpstream
+ * state, and runs once at startup before we've decided whether to flip the
+ * toggle on. Bounded to 5s; fails soft on any error.
  */
-async function logExitIp(localProxyUrl: string): Promise<void> {
+async function logExitIp(upstreamProxyUrl: string): Promise<void> {
   try {
     // axios's `proxy` config doesn't tunnel HTTPS targets through an HTTP
-    // proxy via CONNECT — proxy-chain returns 400 for the resulting request.
-    // HttpsProxyAgent as `httpsAgent` (and `proxy: false` to disable axios's
-    // own proxy handling) issues CONNECT correctly.
+    // proxy via CONNECT correctly. HttpsProxyAgent as `httpsAgent` (with
+    // `proxy: false` to disable axios's own proxy handling) issues CONNECT
+    // properly.
     const res = await axios.get<{
       proxy?: { ip?: string }
       country?: { code?: string; name?: string }
       city?: { name?: string }
       isp?: { isp?: string; asn?: number }
     }>("https://ip.decodo.com/json", {
-      httpsAgent: new HttpsProxyAgent(localProxyUrl),
+      httpsAgent: new HttpsProxyAgent(upstreamProxyUrl),
       proxy: false,
       timeout: 5000
     })

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -1,3 +1,10 @@
+import axios from "axios"
+// https-proxy-agent v9 is ESM-only with the modern `exports` field; our
+// tsconfig sits on legacy moduleResolution: "node" so TS can't resolve the
+// types. Runtime works fine — only the d.ts lookup fails. Suppress until
+// the codebase moves to moduleResolution: "bundler" or "node16".
+// @ts-expect-error - see comment above; remove this once tsconfig moves on.
+import { HttpsProxyAgent } from "https-proxy-agent"
 import { Server } from "proxy-chain"
 import { envVars } from "../config/env-vars"
 
@@ -49,6 +56,11 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
     const port = server.port
     const proxyUrl = `http://127.0.0.1:${port}`
     console.log(`[ToggleProxy] ✅ Started on ${proxyUrl}`)
+    // One-shot exit-IP probe so each bot's log includes the residential IP
+    // (and its ISP/country) it will use for the join. Goes through the local
+    // toggle proxy on purpose — same path Chrome takes, so the IP we observe
+    // here is what Google will see. Fails soft if the upstream is unreachable.
+    await logExitIp(proxyUrl)
     return proxyUrl
   } catch (error) {
     console.error(
@@ -56,6 +68,40 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
     )
     server = null
     return null
+  }
+}
+
+/**
+ * Probes the exit IP that the upstream residential proxy has assigned to this
+ * bot's session and logs the result. Goes through the local toggle proxy — same
+ * path Chrome takes, so the IP we observe is what Google will see. Bounded
+ * to 5s so a slow/stuck residential link doesn't delay bot startup; fails
+ * soft (log a warning, return) on any error.
+ */
+async function logExitIp(localProxyUrl: string): Promise<void> {
+  try {
+    // axios's `proxy` config doesn't tunnel HTTPS targets through an HTTP
+    // proxy via CONNECT — proxy-chain returns 400 for the resulting request.
+    // HttpsProxyAgent as `httpsAgent` (and `proxy: false` to disable axios's
+    // own proxy handling) issues CONNECT correctly.
+    const res = await axios.get<{
+      proxy?: { ip?: string }
+      country?: { code?: string; name?: string }
+      city?: { name?: string }
+      isp?: { isp?: string; asn?: number }
+    }>("https://ip.decodo.com/json", {
+      httpsAgent: new HttpsProxyAgent(localProxyUrl),
+      proxy: false,
+      timeout: 5000
+    })
+    const d = res.data
+    const ip = d.proxy?.ip ?? "unknown"
+    const geo = `${d.country?.code ?? "?"}/${d.city?.name ?? "?"}`
+    const isp = `${d.isp?.isp ?? "?"} (AS${d.isp?.asn ?? "?"})`
+    console.log(`[ToggleProxy] 🌍 Exit IP: ${ip} | ${geo} | ${isp}`)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    console.warn(`[ToggleProxy] Could not verify exit IP: ${msg}`)
   }
 }
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -1,0 +1,79 @@
+import { Server } from "proxy-chain"
+import { envVars } from "../config/env-vars"
+
+// Chrome background services & static-asset CDNs that aren't needed for Meet
+// but consume disproportionate residential bandwidth. Always go direct, even
+// while the rest of the session is proxied. Exact hostname match — add hosts
+// here as Decodo dashboard reveals them.
+const PROXY_BYPASS_HOSTS = new Set([
+  "optimizationguide-pa.googleapis.com", // Chrome ML model downloads
+  "fonts.gstatic.com", // Google Fonts CDN
+  "gstatic.com", // Google static asset CDN
+  "play.google.com" // Chrome Play Store / extension chatter
+])
+
+let server: Server | null = null
+let useUpstream = true
+
+export async function startToggleProxy(sessionId: string): Promise<string | null> {
+  if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
+    console.log("[ToggleProxy] No RESIDENTIAL_PROXY_TEMPLATE configured, skipping proxy")
+    return null
+  }
+  // Decodo session labels must be alphanumeric; bot UUIDs have hyphens.
+  const session = sessionId.replace(/-/g, "")
+  const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
+
+  try {
+    server = new Server({
+      port: 0,
+      prepareRequestFunction: ({ request }) => {
+        // CONNECT requests use "host:port" format, not a full URL
+        const target = request.url.includes("://")
+          ? new URL(request.url).hostname
+          : request.url.split(":")[0]
+        if (PROXY_BYPASS_HOSTS.has(target)) {
+          console.log(`[ToggleProxy] BYPASS  → ${target}`)
+          return {}
+        }
+        if (useUpstream) {
+          console.log(`[ToggleProxy] PROXIED → ${target}`)
+          return { upstreamProxyUrl: upstreamUrl }
+        }
+        console.log(`[ToggleProxy] DIRECT  → ${target}`)
+        return {}
+      }
+    })
+
+    await server.listen()
+    const port = server.port
+    const proxyUrl = `http://127.0.0.1:${port}`
+    console.log(`[ToggleProxy] ✅ Started on ${proxyUrl}`)
+    return proxyUrl
+  } catch (error) {
+    console.error(
+      `[ToggleProxy] ❌ Failed to start, proceeding without proxy: ${error instanceof Error ? error.message : String(error)}`
+    )
+    server = null
+    return null
+  }
+}
+
+export function setDirectMode(): void {
+  useUpstream = false
+  console.log("[ToggleProxy] Switched to direct mode (no upstream proxy)")
+}
+
+export async function stopToggleProxy(): Promise<void> {
+  if (server) {
+    try {
+      await server.close(true)
+      console.log("[ToggleProxy] Server stopped")
+    } catch (error) {
+      console.warn(
+        `[ToggleProxy] Error stopping server: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+    server = null
+  }
+}

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -6,6 +6,7 @@ import axios from "axios"
 // @ts-expect-error - see comment above; remove this once tsconfig moves on.
 import { HttpsProxyAgent } from "https-proxy-agent"
 import { Server } from "proxy-chain"
+import type { ConnectionStats } from "proxy-chain"
 import { envVars } from "../config/env-vars"
 
 // Allowlist of hosts that route through the residential upstream. Everything
@@ -45,6 +46,60 @@ let server: Server | null = null
 // page-load IP with RPC-IP — so we keep upstream active the whole pre-join
 // window. setDirectMode() flips it off post-admission.
 let useUpstream = true
+let exitIp: string | null = null
+
+// Accumulated byte counts from closed connections, reset on each startToggleProxy call.
+// srcTx/srcRx = bytes between Chrome and local proxy; trgTx/trgRx = bytes between local
+// proxy and the upstream residential proxy (or target when in direct mode).
+const stats = {
+  srcTxBytes: 0,
+  srcRxBytes: 0,
+  trgTxBytes: 0,
+  trgRxBytes: 0,
+  connectionCount: 0
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+function logStats(label: string): void {
+  // Start with bytes from already-closed connections
+  let srcTx = stats.srcTxBytes
+  let srcRx = stats.srcRxBytes
+  let trgTx = stats.trgTxBytes
+  let trgRx = stats.trgRxBytes
+  let count = stats.connectionCount
+
+  // Add bytes from connections still open at log time — these are long-lived
+  // keep-alive/H2 tunnels that carry most of the traffic but haven't closed yet.
+  if (server) {
+    for (const id of server.getConnectionIds()) {
+      const cs = server.getConnectionStats(id)
+      if (cs) {
+        srcTx += cs.srcTxBytes
+        srcRx += cs.srcRxBytes
+        trgTx += cs.trgTxBytes ?? 0
+        trgRx += cs.trgRxBytes ?? 0
+        count++
+      }
+    }
+  }
+
+  const ipSuffix = exitIp ? ` | exit IP: ${exitIp}` : ""
+  console.log(
+    `[ToggleProxy] 📊 ${label} | ` +
+      `connections: ${count} | ` +
+      `client→proxy: ${formatBytes(srcTx)} | ` +
+      `proxy→client: ${formatBytes(srcRx)} | ` +
+      `proxy→target: ${formatBytes(trgTx)} | ` +
+      `target→proxy: ${formatBytes(trgRx)} | ` +
+      `total: ${formatBytes(srcTx + srcRx)}` +
+      ipSuffix
+  )
+}
 
 export async function startToggleProxy(sessionId: string): Promise<string | null> {
   if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
@@ -54,6 +109,14 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
   // Decodo session labels must be alphanumeric; bot UUIDs have hyphens.
   const session = sessionId.replace(/-/g, "")
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
+
+  // Reset stats and exit IP for this new session
+  stats.srcTxBytes = 0
+  stats.srcRxBytes = 0
+  stats.trgTxBytes = 0
+  stats.trgRxBytes = 0
+  stats.connectionCount = 0
+  exitIp = null
 
   try {
     server = new Server({
@@ -74,6 +137,18 @@ export async function startToggleProxy(sessionId: string): Promise<string | null
         console.log(`[ToggleProxy] DIRECT  → ${target} (post-admission)`)
         return {}
       }
+    })
+
+    // Accumulate per-connection byte counts as connections close.
+    // The local proxy server must stay running after joining (Chrome was launched
+    // with --proxy-server pointing here), but setDirectMode() stops routing through
+    // the upstream residential proxy — so stats at that point reflect residential usage.
+    server.on("connectionClosed", ({ stats: cs }: { connectionId: number; stats: ConnectionStats }) => {
+      stats.connectionCount++
+      stats.srcTxBytes += cs.srcTxBytes
+      stats.srcRxBytes += cs.srcRxBytes
+      stats.trgTxBytes += cs.trgTxBytes ?? 0
+      stats.trgRxBytes += cs.trgRxBytes ?? 0
     })
 
     await server.listen()
@@ -119,6 +194,7 @@ async function logExitIp(upstreamProxyUrl: string): Promise<void> {
     })
     const d = res.data
     const ip = d.proxy?.ip ?? "unknown"
+    exitIp = ip
     const geo = `${d.country?.code ?? "?"}/${d.city?.name ?? "?"}`
     const isp = `${d.isp?.isp ?? "?"} (AS${d.isp?.asn ?? "?"})`
     console.log(`[ToggleProxy] 🌍 Exit IP: ${ip} | ${geo} | ${isp}`)
@@ -130,6 +206,10 @@ async function logExitIp(upstreamProxyUrl: string): Promise<void> {
 
 export function setDirectMode(): void {
   useUpstream = false
+  // Log residential proxy usage at the moment we stop routing through the upstream.
+  // Connections that were still open at this point close shortly after, so the count
+  // here is a near-complete picture of residential bandwidth consumed during join.
+  logStats("Residential upstream disabled (join complete)")
   console.log("[ToggleProxy] Switched to direct mode (no upstream proxy)")
 }
 
@@ -137,6 +217,7 @@ export async function stopToggleProxy(): Promise<void> {
   if (server) {
     try {
       await server.close(true)
+      logStats("Final stats at proxy shutdown")
       console.log("[ToggleProxy] Server stopped")
     } catch (error) {
       console.warn(

--- a/src/state-machine/states/cleanup-state.ts
+++ b/src/state-machine/states/cleanup-state.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs"
 import { ChatManager } from "../../chat-manager"
 import { envVars } from "../../config/env-vars"
 import { SoundContext, VideoContext } from "../../media_context"
+import { stopToggleProxy } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { HtmlSnapshotService } from "../../services/html-snapshot-service"
 import { GLOBAL } from "../../singleton"
@@ -62,7 +63,14 @@ export class CleanupState extends BaseState {
         this.context.currentPauseStart = null
       }
 
-      // Step 0: Stop dialog observer (runs in Node, not in the page)
+      // Step 0a: Stop toggle proxy (no longer needed after meeting)
+      try {
+        await stopToggleProxy()
+      } catch (error) {
+        console.warn("🧹 Toggle proxy stop failed, continuing cleanup:", error)
+      }
+
+      // Step 0b: Stop dialog observer (runs in Node, not in the page)
       console.info("🧹 Step 0: Stopping dialog observer")
       try {
         this.stopDialogObserver()

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -9,6 +9,7 @@ import {
   warmUpCamera
 } from "../../branding"
 import { openBrowser } from "../../browser/browser"
+import { startToggleProxy } from "../../proxy/toggle-proxy"
 import { GLOBAL } from "../../singleton"
 import { formatError } from "../../utils/Logger"
 import { PathManager } from "../../utils/PathManager"
@@ -97,7 +98,21 @@ export class InitializationState extends BaseState {
         })
 
         // Execute the promise to open the browser with a timeout
-        const result = await Promise.race<BrowserResult>([openBrowser(), timeoutPromise])
+        // Start toggle proxy for residential IP routing during join phase (Google Meet only).
+        // Pass bot_uuid so the per-bot sticky session label is unique — different
+        // bots land on different residential IPs, same bot keeps one IP throughout
+        // the join.
+        if (!this.context.proxyUrl && GLOBAL.get().meeting_platform === "meet") {
+          const proxyUrl = await startToggleProxy(GLOBAL.get().bot_uuid)
+          if (proxyUrl) {
+            this.context.proxyUrl = proxyUrl
+          }
+        }
+
+        const result = await Promise.race<BrowserResult>([
+          openBrowser(this.context.proxyUrl),
+          timeoutPromise
+        ])
 
         // If we get here, openBrowser has succeeded
         this.context.browserContext = result.browser

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -1,5 +1,6 @@
 import { notifyJoinReady } from "../../branding"
 import { Events } from "../../events"
+import { setDirectMode } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { HtmlSnapshotService } from "../../services/html-snapshot-service"
 import { GLOBAL } from "../../singleton"
@@ -218,6 +219,7 @@ export class WaitingRoomState extends BaseState {
           () => {
             joinSuccessful = true
             console.log("Join successful notification received")
+            setDirectMode()
           },
           this.context.dialogObserver
         )

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -117,6 +117,9 @@ export interface MeetingContext {
 
   // Dialog observer
   dialogObserver?: SimpleDialogObserver
+
+  // Proxy
+  proxyUrl?: string
 }
 
 export interface StateTransition {


### PR DESCRIPTION
## Summary

Two pieces of Meet bot-detection infrastructure: a per-bot sticky **residential proxy** during the join phase, and a **real-time bot-detection telemetry** signal from Meet's own protobuf response. Together they let us route the pre-admission join through a residential IP and observe — without guessing — whether Google flagged us.

This is Phase 1 of the bot-detection work. Phase 2 (rebrowser, OS-level humanization, mouse trajectories, browser console bridge) is queued on a separate branch and will follow.

## What's in this PR

### 1. Residential proxy with per-bot sticky session
- New `src/proxy/toggle-proxy.ts` — local-loopback proxy via `proxy-chain`. Chrome launches with `--proxy-server=http://127.0.0.1:<port>` and the toggle decides per-request whether to forward to the residential upstream or go direct.
- `RESIDENTIAL_PROXY_TEMPLATE` env var holds the Decodo-style backconnect URL with a `{SESSION}` placeholder, substituted at runtime with `bot_uuid` (hyphens stripped, since Decodo session labels must be alphanumeric).
- Different bot UUIDs naturally pull different residential IPs from the pool. Same bot keeps the same IP throughout the join.
- `setDirectMode()` flips the toggle off the moment admission is confirmed (`waiting-room-state.ts`), so post-admission traffic goes direct and the meeting itself doesn't burn residential bandwidth.
- `stopToggleProxy()` on cleanup.
- Meet-only. Teams doesn't have the same dual-queue lobby.

### 2. Meet bot-detection signal via `page.on('response')`
- Reads the `detectedAsBot` varint (field 36) from the protobuf body of Meet's `CreateMeetingDevice` RPC response during the join handshake.
- Logs `[Meet] 🚨 Meet flagged this bot` or `[Meet] ✅ Meet did NOT flag this bot` per bot to `bot.log`. Detection only — does not change avoidance behaviour.
- Uses `page.on('response')` as a passive observer. We tried `page.route()` + `route.fetch()` first; that re-issues the request from Node's HTTP stack with a different JA3/JA4 fingerprint and consistently returned `detectedAsBot=2` (i.e. the observer was self-flagging us). `page.on('response')` reads from Playwright's already-buffered response body without touching the wire.
- Node-side decoder uses `protobufjs.Type` + `.Field` reflection; unknown fields are skipped automatically so we don't have to spell out the entire protobuf message.

### 3. Exit-IP telemetry at proxy startup
- One-shot probe to `https://ip.decodo.com/json` via the residential upstream at toggle-proxy startup. Logs a line per bot like:
  ```
  [ToggleProxy] 🌍 Exit IP: 24.135.31.134 | RS/Novi Sad | SBB (AS31042)
  ```
- Lets us correlate flag rate with specific networks/ISPs across preprod batches.
- 5s timeout so a slow residential link doesn't delay startup; fails soft (warns and returns) on any error.
- Uses `axios` + `HttpsProxyAgent` (via `https-proxy-agent@9.0.0`). axios's built-in `proxy` config doesn't CONNECT-tunnel HTTPS targets through an HTTP proxy correctly with `proxy-chain` (returns 400); `httpsAgent` + `proxy: false` is the standard fix.

### 4. Allowlist (not deny-list) for the toggle proxy
- Switched from "proxy everything except known-bypass hosts" to "proxy only known-allowlist hosts". Default-direct means future Google asset additions (CDNs, etc.) go direct automatically instead of silently burning residential bandwidth.
- Allowlist (suffix-matched, covers subdomains): `meet.google.com`, `accounts.google.com`, `apis.google.com`, `clients6.google.com`.
- Allowlist (exact, no subdomain spillover): `google.com`, `www.google.com`, `ip.decodo.com` (the probe target).
- Projected ~24% bandwidth reduction on the current preprod Decodo workload.

## What is NOT in this PR

Queued for Phase 2 (separate branch, will rebase off this once merged):
- `rebrowser-playwright` drop-in, removal of `--enable-logging=stderr` family flags in prod
- OS-level (X11) input via `xdotool` — `humanClick` / `humanType` / `humanKey` migrating the Meet pre-join interactions away from CDP
- 10-trajectory mouse motion engine + Unicode-safe (grapheme-cluster) typing
- Browser-side console bridge (rebrowser's CDP `Runtime.enable` patch suppresses `page.on("console")` — Phase 2 adds an `exposeFunction` bridge so we can see browser-side logs again)
- v4l2 webcam `cardLabel` hardening (deployment helm chart change)

## Failed / reverted experiments worth knowing

- **Lazy-enable** (let the Meet SPA load direct from the pod IP to save ~30 MB of residential bandwidth, then flip the proxy on right before the join handshake). Increased flag rate measurably — Google appears to correlate the page-load source IP with the RPC-issuing source IP. Reverted, with a comment in `toggle-proxy.ts` explaining why.
- **Decodo Residential** pool: every IP from `gate.decodo.com:7000` was getting flagged regardless of continent or sticky-session settings. Switched the preprod deployment to Decodo ISP (`isp.decodo.com:10000`) which has a smaller but cleaner pool. Env-side change, no code impact.

## Testing

- `pnpm build` passes.
- End-to-end smoke tests of `startToggleProxy` → exit-IP probe → `setDirectMode()` round-trip through real Decodo upstreams.
- Per-bot session stickiness verified via curls against `https://ip.decodo.com/json`: same session label returns the same IP, different session labels return different IPs concurrently.
- Preprod batches with the protobuf observer confirmed the signal fires correctly (`detectedAsBot=true`/`false` matches the visible "with potential threats" banner state on the host side).

## Test plan for reviewers

- [x] Verify `RESIDENTIAL_PROXY_TEMPLATE` env var picked up correctly in your preprod (configmap, not secret — see comment in `toggle-proxy.ts` if curious about why)
- [x] Run a small preprod batch; confirm `[ToggleProxy] ✅ Started on ...`, `[ToggleProxy] 🌍 Exit IP: ...`, and `[Meet] ✅`/`🚨` lines appear in bot.log
- [x] Confirm `[ToggleProxy] DIRECT  → <host> (not allowlisted)` appears for static CDNs (gstatic, gvt1, etc.) and `[ToggleProxy] PROXIED → meet.google.com` for the SPA + RPC traffic
- [x] No regression in Teams flow (Teams doesn't touch the toggle proxy)
