### PR TITLE
chore(deps): bump @playwright/test from 1.53.0 to 1.55.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@aws-sdk/client-s3": "^3.873.0",
         "@aws-sdk/client-sqs": "^3.873.0",
         "@aws-sdk/lib-storage": "^3.873.0",
-        "@playwright/test": "^1.53.0",
+        "@playwright/test": "^1.55.1",
         "async": "^3.2.6",
         "axios": "^1.13.5",
         "axios-retry": "^4.5.0",
@@ -83,27 +83,7 @@
         "url": "https://github.com/yourusername/meet-teams-bot/issues"
     },
     "homepage": "https://github.com/yourusername/meet-teams-bot#readme",
-    "pnpm": {
-        "overrides": {
-            "minimatch@<3.1.4": ">=3.1.4",
-            "minimatch@>=5.0.0 <5.1.8": ">=5.1.8",
-            "minimatch@>=7.0.0 <7.4.8": ">=7.4.8",
-            "minimatch@>=9.0.0 <9.0.7": ">=9.0.7",
-            "qs@<6.14.2": ">=6.14.2",
-            "fast-xml-parser@>=5.0.0 <5.3.8": ">=5.3.8",
-            "simple-git@>=3.15.0 <3.32.3": ">=3.32.3",
-            "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
-            "js-yaml@<3.14.2": ">=3.14.2",
-            "lodash@<=4.17.22": ">=4.17.23",
-            "cookie@<0.7.0": ">=0.7.0",
-            "send@<0.19.0": ">=0.19.0",
-            "serve-static@<1.16.0": ">=1.16.0",
-            "path-to-regexp@<0.1.12": ">=0.1.12",
-            "body-parser@<1.20.3": ">=1.20.3",
-            "@smithy/config-resolver@<4.4.0": ">=4.4.0"
-        }
-    },
-    "volta": {
+  "volta": {
         "node": "20.18.0"
     }
 }


### PR DESCRIPTION
Resolves high-severity Dependabot alert for Playwright.

- Bump `@playwright/test` from `^1.53.0` to `^1.55.1`
- Remove dead pnpm overrides from package.json (moved to monorepo root)

Part of the monorepo-wide vulnerability resolution (see Meeting-BaaS/meeting-baas-v2#124).