### PR TITLE
feat(meet): align browser timezone with exit-IP geo (locale stays English)

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -2,6 +2,17 @@ import { type BrowserContext, chromium } from "@playwright/test"
 import { envVars } from "../config/env-vars"
 import { GLOBAL } from "../singleton"
 import { formatError } from "../utils/Logger"
+import { getExitGeo } from "../proxy/toggle-proxy"
+
+// Map the exit IP's country (from the residential-proxy probe) to a browser
+// locale, so locale/Accept-Language match the proxied egress geo instead of a
+// hardcoded en-US. Timezone comes straight from the probe. Unmapped → en-US.
+const COUNTRY_LOCALE: Record<string, string> = {
+  US: "en-US", GB: "en-GB", IE: "en-IE", CA: "en-CA", AU: "en-AU",
+  FR: "fr-FR", DE: "de-DE", ES: "es-ES", IT: "it-IT", NL: "nl-NL",
+  PL: "pl-PL", PT: "pt-PT", BR: "pt-BR", SE: "sv-SE", NO: "nb-NO",
+  DK: "da-DK", FI: "fi-FI", BE: "fr-BE", CH: "de-CH", AT: "de-AT",
+}
 
 export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: BrowserContext }> {
   // Resolution configuration from environment variable
@@ -13,6 +24,16 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
   const windowWidth = width
   const windowHeight = resolution === "1080" ? 1220 : 860
 
+  // Align locale + timezone with the residential exit IP's geo (set by the
+  // proxy probe). Falls back to en-US / browser-default tz when unknown.
+  const geo = getExitGeo()
+  const locale = COUNTRY_LOCALE[geo?.country ?? ""] ?? "en-US"
+  const lang = locale.split("-")[0]
+  const timezoneId = geo?.timezone ?? undefined
+  if (geo?.country || geo?.timezone) {
+    console.log(`[Browser] Geo from exit IP: country=${geo?.country ?? "?"} tz=${geo?.timezone ?? "?"} → locale=${locale}`)
+  }
+
   const sharedArgs = [
     // Window size and position - must match Xvfb display exactly
     `--window-size=${windowWidth},${windowHeight}`,
@@ -21,8 +42,8 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
     // Security configurations
     "--no-sandbox",
     "--disable-setuid-sandbox",
-    "--lang=en-US", // Force English language with region code
-    "--accept-lang=en-US,en", // Accept English for HTTP requests
+    `--lang=${locale}`, // align UI language with exit-IP geo
+    `--accept-lang=${locale},${lang}`, // align Accept-Language with exit-IP geo
 
     // ========================================
     // AUDIO CONFIGURATION FOR PULSEAUDIO
@@ -101,7 +122,8 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
         userDataDir: "",
         headless: false,
         viewport: { width, height },
-        locale: "en-US",
+        locale,
+        ...(timezoneId ? { timezoneId } : {}),
         humanize: true,
         ...(proxyUrl ? { proxy: proxyUrl } : {}),
         args: [
@@ -139,7 +161,8 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
       headless: false,
       viewport: { width, height },
       executablePath: chromePath,
-      locale: "en-US", // Set locale for Playwright context
+      locale, // align with exit-IP geo
+      ...(timezoneId ? { timezoneId } : {}),
       args: sharedArgs,
       permissions: ["microphone", "camera"],
       ignoreHTTPSErrors: true,

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -4,16 +4,6 @@ import { GLOBAL } from "../singleton"
 import { formatError } from "../utils/Logger"
 import { getExitGeo } from "../proxy/toggle-proxy"
 
-// Map the exit IP's country (from the residential-proxy probe) to a browser
-// locale, so locale/Accept-Language match the proxied egress geo instead of a
-// hardcoded en-US. Timezone comes straight from the probe. Unmapped → en-US.
-const COUNTRY_LOCALE: Record<string, string> = {
-  US: "en-US", GB: "en-GB", IE: "en-IE", CA: "en-CA", AU: "en-AU",
-  FR: "fr-FR", DE: "de-DE", ES: "es-ES", IT: "it-IT", NL: "nl-NL",
-  PL: "pl-PL", PT: "pt-PT", BR: "pt-BR", SE: "sv-SE", NO: "nb-NO",
-  DK: "da-DK", FI: "fi-FI", BE: "fr-BE", CH: "de-CH", AT: "de-AT",
-}
-
 export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: BrowserContext }> {
   // Resolution configuration from environment variable
   // Defaults to 720p if RESOLUTION is not set or invalid
@@ -24,15 +14,13 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
   const windowWidth = width
   const windowHeight = resolution === "1080" ? 1220 : 860
 
-  // Align locale + timezone with the residential exit IP's geo (set by the
-  // proxy probe). Falls back to en-US / browser-default tz when unknown.
-  const geo = getExitGeo()
-  const locale = COUNTRY_LOCALE[geo?.country ?? ""] ?? "en-US"
-  const lang = locale.split("-")[0]
-  const timezoneId = geo?.timezone ?? undefined
-  if (geo?.country || geo?.timezone) {
-    console.log(`[Browser] Geo from exit IP: country=${geo?.country ?? "?"} tz=${geo?.timezone ?? "?"} → locale=${locale}`)
-  }
+  // Align ONLY the timezone with the residential exit IP's geo. Locale and
+  // Accept-Language stay en-US on purpose: the Meet/Teams join + UI-cleaning
+  // logic matches English UI strings ("Ask to join", "Continue without audio",
+  // "Turn off camera", …), so a non-English UI would break those selectors. A
+  // UTC clock on a non-UTC egress IP is the stronger bot tell anyway.
+  const timezoneId = getExitGeo()?.timezone ?? undefined
+  if (timezoneId) console.log(`[Browser] Aligning timezone with exit IP: ${timezoneId}`)
 
   const sharedArgs = [
     // Window size and position - must match Xvfb display exactly
@@ -42,8 +30,8 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
     // Security configurations
     "--no-sandbox",
     "--disable-setuid-sandbox",
-    `--lang=${locale}`, // align UI language with exit-IP geo
-    `--accept-lang=${locale},${lang}`, // align Accept-Language with exit-IP geo
+    "--lang=en-US", // English UI — the bot matches English selectors (do not localize)
+    "--accept-lang=en-US,en",
 
     // ========================================
     // AUDIO CONFIGURATION FOR PULSEAUDIO
@@ -122,7 +110,7 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
         userDataDir: "",
         headless: false,
         viewport: { width, height },
-        locale,
+        locale: "en-US",
         ...(timezoneId ? { timezoneId } : {}),
         humanize: true,
         ...(proxyUrl ? { proxy: proxyUrl } : {}),
@@ -161,7 +149,7 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
       headless: false,
       viewport: { width, height },
       executablePath: chromePath,
-      locale, // align with exit-IP geo
+      locale: "en-US", // English UI — the bot matches English selectors (do not localize)
       ...(timezoneId ? { timezoneId } : {}),
       args: sharedArgs,
       permissions: ["microphone", "camera"],

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -47,6 +47,15 @@ let server: Server | null = null
 // window. setDirectMode() flips it off post-admission.
 let useUpstream = true
 let exitIp: string | null = null
+// Country code + IANA timezone of the current exit IP (set by logExitIp), so the
+// browser can align its locale/timezone with the proxied egress geo instead of a
+// hardcoded en-US/UTC. Null until the exit-IP probe runs.
+let exitGeo: { country: string | null; timezone: string | null } | null = null
+
+/** Country code + IANA timezone of the current exit IP, or null until probed. */
+export function getExitGeo(): { country: string | null; timezone: string | null } | null {
+  return exitGeo
+}
 
 // Set of connectionIds that were routed through the residential upstream.
 // Used to filter stats so only Decodo-billed traffic is counted.
@@ -113,6 +122,7 @@ export async function startToggleProxy(sessionId: string, retryCount = 0): Promi
   stats.connectionCount = 0
   proxiedConnectionIds.clear()
   exitIp = null
+  exitGeo = null
 
   try {
     server = new Server({
@@ -186,7 +196,7 @@ async function logExitIp(upstreamProxyUrl: string): Promise<boolean> {
     const res = await axios.get<{
       proxy?: { ip?: string }
       country?: { code?: string; name?: string }
-      city?: { name?: string }
+      city?: { name?: string; time_zone?: string }
       isp?: { isp?: string; asn?: number }
     }>("https://ip.decodo.com/json", {
       httpsAgent: new HttpsProxyAgent(upstreamProxyUrl),
@@ -196,6 +206,7 @@ async function logExitIp(upstreamProxyUrl: string): Promise<boolean> {
     const d = res.data
     const ip = d.proxy?.ip ?? "unknown"
     exitIp = ip
+    exitGeo = { country: d.country?.code ?? null, timezone: d.city?.time_zone ?? null }
     const geo = `${d.country?.code ?? "?"}/${d.city?.name ?? "?"}`
     const isp = `${d.isp?.isp ?? "?"} (AS${d.isp?.asn ?? "?"})`
     console.log(`[ToggleProxy] 🌍 Exit IP: ${ip} | ${geo} | ${isp}`)


### PR DESCRIPTION
## What
Set the browser's `timezoneId` from the **residential exit IP's geo** so the clock matches the egress region, instead of running a UTC container clock behind a non-UTC IP (a common bot tell).

## Why timezone only (not locale)
Originally this also localized `locale`/`Accept-Language` to the exit-IP country — **dropped**, because the Meet/Teams join + UI-cleaning logic matches **~40 English UI strings** (`"Ask to join"`, `"Continue without audio"`, `"Turn off camera"`, `"Use without an account"`, …). A non-English UI would break every one of those selectors. So **`locale`/`Accept-Language` stay `en-US`** (English UI), and only the timezone — which doesn't affect UI language — follows the IP. The UTC-clock-on-foreign-IP mismatch is the stronger signal anyway.

## How (minimal)
- `toggle-proxy.ts`: the existing `logExitIp()` probe already reads `ip.decodo.com/json`; capture `city.time_zone` (IANA, e.g. `Europe/Madrid`) into `exitGeo`, expose **`getExitGeo()`**.
- `browser.ts`: `const timezoneId = getExitGeo()?.timezone`; apply to both the CloakBrowser (Meet) and Chrome (Teams) launches. Fallback: browser-default tz when geo unknown / proxy off → no change.

Based on the v2 prod bot line (`v2-improvements`), which runs the exit-IP probe in prod. Worth A/B'ing against the `detectedAsBot` signal.