### PR TITLE
fix(teams+meet): LoginRequired reclassification + fail-fast on denial page

### DIFF
--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -184,6 +184,14 @@ export class MeetProvider implements MeetingProviderInterface {
       // Bail out early if page already navigated away (e.g. denial during timing wait)
       assertOnMeetPage(page)
 
+      // Fail-fast: if Meet has already rendered a denial page ("You can't join
+      // this video call", anti-bot block, etc.) before we touch any UI, skip
+      // the 10-attempt typeBotName loop. notAcceptedInMeeting() sets the
+      // appropriate end-reason (and retry flag for the anti-bot text) internally.
+      if (await notAcceptedInMeeting(page)) {
+        throw new Error("Bot not accepted into meeting - denied at page load")
+      }
+
       await clickDismiss(page)
       await sleep(300)
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -209,7 +209,27 @@ export class ScreenRecorder extends EventEmitter {
       // No end_reason yet — unexpected. Set StreamingSetupFailed so the bot still
       // reports a failure (rather than ending up as UNKNOWN_ERROR).
       const errorMessage = error instanceof Error ? error.message : String(error)
-      GLOBAL.setError(MeetingEndReason.StreamingSetupFailed, errorMessage)
+
+      // Teams-specific: "Execution context was destroyed" during sync-signal /
+      // recording setup almost always means Teams redirected the page to a
+      // login/auth flow mid-page.evaluate. Reclassify as LoginRequired and
+      // mark retryable — if it was a transient nav, the retry recovers; if
+      // login really is required, the retry hits the same wall and we end
+      // up with the correct terminal status either way.
+      const isTeamsNavigationDestroyedV8 =
+        GLOBAL.get().meeting_platform === "teams" &&
+        error instanceof Error &&
+        error.message.includes("Execution context was destroyed")
+
+      if (isTeamsNavigationDestroyedV8) {
+        console.log(
+          "🔄 Teams sync-signal context destruction — reclassifying as LoginRequired and marking for retry"
+        )
+        GLOBAL.setError(MeetingEndReason.LoginRequired, errorMessage)
+        GLOBAL.setShouldRetry(true)
+      } else {
+        GLOBAL.setError(MeetingEndReason.StreamingSetupFailed, errorMessage)
+      }
       this.emit("error", { type: "startError", error })
     }
   }


### PR DESCRIPTION
## Summary

Two narrowly-scoped bot reliability fixes, both rooted in prod evidence from stuck bots in the last 30 days.

### 1. `fix(teams)`: reclassify sync-signal context-destroyed crash as LoginRequired (c7dad13b)

Teams sometimes redirects the meeting page to a login/auth flow mid-\`page.evaluate\` (verification modal, tenant-blocked anonymous join, expired meeting, etc.). The V8 execution context is destroyed and the failure surfaces as a generic \`Execution context was destroyed, most likely because of a navigation\` thrown from \`generateSyncSignal\` during \`ScreenRecorder.startRecording\`. The catch block has been labelling this as \`StreamingSetupFailed\`, which is the symptom code, not the underlying cause.

Now: when the platform is \`teams\` AND the error message contains \`Execution context was destroyed\`, reclassify to \`LoginRequired\` and mark retryable.

- If the navigation was transient (network blip, page reload race), the retry recovers and the bot joins normally.
- If login really is required, the retry hits the same wall and the bot ends in \`LOGIN_REQUIRED\` — the correct terminal status either way.

Heuristic kept narrow: \`StreamingSetupFailed\` preserved for everything else (audio device timeouts, FFmpeg setup, Meet-side crashes).

**Prod evidence:** 4 stuck bots over the last 30 days hit this exact signature and ended up trapped at \`resolved_status=in_waiting_room\` because the process exited code 1 before the terminal \`bot_failed\` event could be sent:
- \`aee3414b-5a01-47cf-94c7-9aebb077b64d\` — 2026-05-26
- \`ab4d9b0f-f1e3-41d3-99f2-f048e4d451a9\` — 2026-05-15
- \`d788548a-dade-4e76-bace-574ae83819cc\` — 2026-05-15
- \`084390f6-f989-4ce8-8af3-852725ccd63c\` — 2026-05-15

### 2. `fix(meet)`: fail-fast on denial page rendered before any UI interaction (c37aad06)

The post-\`typeBotName\` loop already calls \`notAcceptedInMeeting()\` to catch Meet denial pages mid-join, but if Meet rendered the denial (\"You can't join this video call\", anti-bot block, etc.) *before* we touched any UI, we'd still burn the full 10-attempt \`typeBotName\` retry loop against a page with no name input — adding ~30s of pure latency to a bot already rejected at page load.

Add the same \`notAcceptedInMeeting()\` check right after the existing \`assertOnMeetPage()\` at the top of \`joinMeeting\`, before \`clickDismiss\` and the \`typeBotName\` loop.

Pure latency win: bots that were going to fail anyway now fail in <1s instead of ~30s, freeing the pod sooner and getting the SQS retry started faster for retryable denials.

This pattern originally lived on the \`wip/google-meet-bot-detection-proxy-poc\` branch (commit \`76e80d56\`) but didn't come over with PR #159, which brought across the rest of the proxy + detection-signal work.

## Test plan

- [x] Re-run a known-LOGIN_REQUIRED-failing Teams meeting in preprod; confirm \`resolved_status\` ends at \`LOGIN_REQUIRED\` (not stuck at \`in_waiting_room\`)
- [x] Confirm SQS retry actually fires (attempt 2/3 visible in logs)
- [x] Verify a healthy Teams join still works end-to-end (no false-positive reclassification)
- [x] Run a Meet bot against a meeting that denies anonymous join; confirm fail-fast path triggers (~1s exit instead of ~30s)
- [x] Verify a healthy Meet join still works end-to-end