### PR TITLE
fix(recording): preserve recorder end reason

### DIFF
--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -181,7 +181,14 @@ export class RecordingState extends BaseState {
             : String(error)
       }
 
-      GLOBAL.setError(MeetingEndReason.StreamingSetupFailed, errorMessage)
+      const existingReason = GLOBAL.getEndReason()
+      if (existingReason) {
+        console.log(
+          `Preserving existing end_reason ${existingReason} instead of overriding with StreamingSetupFailed`
+        )
+      } else {
+        GLOBAL.setError(MeetingEndReason.StreamingSetupFailed, errorMessage)
+      }
       this.isProcessing = false
     })
 


### PR DESCRIPTION
## Summary
- Preserve an existing meeting end reason when the recorder emits a later error
- Only classify recorder errors as `streamingSetupFailed` when no earlier end reason exists

## Verification
- `npm ci`
- `npm run build`

Parent PR: https://github.com/Meeting-BaaS/meeting-baas-v2/pull/194
