### PR TITLE
fix(recording): fail BotRemovedTooEarly when finalization yields no usable output

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1416,6 +1416,33 @@ export class ScreenRecorder extends EventEmitter {
       // speaker_view / gallery_view modes
     }
 
+    // Integrity gate: a bot admitted then removed within seconds can produce empty audio
+    // and a corrupt/near-empty video, while each finalize step above swallows its own
+    // failure ("still deliverable on its own") — and getDuration is now non-fatal, so a
+    // corrupt file no longer even throws at the probe. Before declaring success, require the
+    // final output to actually contain something. This is checked by byte size, NOT ffprobe,
+    // so an ffprobe timeout/wall-clock fallback cannot mask an empty recording. If there is
+    // nothing usable, report BotRemovedTooEarly so the bot emits recording_failed instead of
+    // a silent-success callback with a broken artifact. (audio_only already fails above.)
+    const fileSize = (p: string): number => (fs.existsSync(p) ? fs.statSync(p).size : 0)
+    const videoBytes = fileSize(this.outputPath)
+    const audioBytes = fileSize(this.audioOutputPath)
+    // 50 KB is far above a header-only / corrupt stub (the failing bot produced a ~200-byte
+    // mp4) yet well below any real recording — even a few seconds of video exceeds it.
+    const MIN_USABLE_OUTPUT_BYTES = 50 * 1024
+    if (videoBytes < MIN_USABLE_OUTPUT_BYTES && audioBytes < MIN_USABLE_OUTPUT_BYTES) {
+      console.warn(
+        `❌ Final recording has no usable content (video=${videoBytes}B, audio=${audioBytes}B) — marking bot-removed-too-early`
+      )
+      // Preserve any terminal end_reason the state machine already set (e.g. botRemoved).
+      if (!GLOBAL.hasError()) {
+        GLOBAL.setError(MeetingEndReason.BotRemovedTooEarly)
+      }
+      throw new Error(
+        `Recording produced no usable content (video=${videoBytes}B, audio=${audioBytes}B)`
+      )
+    }
+
     // 10. Cleanup temporary files
     await this.cleanupTempFiles()
 


### PR DESCRIPTION
v2 port of the on-prem fix (#185 on `output-flac-cloak-browser`).

## Problem
A bot admitted then removed within seconds (Google `"You've been removed"`) can capture **0-byte audio** and a **corrupt ~200-byte video**, yet still send a **successful completion callback with no error**.

## Why it slips through on v2 specifically
Each finalize step swallows its own failure to stay "deliverable", **and** `getDuration` is now non-fatal (#179 — wall-clock fallback on ffprobe failure), so a corrupt file no longer even throws at the probe. An empty recording therefore reaches the success path.

## Fix
Integrity gate at the end of the sync/merge: if **neither** the final video **nor** audio output exceeds a small floor (`50 KB`), set `MeetingEndReason.BotRemovedTooEarly` (preserving any end_reason already set, e.g. `botRemoved`) and throw → the bot emits `recording_failed` instead of silent success.

**Checked by file byte size, not ffprobe** — so an ffprobe timeout / wall-clock fallback cannot mask an empty recording (the gate doesn't call ffprobe).

- ✅ Empty audio + corrupt/tiny video → `recording_failed` (`BotRemovedTooEarly`)
- ✅ Real recording (video and/or audio present) → unaffected
- ✅ Legit no-audio video meeting → video clears the floor, still delivered
- ✅ `audio_only` empty case → already failed earlier; this is a backstop

`tsc --noEmit` clean. Mirrors #185 (same gate, adapted to v2 code style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)