### PR TITLE
fix: update STT provider schema for v2

### DIFF
--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -13,7 +13,14 @@ import {
 } from "zod"
 
 export const RecordingModeSchema = zodEnum(["speaker_view", "audio_only", "gallery_view"])
-export const SpeechToTextProviderSchema = zodEnum(["gladia", "assembly", "none"])
+export const SpeechToTextProviderSchema = zodEnum([
+  "gladia",
+  "deepgram",
+  "assemblyai",
+  "speechmatics",
+  "soniox",
+  "none"
+])
 export const MeetingPlatformSchema = zodEnum(["zoom", "meet", "teams"])
 
 /**


### PR DESCRIPTION
## Summary
- update the v2 bot message schema to accept the STT providers sent by meeting-baas-v2
- supported batch providers verified in meeting-baas-v2: gladia, deepgram, assemblyai, speechmatics, soniox
- keep none for disabled transcription

This supersedes #141 for the v2-improvements branch. The original PR targeted main and changed an older local type alias that no longer exists on v2-improvements.

## Testing
- git diff --check
- not run: TypeScript build/tests, node is not available on this machine PATH