### PR TITLE
Fix/grace period blocks participant detection

### DIFF
--- a/src/state-machine/states/recording-state.test.ts
+++ b/src/state-machine/states/recording-state.test.ts
@@ -1,0 +1,186 @@
+import { MeetingEndReason, MeetingStateType, type MeetingContext } from "../types"
+
+// ── mock the world ──────────────────────────────────────────────
+// jest.mock calls are hoisted – do NOT reference module-scope variables here.
+
+jest.mock("../../singleton", () => ({
+  GLOBAL: {
+    get: jest.fn(),
+    getEndReason: jest.fn().mockReturnValue(undefined),
+    getParticipants: jest.fn().mockReturnValue([]),
+    setEndReason: jest.fn(),
+    setExitTime: jest.fn(),
+    hasError: jest.fn().mockReturnValue(false),
+    setError: jest.fn(),
+    hasNetworkInterceptionSetupFailed: jest.fn().mockReturnValue(false),
+    hasDiarizationFallbackTriggered: jest.fn().mockReturnValue(false),
+    setNetworkInterceptionSetupFailed: jest.fn(),
+    setDiarizationFallbackTriggered: jest.fn(),
+  },
+}))
+
+jest.mock("../../speaker-manager", () => ({
+  SpeakerManager: {
+    getInstance: jest.fn().mockReturnValue({
+      getLastCallbackTime: jest.fn().mockReturnValue(Date.now()),
+      handleSpeakerUpdate: jest.fn(),
+    }),
+    start: jest.fn(),
+    finalize: jest.fn(),
+  },
+}))
+
+jest.mock("../../utils/sound-level-monitor", () => ({
+  SoundLevelMonitor: {
+    peekInstance: jest.fn(),
+    getInstance: jest.fn(),
+    stopIfStarted: jest.fn(),
+  },
+}))
+
+jest.mock("../../recording/ScreenRecorder", () => ({
+  ScreenRecorderManager: {
+    getInstance: jest.fn().mockReturnValue({
+      on: jest.fn(),
+      setMeetingStartTime: jest.fn(),
+    }),
+  },
+}))
+
+jest.mock("../../events", () => ({ Events: { callEnded: jest.fn().mockResolvedValue(undefined) } }))
+
+jest.mock("../../utils/sleep", () => ({ sleep: jest.fn() }))
+
+jest.mock("../../browser/page-logger", () => ({ listenPage: jest.fn() }))
+
+jest.mock("../../meeting/meet/ui-observer", () => ({ startUIBasedObserver: jest.fn() }))
+
+jest.mock("../../meeting/meet/network-interception", () => ({ stopNetworkInterception: jest.fn() }))
+
+jest.mock("../../utils/diarization-monitor", () => ({
+  checkDiarizationHealth: jest.fn().mockResolvedValue({ status: "optimal" }),
+  logHealthStatus: jest.fn(),
+}))
+
+// Import after mocks so the SUT picks up mocked dependencies.
+import { RecordingState } from "./recording-state"
+
+// ── helpers ─────────────────────────────────────────────────────
+
+function mockGLOBAL() {
+  return require("../../singleton").GLOBAL as Record<string, jest.Mock>
+}
+
+function mockSoundLevelMonitor() {
+  return require("../../utils/sound-level-monitor").SoundLevelMonitor as Record<string, jest.Mock>
+}
+
+function createContext(overrides: Partial<MeetingContext> = {}): MeetingContext {
+  return {
+    provider: {
+      findEndMeeting: jest.fn().mockResolvedValue(false),
+      closeMeeting: jest.fn(),
+    } as any,
+    playwrightPage: undefined,
+    browserContext: undefined,
+    startTime: Date.now(),
+    attendeesCount: 0,
+    firstUserJoined: false,
+    pauseWindows: [],
+    currentPauseStart: null,
+    ...overrides,
+  }
+}
+
+function setMeetingParams(params: Record<string, unknown>): void {
+  mockGLOBAL().get.mockImplementation((path: string) => params[path])
+}
+
+// ── tests ───────────────────────────────────────────────────────
+
+describe("RecordingState – grace period participant detection", () => {
+  let state: RecordingState
+  let context: MeetingContext
+  let startTime: number
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: 0 })
+    jest.clearAllMocks()
+
+    startTime = Date.now()
+
+    setMeetingParams({
+      meeting_platform: "teams",
+      grace_period: 10,
+      silence_timeout: 30,
+      no_one_joined_timeout: 30,
+    })
+
+    // SoundLevelMonitor: active but silent
+    mockSoundLevelMonitor().peekInstance.mockReturnValue({
+      getCurrentSoundLevel: jest.fn().mockReturnValue(0),
+      getIsActive: jest.fn().mockReturnValue(true),
+    })
+
+    context = createContext({
+      startTime,
+      attendeesCount: 5,
+    })
+
+    state = new RecordingState(context, MeetingStateType.Recording)
+
+    // Suppress checkBotRemoved (needs browser page, which we don't have)
+    jest.spyOn(state as any, "checkBotRemoved").mockResolvedValue(false)
+  })
+
+  describe("fix: humans leave during grace period", () => {
+    it("DOES set hasNoOneJoinedPeriodEnded when attendees are present during grace period", async () => {
+      jest.setSystemTime(startTime + 2000)
+      await (state as any).checkEndConditions()
+
+      expect((state as any).hasNoOneJoinedPeriodEnded).toBe(true)
+    })
+
+    it("proceeds to silence/alone checks after grace period expires (not stuck in noone-joined)", async () => {
+      // T=2s: inside grace period, humans present → detection happens
+      jest.setSystemTime(startTime + 2000)
+      await (state as any).checkEndConditions()
+
+      // Humans leave during grace period
+      context.attendeesCount = 1
+
+      // T=12s: grace period expired
+      jest.setSystemTime(startTime + 12000)
+      const result = await (state as any).checkEndConditions()
+
+      // Fix: hasNoOneJoinedPeriodEnded is true — checkAloneInMeeting is reached
+      expect((state as any).hasNoOneJoinedPeriodEnded).toBe(true)
+      // Should not be stuck (doesn't return early at "Still waiting" block)
+      // Note: result is still false because we need 30s alone before leaving
+    })
+  })
+
+  describe("grace period exit suppression", () => {
+    it("does not end meeting during grace period even when alone", async () => {
+      jest.setSystemTime(startTime + 2000)
+      context.attendeesCount = 1
+
+      const result = await (state as any).checkEndConditions()
+      expect(result.shouldEnd).toBe(false)
+    })
+  })
+
+  describe("API stop request", () => {
+    it("returns shouldEnd=true when end reason is set externally", async () => {
+      // Override the mock from beforeEach to return a reason this time
+      mockGLOBAL().getEndReason.mockReset()
+      mockGLOBAL().getEndReason.mockReturnValue(MeetingEndReason.ApiRequest)
+
+      jest.setSystemTime(startTime + 2000)
+      const result = await (state as any).checkEndConditions()
+
+      expect(result.shouldEnd).toBe(true)
+      expect(result.reason).toBe(MeetingEndReason.ApiRequest)
+    })
+  })
+})

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -206,6 +206,28 @@ export class RecordingState extends BaseState {
         return { shouldEnd: true, reason: GLOBAL.getEndReason() }
       }
 
