### PR TITLE
Bugfix/toggle proxy timeout&in meeting indicator improvement

### DIFF
--- a/src/meeting/meet-state-config.ts
+++ b/src/meeting/meet-state-config.ts
@@ -56,9 +56,14 @@ export const MEET_STATE_CONFIG: StateDetectionConfig = {
       'nav button[data-panel-id="1"][role="button"]',
       'button[aria-label="Chat with everyone"]',
       'button[aria-label="Chat with everyone - New message"]',
-      "[data-participant-id]",
-      "[data-self-name]",
-      "div[data-participant-id]"
+      '[data-participant-id]',
+      '[data-self-name]',
+      'div[data-participant-id]',
+      'button[aria-label*="Raise hand"]',
+      'button[aria-label="Send a reaction"]',
+      'button[aria-label="Share screen"]',
+      'button[aria-label="Meeting details"]',
+      'button[aria-label="Meeting tools"]',
     ],
     threshold: 4, // Increased from 3 to 4 to require chat button (prevents false positives in waiting room)
     checkVisibility: true // Check DOM presence only, not visibility - helps with fast admissions

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -97,13 +97,14 @@ function logStats(label: string): void {
   )
 }
 
-export async function startToggleProxy(sessionId: string): Promise<string | null> {
+export async function startToggleProxy(sessionId: string, retryCount = 0): Promise<string | null> {
   if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
     console.log("[ToggleProxy] No RESIDENTIAL_PROXY_TEMPLATE configured, skipping proxy")
     return null
   }
   // Decodo session labels must be alphanumeric; bot UUIDs have hyphens.
-  const session = sessionId.replace(/-/g, "")
+  // Append retry count so each SQS retry lands on a different residential IP.
+  const session = `${sessionId.replace(/-/g, "")}${retryCount}`
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
 
   // Reset stats, proxied-connection tracking, and exit IP for this new session

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -151,7 +151,7 @@ export async function startToggleProxy(sessionId: string, retryCount = 0): Promi
     await server.listen()
     const port = server.port
     const proxyUrl = `http://127.0.0.1:${port}`
-    console.log(`[ToggleProxy] ✅ Started on ${proxyUrl}`)
+    console.log(`[ToggleProxy] ✅ Started on ${proxyUrl} (attempt ${retryCount + 1})`)
     // Verify the upstream is reachable. If not (wrong credentials, server
     // down, etc.), tear down and let the bot run direct.
     const upstreamOk = await logExitIp(upstreamUrl)

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -10,6 +10,7 @@ import {
 } from "../../branding"
 import { openBrowser } from "../../browser/browser"
 import { startToggleProxy } from "../../proxy/toggle-proxy"
+import { MAX_RETRY_COUNT } from "../../utils/retry-handler"
 import { GLOBAL } from "../../singleton"
 import { formatError } from "../../utils/Logger"
 import { PathManager } from "../../utils/PathManager"
@@ -103,9 +104,14 @@ export class InitializationState extends BaseState {
         // bots land on different residential IPs, same bot keeps one IP throughout
         // the join.
         if (!this.context.proxyUrl && GLOBAL.get().meeting_platform === "meet") {
-          const proxyUrl = await startToggleProxy(GLOBAL.get().bot_uuid)
-          if (proxyUrl) {
-            this.context.proxyUrl = proxyUrl
+          const retryCount = GLOBAL.getRetryCount()
+          if (retryCount >= MAX_RETRY_COUNT) {
+            console.log("[InitializationState] Last retry attempt — running without proxy")
+          } else {
+            const proxyUrl = await startToggleProxy(GLOBAL.get().bot_uuid, retryCount)
+            if (proxyUrl) {
+              this.context.proxyUrl = proxyUrl
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
Fix proxy session reuse across SQS retries for Google Meet bots. When a bot failed and was requeued, the same bot_uuid was used as the Decodo session label every time, pinning all retries to the same residential IP that had already timed. 

Two changes:
- startToggleProxy now accepts a retryCount parameter and appends it to the session label (uuid0, uuid1, …), so each retry lands on a fresh residential IP.

- On the final retry attempt (retry_count >= MAX_RETRY_COUNT), the proxy is skipped entirely and the bot runs direct — since the issue is sometimes the proxy itself causing Meet to time out, not the IP.

## Testing
- Verify retry 0 and retry 1 log different exit IPs via the [ToggleProxy] 🌍 Exit IP: line.
- Verify retry 2 logs [ToggleProxy] Last retry attempt — running without proxy and no [ToggleProxy] output follows.
- Confirm RESIDENTIAL_PROXY_TEMPLATE unset still results in no proxy (existing behavior unchanged).


## Release Notes
- Internal only. 
- Improves bot join reliability for Google Meet: repeated failures due to a blocked or timing-out residential IP will now rotate to a fresh IP on each retry, and the final retry attempt bypasses the proxy altogether as a last resort.