### PR TITLE
fix(recording): fail BotRemovedTooEarly when finalization yields no usable output

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1427,6 +1427,38 @@ export class ScreenRecorder extends EventEmitter {
             // speaker_view / gallery_view modes
         }
 
+        // Integrity gate: a bot admitted then removed within seconds can produce
+        // empty audio and a corrupt/near-empty video, while each finalize step above
+        // swallows its own failure ("still deliverable on its own"). Before declaring
+        // success, require the final output to actually contain something — otherwise
+        // report BotRemovedTooEarly so the bot emits recording_failed instead of a
+        // silent-success callback carrying a broken artifact. (audio_only already fails
+        // above on extraction error; this also covers the video modes.)
+        const fileSize = (p: string): number =>
+            fs.existsSync(p) ? fs.statSync(p).size : 0
+        const videoBytes = fileSize(this.outputPath)
+        const audioBytes = fileSize(this.audioOutputPath)
+        // 50 KB is far above a header-only / corrupt stub (the failing bot produced a
+        // ~200-byte mp4) yet well below any real recording — even a few seconds of
+        // speaker-view video exceeds it.
+        const MIN_USABLE_OUTPUT_BYTES = 50 * 1024
+        if (
+            videoBytes < MIN_USABLE_OUTPUT_BYTES &&
+            audioBytes < MIN_USABLE_OUTPUT_BYTES
+        ) {
+            console.warn(
+                `❌ Final recording has no usable content (video=${videoBytes}B, audio=${audioBytes}B) — marking bot-removed-too-early`,
+            )
+            // Preserve any terminal end_reason the state machine already set (e.g. the
+            // botRemoved/botNotAccepted from a post-admission kick) rather than clobber it.
+            if (!GLOBAL.hasError()) {
+                GLOBAL.setError(MeetingEndReason.BotRemovedTooEarly)
+            }
+            throw new Error(
+                `Recording produced no usable content (video=${videoBytes}B, audio=${audioBytes}B)`,
+            )
+        }
+
         // 10. Cleanup temporary files
         await this.cleanupTempFiles([
             rawVideoPath,


### PR DESCRIPTION
## Problem (reported by an on-prem client)
A Google Meet bot was **admitted then removed within ~8s** (`"You've been removed"`). It captured **0 bytes of audio** and only a **corrupt ~200-byte video**, yet sent a **successful completion callback with no error** — leaving the client to infer the failure and surface a generic code.

## Root cause
Every finalize step swallows its own failure to stay "deliverable", so an empty/broken recording reaches the success path:
- The merge logs `✅ Efficient sync and merge completed successfully` even though FFmpeg errored (`Error opening output file …output.flac: Invalid argument`) on the empty audio.
- The audio-extraction `catch` only converts the failure into `BotRemovedTooEarly` when `recording_mode === 'audio_only'`; in **video modes** it just warns *"Continuing without audio extraction… the video mp4 is still deliverable"* and proceeds — even when the mp4 is a 200-byte stub.
- `botRemoved` (post-admission kick) is treated as a normal termination, clearing the error state.

Net: kicked-seconds-after-admit + empty/corrupt output → clean success callback, no error.

## Fix
Add an integrity gate at the end of the sync/merge, just before the success log: if **neither** the final video **nor** audio output exceeds a small floor (`50 KB` — far above a header-only/corrupt stub, comfortably below any real recording), set `MeetingEndReason.BotRemovedTooEarly` (preserving any end_reason the state machine already set, e.g. `botRemoved`) and throw — so the bot emits `recording_failed` with a meaningful reason instead of silent success.

- ✅ Empty audio + corrupt/tiny video → `recording_failed` (`BotRemovedTooEarly`)
- ✅ Real recording (video and/or audio present) → unaffected
- ✅ Legit no-audio video meeting → video passes the floor, still delivered
- ✅ `audio_only` empty case → already failed earlier; this is a belt-and-suspenders backstop

`tsc` clean for this file (the only tsc error is a pre-existing missing `@types/jest`, unrelated).

## Notes
- Targeted at `output-flac-cloak-browser` (the on-prem line; superset of `output-flac`). If the plain `output-flac` line is also built, the same one-block change should be cherry-picked there.
- Secondary hardening not done here (kept minimal): the merge step itself still logs success despite an FFmpeg error — worth honoring the merge exit code separately, but the output gate already catches the user-visible symptom regardless of which step failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)