+      /**
+       * participant / sound detection (even during grace period)
+       * 
+       * The grace period must suppress EXIT but NOT detection.
+       * If participants are present or sound is heard, record it so the
+       * bot switches to silence / alone-in-meeting monitoring once the
+       * grace period ends.  Otherwise the bot gets stuck in
+       * "waiting for first sound or attendees" for the full
+       * no_one_joined_timeout even though humans were clearly present.
+       */
+      if (!this.hasNoOneJoinedPeriodEnded) {
+        const monitor = SoundLevelMonitor.peekInstance()
+        const currentSoundLevel = monitor?.getCurrentSoundLevel() ?? 0
+        if (currentSoundLevel > SOUND_LEVEL_ACTIVITY_THRESHOLD) {
+          this.hasNoOneJoinedPeriodEnded = true
+          this.lastSoundActivity = now
+        } else if ((this.context.attendeesCount || 0) > 1) {
+          this.hasNoOneJoinedPeriodEnded = true
+          this.lastSoundActivity = now
+        }
+      }
+
       // During grace period the bot must stay in the meeting unconditionally —
       // even if all participants leave or the platform signals bot removal.
       // Keep lastSoundActivity fresh so the silence clock only starts after
@@ -528,37 +550,32 @@ export class RecordingState extends BaseState {
     shouldEnd: boolean
     reason?: MeetingEndReason
   } {
-    // Never end with NoAttendees during the grace period, and don't start
-    // the no_one_joined timeout countdown until the grace period has finished.
-    if (this.isInGracePeriod(now)) {
-      return { shouldEnd: false }
-    }
-
     const startTime = this.context.startTime
     if (!startTime) {
       return { shouldEnd: false }
     }
 
     // Check for positive attendee signals (only use when true, not when false/0)
-    // This helps when users are present but haven't spoken yet
     const attendeesCount = this.context.attendeesCount || 0
 
-    // If grace period has already ended (by sound or attendees), return early
-    if (this.hasNoOneJoinedPeriodEnded) {
-      return { shouldEnd: false }
-    }
-
-    // If attendees detected via speaker observer (positive signal), end grace period
-    // Use > 1 because the bot itself is counted as an attendee.
-    // This way, if detection works, we use it; if it doesn't, we fall back to sound
-    if (attendeesCount > 1) {
-      // Reset silence timer to start monitoring from now
-      // This is important to ensure that the silence timeout is not triggered too early
+    // ── detection always active (even during grace period) ──
+    if (!this.hasNoOneJoinedPeriodEnded && attendeesCount > 1) {
       this.lastSoundActivity = now
       console.log(
         `[noone-joined] Grace period ended (attendees detected: count=${attendeesCount}, excluding bot), enabling silence timeout checks`
       )
       this.hasNoOneJoinedPeriodEnded = true
+      return { shouldEnd: false }
+    }
+
+    // Never end with NoAttendees during the grace period — exit is suppressed
+    // but detection above has already flipped the flag if needed.
+    if (this.isInGracePeriod(now)) {
+      return { shouldEnd: false }
+    }
+
+    // If grace period has already ended (by sound or attendees), return early
+    if (this.hasNoOneJoinedPeriodEnded) {
       return { shouldEnd: false }
     }
 


### PR DESCRIPTION
# Bug
grace period blocks the "humans were here" flag from being set → after grace period expires and humans are gone, the bot thinks "nobody ever joined" → waits full `no_one_joined_timeout` before leaving.

# Fix
grace period still blocks exit but no longer blocks setting the "humans were here" flag → after grace period expires, bot knows people came and left → proceeds to checkAloneInMeeting → detects it's alone → leaves.

# Tests
[recording-state.test.ts](https://github.com/Meeting-BaaS/meet-teams-bot/commit/7dc412a96e6415de7492dab4e54522c43002d88d#diff-e05afe01b9b465e4f4cd35ada19f61482660d5c3d2c82f5f465d8787cf40a74f): 4 tests with Jest fake timers, mocked GLOBAL, SpeakerManager, SoundLevelMonitor