### PR TITLE
fix(in-call): make HTML cleanup + speaker observation non-fatal/non-blocking

### DIFF
--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -86,39 +86,36 @@ export class InCallState extends BaseState {
       throw new Error("Playwright page not initialized")
     }
 
-    try {
-      console.log("Setting up browser components with integrated HTML cleanup...")
+    console.log("Setting up browser components with integrated HTML cleanup...")
 
-      // fix: Set meeting start time BEFORE starting speakers observation
-      // This prevents race condition where speakers are detected before startTime is set
-      const startTime = Date.now()
-      this.context.startTime = startTime
-      ScreenRecorderManager.getInstance().setMeetingStartTime(startTime)
-      console.log(`Meeting start time set to: ${startTime} (${new Date(startTime).toISOString()})`)
+    // Essential + synchronous: set the meeting start time BEFORE speakers observation
+    // starts (prevents a race where speakers are detected before startTime is set).
+    const startTime = Date.now()
+    this.context.startTime = startTime
+    ScreenRecorderManager.getInstance().setMeetingStartTime(startTime)
+    console.log(`Meeting start time set to: ${startTime} (${new Date(startTime).toISOString()})`)
 
-      // Start HTML cleanup first to clean the interface
-      await this.startHtmlCleaning()
-    } catch (error) {
-      console.error(
-        "Error in setupBrowserComponents:",
-        formatError(error, {
-          hasPlaywrightPage: !!this.context.playwrightPage,
-          recordingMode: GLOBAL.get().recording_mode,
-          meetingPlatform: GLOBAL.get().meeting_platform,
-          botName: GLOBAL.get().bot_name
-        })
+    // HTML cleanup (cosmetic) and speakers observation (diarization — independent of
+    // the recording) are NON-ESSENTIAL to capturing audio/video, so run them OFF the
+    // setup critical path: never await them, and never let them fail or hang setup.
+    //
+    // Previously startHtmlCleaning() was awaited and re-threw (fatal), and
+    // startSpeakersObservation() was awaited. A broken/unresponsive meeting page
+    // (e.g. a Teams Trusted-Types / ChunkLoader crash that hangs page.evaluate) would
+    // then either abort the recording or trip SETUP_TIMEOUT, making the bot exit ~30s
+    // after joining even though the recording was fine. Kick them off non-blocking and
+    // non-fatal so the bot still transitions to Recording and RecordingState's
+    // leave-conditions (silence/no-one/etc.) decide when to leave. (chat + audio
+    // verification below are already fire-and-forget for the same reason.)
+    void this.startHtmlCleaning()
+      .catch((error) =>
+        console.error("HTML cleanup failed (non-fatal, continuing):", formatError(error))
       )
-      throw new Error(`Browser component setup failed: ${error as Error}`)
-    }
-
-    // Start speakers observation in all cases
-    // Speakers observation is independent of video recording
-    try {
-      await this.startSpeakersObservation()
-    } catch (error) {
-      console.error("Failed to start speakers observation:", formatError(error))
-      // Continue even if speakers observation fails
-    }
+      .then(() =>
+        this.startSpeakersObservation().catch((error) =>
+          console.error("Speakers observation failed (non-fatal, continuing):", formatError(error))
+        )
+      )
 
     // Start chat observation + entry message (non-critical, non-blocking)
     // Chat panel opening on Teams can take up to 25s of retries — must not block SETUP_TIMEOUT.


### PR DESCRIPTION
## Problem
A broken/unresponsive meeting page during in-call setup can abort the **entire** recording. In `setupBrowserComponents()`:
- `await this.startHtmlCleaning()` re-throws on failure → **fatal**, and
- `await this.startSpeakersObservation()` is awaited → can **hang** if `page.evaluate`/`exposeFunction` never returns on a dead SPA.

Observed on a Teams bot: the Teams web client crashed mid-setup (`TrustedTypeError: DUPLICATE_POLICY_FOUND` / `coreSecurityService already defined` / `ChunkLoader` → page unresponsive). The speaker-observer `page.evaluate` hung, the **30s `SETUP_TIMEOUT` fired**, the bot went `error → cleanup` and **left ~30s after joining** — discarding an otherwise-fine recording (it had already captured audio/video; only ~35s of in-meeting footage survived the trim, then was marked `recording_failed`).

## Fix
HTML cleanup is **cosmetic** and speaker observation is **independent of the recording**, so move both **off the setup critical path** — kick them off **non-blocking and non-fatal** (exactly like chat observation + audio verification already are). Only `meetingStartTime` stays synchronous (it must precede observation).

Net: a broken/slow meeting page now costs at most live diarization + UI cleanup, but the bot still transitions to **Recording** and lets `RecordingState`'s leave-conditions (silence / no-one / etc.) decide when to leave — instead of self-exiting over a cosmetic setup step and dropping the recording.

One file: `src/state-machine/states/in-call-state.ts`. Typechecks clean.

## Rollout
Submodule PR (→ `v2-improvements`) first; monorepo submodule-bump PR (→ `preprod` → `staging` → `main`) to follow.

## Follow-ups (not in this PR)
- Salvage the already-captured recording on a setup-stage failure (don't `recording_failed` when audio/video exists).
- Time-box the Teams observer `page.evaluate`/`exposeFunction` calls so they fail fast rather than hang.
- Investigate the Teams Trusted-Types/ChunkLoader trigger (whether our injection causes it).