### PR TITLE
fix(deps): bump ws to ^8.21.0 and override form-data ^4.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "ts-node": "^10.9.2",
                 "tslib": "^2.8.1",
                 "winston": "^3.17.0",
-                "ws": "8.18.0",
+                "ws": "^8.21.0",
                 "zod": "^4.3.6"
             },
             "devDependencies": {
@@ -6266,16 +6266,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -6579,9 +6579,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -10480,9 +10481,10 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "winston": "^3.17.0",
-        "ws": "8.18.0",
+        "ws": "^8.21.0",
         "zod": "^4.3.6"
     },
     "devDependencies": {
@@ -56,6 +56,7 @@
         "esbuild": "^0.28.1",
         "fast-xml-parser": "^5.7.0",
         "flatted": "^3.4.2",
+        "form-data": "^4.0.6",
         "lodash": "^4.17.24",
         "minimatch": "^9.0.5",
         "simple-git": "^3.36.0"


### PR DESCRIPTION
Clears the remaining Dependabot/Vanta alerts on this repo:
- ws 8.18.0 -> 8.21.0 (CVE-2026-48779)
- form-data 4.0.5 -> 4.0.6 (CVE-2026-12143)