### PR TITLE
feat: filter ignored_participant_names from attendeesCount in auto-leave checks

### DIFF
--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -210,9 +210,17 @@ export class SpeakerManager {
     }
     // If speakersCount is neither 0 nor > 0 (impossible), keep existing value
 
+    const ignoredNames = GLOBAL.get().ignored_participant_names ?? []
+    const filteredSpeakersLength =
+      ignoredNames.length > 0
+        ? speakers.filter(
+            (s) => !ignoredNames.some((n) => n.toLowerCase() === s.name.toLowerCase())
+          ).length
+        : speakers.length
+
     const participantState: ParticipantState = {
-      attendeesCount: speakers.length,
-      firstUserJoined: speakers.length > 0,
+      attendeesCount: filteredSpeakersLength,
+      firstUserJoined: filteredSpeakersLength > 0,
       lastSpeakerTime: this.lastSpeakerTime,
       noSpeakerDetectedTime
     }

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -577,14 +577,15 @@ export class RecordingState extends BaseState {
     }
 
     // If attendees detected via speaker observer (positive signal), end grace period
-    // Use > 1 because the bot itself is counted as an attendee.
+    // attendeesCount is filtered by ignored_participant_names, so > 1 means at least
+    // one real non-ignored participant beyond the bot itself is present.
     // This way, if detection works, we use it; if it doesn't, we fall back to sound
     if (attendeesCount > 1) {
       // Reset silence timer to start monitoring from now
       // This is important to ensure that the silence timeout is not triggered too early
       this.lastSoundActivity = now
       console.log(
-        `[noone-joined] Grace period ended (attendees detected: count=${attendeesCount}, excluding bot), enabling silence timeout checks`
+        `[noone-joined] Grace period ended (attendees detected: count=${attendeesCount}), enabling silence timeout checks`
       )
       this.hasNoOneJoinedPeriodEnded = true
       return { shouldEnd: false }
@@ -701,7 +702,9 @@ export class RecordingState extends BaseState {
 
     // Gate: only activate alone-in-meeting if we've ever seen a real participant.
     // v2 includes the bot itself in the participants list, so > 1 means at least
-    // one real human was detected at some point during the meeting.
+    // one real human or other bot was detected at some point during the meeting.
+    // attendeesCount is filtered by ignored_participant_names, so isAlone can
+    // still be true even when other (ignored) bots remain.
     const participantsEverSeen = GLOBAL.getParticipants().length > 1
     if (!participantsEverSeen) {
       return { shouldEnd: false }

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -1,4 +1,5 @@
 import {
+  array,
   nullable,
   number,
   object,
@@ -44,6 +45,7 @@ export const BotMessageSchema = object({
   no_one_joined_timeout: number().int().positive().default(600),
   silence_timeout: number().int().positive().default(600),
   grace_period: number().int().nonnegative().default(0),
+  ignored_participant_names: array(string()).default([]),
   speech_to_text_provider: SpeechToTextProviderSchema.default("none"),
   retry_count: number().int().nonnegative().default(0),
 


### PR DESCRIPTION
## Summary
When multiple bots join the same meeting (e.g. sandbox + staging), each bot counts other bots as regular participants. This prevents auto-leave from triggering because attendeesCount never drops to 1 or below.

This change adds ignored_participant_names to the bot message schema and filters those names out of attendeesCount in SpeakerManager.updateMeetingState(). The filtering is case-insensitive and only affects the attendee count — the full participant list is preserved for chat attribution and analytics.

## Testing

-  Verified attendeesCount correctly excludes ignored names when ignored_participant_names is set
-  Verified empty/undefined ignored_participant_names produces identical behavior to before (no filtering)
-  tsc --noEmit passes with zero errors
-  Case-insensitive matching confirmed (e.g. "staging bot" matches "Staging Bot")
- ## Release Notes

User-facing: Bots can now be configured with ignored_participant_names — a list of participant names to exclude from auto-leave attendee counting. When all non-ignored participants leave, the bot will detect it's alone and exit normally instead of waiting for silence_timeout.

Operational: No breaking changes. New field defaults to [] (empty) — existing bot configs are unaffected.