### PR TITLE
fix: make ffprobe duration/keyframe probing non-fatal in finalization

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1612,13 +1612,26 @@ file '${absoluteInputPath}'`
       "csv=p=0",
       videoPath
     ]
-    const result = await this.runFFprobe(args)
-    return result
-      .trim()
-      .split("\n")
-      .map((s) => Number.parseFloat(s))
-      .filter((n) => Number.isFinite(n))
-      .sort((a, b) => a - b)
+    try {
+      const result = await this.runFFprobe(args)
+      return result
+        .trim()
+        .split("\n")
+        .map((s) => Number.parseFloat(s))
+        .filter((n) => Number.isFinite(n))
+        .sort((a, b) => a - b)
+    } catch (error) {
+      // Non-fatal: keyframe probing only refines pause-window cut points. If it
+      // fails (probe timeout / killed process), return no keyframes — the caller
+      // (snapPauseWindowsToKeyframes) already skips snapping on an empty result,
+      // so pause trimming proceeds with unsnapped timestamps rather than failing
+      // the whole recording during finalization.
+      console.warn(
+        `⚠️ getKeyframePositions failed for ${videoPath} (${formatError(error)}). ` +
+          "Continuing without keyframe snapping (non-fatal).",
+      )
+      return []
+    }
   }
 
   /**
@@ -2038,8 +2051,23 @@ file '${absoluteInputPath}'`
     }
 
     const args = ["-v", "quiet", "-show_entries", "format=duration", "-of", "csv=p=0", filePath]
-    const result = await this.runFFprobe(args, fileSizeMB)
-    return Number.parseFloat(result.trim())
+    try {
+      const result = await this.runFFprobe(args, fileSizeMB)
+      const duration = Number.parseFloat(result.trim())
+      if (Number.isFinite(duration) && duration > 0) return duration
+    } catch (error) {
+      console.warn(`⚠️ getDuration ffprobe failed for ${filePath}: ${formatError(error)}`)
+    }
+
+    // Non-fatal: ffprobe duration probing is best-effort (originally added only to
+    // chunk long audio for Gladia's max-duration limit). A slow probe on a multi-GB
+    // file must never discard an otherwise-complete recording during finalization.
+    // Fall back to the wall-clock recording span — an UPPER bound on real content,
+    // so any downstream `-t` trim clamps to end-of-file instead of truncating footage.
+    const fallback =
+      this.recordingStartTime > 0 ? (Date.now() - this.recordingStartTime) / 1000 : 24 * 60 * 60
+    console.warn(`⚠️ Using wall-clock duration fallback ${fallback.toFixed(1)}s (non-fatal)`)
+    return fallback
   }
 
   private async cleanupTempFiles(): Promise<void> {

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1627,8 +1627,8 @@ file '${absoluteInputPath}'`
       // so pause trimming proceeds with unsnapped timestamps rather than failing
       // the whole recording during finalization.
       console.warn(
-        `⚠️ getKeyframePositions failed for ${videoPath} (${formatError(error)}). ` +
-          "Continuing without keyframe snapping (non-fatal).",
+        `⚠️ getKeyframePositions failed for ${videoPath}; continuing without keyframe snapping (non-fatal):`,
+        formatError(error),
       )
       return []
     }
@@ -2056,7 +2056,7 @@ file '${absoluteInputPath}'`
       const duration = Number.parseFloat(result.trim())
       if (Number.isFinite(duration) && duration > 0) return duration
     } catch (error) {
-      console.warn(`⚠️ getDuration ffprobe failed for ${filePath}: ${formatError(error)}`)
+      console.warn(`⚠️ getDuration ffprobe failed for ${filePath}:`, formatError(error))
     }
 
     // Non-fatal: ffprobe duration probing is best-effort (originally added only to


### PR DESCRIPTION
## Problem

A slow `ffprobe` call during recording finalization could exceed its timeout, throw, and propagate out of `handleSuccessfulRecording` — **discarding a fully-captured recording** and mislabelling it as a streaming failure (`streamingSetupFailed`).

This hit **Fairway** (Google Meet bot, ~1h40m recording): streaming ran cleanly the whole meeting, the meeting recorded fine (~131 MB raw, merge + trim succeeded, duration computed as `5378s`), and then a late `ffprobe getDuration` timed out (30s) probing the ~1 GB merged output → the entire recording was lost during post-processing.

The duration probe only exists to **chunk long audio under Gladia's max-duration limit** — and Fairway doesn't use Gladia transcription at all, so the probe is unnecessary for them and should never be fatal.

## Fix

Make both `ffprobe`-backed helpers non-fatal (single chokepoint each):

- **`getDuration`** — on probe failure/timeout or a non-finite result, fall back to the wall-clock recording span instead of throwing. Wall-clock is an *upper bound* on real content, so any downstream `-t` trim clamps to end-of-file rather than truncating footage.
- **`getKeyframePositions`** — on probe failure, return no keyframes; the caller (`snapPauseWindowsToKeyframes`) already skips pause-window snapping on an empty result.

The recording is now preserved and uploaded even when `ffprobe` is unavailable or too slow.

## Notes

- Covers both the *pre-trim* duration probe (feeds `finalTrimFromOffset`) and the *post-trim* probes (`createAudioChunks` / `trimPauseWindows`) — an upload-boundary catch alone would miss the pre-trim case (no output file to upload yet).
- Diff is ~25 lines, no behavioural change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)