### PR TITLE
fix(meet): chat selector + streaming init for input-only bots

### DIFF
--- a/src/meeting/meet-state-config.ts
+++ b/src/meeting/meet-state-config.ts
@@ -55,6 +55,7 @@ export const MEET_STATE_CONFIG: StateDetectionConfig = {
       'nav button[aria-label="Show everyone"][role="button"]',
       'nav button[data-panel-id="1"][role="button"]',
       'button[aria-label="Chat with everyone"]',
+      'button[aria-label="Chat with everyone - New message"]',
       "[data-participant-id]",
       "[data-self-name]",
       "div[data-participant-id]"

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -33,12 +33,15 @@ export class WaitingRoomState extends BaseState {
       )
 
       // Initialize streaming service BEFORE opening meeting page
-      // so that Teams/Meet can detect it and enable audio capture
-      // Only initialize if streaming_output is configured (off by default)
-      if (GLOBAL.get().streaming_output) {
+      // so that Teams/Meet can detect it and enable audio capture.
+      // Output-only, input-only, and bidirectional streaming are all supported;
+      // input-only must still construct Streaming so the bot connects to input_url.
+      const streamingOut = GLOBAL.get().streaming_output
+      const streamingIn = GLOBAL.get().streaming_input
+      if (streamingOut || streamingIn) {
         this.context.streamingService = new Streaming(
-          GLOBAL.get().streaming_input,
-          GLOBAL.get().streaming_output,
+          streamingIn,
+          streamingOut,
           GLOBAL.get().streaming_audio_frequency,
           GLOBAL.get().bot_uuid
         )
@@ -47,8 +50,9 @@ export class WaitingRoomState extends BaseState {
       // Open the meeting page
       await this.openMeetingPage(meetingLink)
 
-      // Start audio capture after page is open (avoids capturing pre-join beep/silence)
-      if (this.context.streamingService) {
+      // Start Pulse → output WebSocket capture only when output streaming is enabled.
+      // Input-only bots still need Streaming (for input WebSocket) but must not run FFmpeg capture.
+      if (this.context.streamingService && GLOBAL.get().streaming_output) {
         this.context.streamingService.startAudioCapture()
       }
 


### PR DESCRIPTION
## Summary

Two independent fixes bundled in the same branch (one commit each).

### 1. Meet state detection: match new-message chat button variant

**Symptom:** Bots admitted into a Meet call where the chat already had unread messages stayed stuck in \`waitingRoom\` state, eventually hitting the 10-minute \`timeoutWaitingToStart\` even though they were fully in the meeting. Reproduced from \`bot-noota/pauline_case_full.txt\`: bot was admitted at 14:27:04 (4 participant tiles + Leave call button visible in DOM snapshot at 14:37:00), but \`Meeting presence indicators: 3/8 visible (threshold: 4, matched: false)\` repeated for the entire 10-minute window.

**Root cause:** \`meet-state-config.ts\` in-meeting pattern requires 4 of 8 selectors to match. Only 3 stable selectors actually match the current Google Meet UI:
- \`div[role="region"][aria-label="Call controls"]\`
- \`[data-participant-id]\`
- \`div[data-participant-id]\`

The intended 4th was \`button[aria-label="Chat with everyone"]\`, but the chat button's aria-label switches to \`Chat with everyone - New message\` the moment chat has any unread — and the exact-match selector then fails.

**Verification with successful prod bot \`de34556d-46fc-4250-9e87-ce01b85187b7\`:** That bot only escaped \`waitingRoom\` because one lucky polling cycle (14:08:10) caught the chat button while its aria-label was still the plain \`Chat with everyone\` (4/8 matched, including the chat selector). Seven seconds later the count dropped back to 3/8. Admission detection was effectively a coin-flip on chat unread state.

**Fix:** Add \`button[aria-label="Chat with everyone - New message"]\` as a second selector. Exactly one of the two chat variants matches at any moment, so admission detection becomes deterministic.

### 2. Waiting-room state: support input-only streaming bots

\`Streaming\` was only constructed when \`streaming_output\` was set, so input-only bots never connected to \`input_url\`. Now \`Streaming\` is constructed when either \`streaming_input\` or \`streaming_output\` is set, and \`startAudioCapture\` is independently gated on \`streaming_output\` so input-only bots don't run unnecessary Pulse → output capture.

## Test plan

- [ ] Deploy to preprod; trigger a Meet bot into a call where chat is already active (or have a participant send a chat message while the bot is in the lobby) — verify it transitions \`waitingRoom → inCall\` immediately on admit instead of timing out.
- [ ] Run an input-only streaming bot and confirm it connects to \`input_url\` (previously silently broken).
- [ ] Run an output-only streaming bot and confirm audio capture still starts.
- [ ] Run a non-streaming bot and confirm no streaming service is constructed (no regression).