### PR TITLE
fix(meet): don't false-confirm "in meeting" while in the waiting room (empty recording)

### DIFF
--- a/src/meeting/meet-state-config.ts
+++ b/src/meeting/meet-state-config.ts
@@ -41,9 +41,16 @@ export const MEET_STATE_CONFIG: StateDetectionConfig = {
       'text="waiting to be let in"',
       'text="Instead of waiting to be let in"',
       'text="Please wait until a meeting host brings you into the call"',
+      // Google also renders the lobby with "admits you to the call" wording;
+      // unquoted text= does a case-insensitive substring match so it survives
+      // minor copy changes. Without this the lobby is not recognised as a
+      // waiting room and the bot can false-confirm "in meeting".
+      'text=admits you to the call',
+      'text="Please wait until a meeting host admits you to the call"',
       '[aria-label*="waiting"]',
       '[aria-label*="Please wait until"]',
-      '[aria-label*="brings you into"]'
+      '[aria-label*="brings you into"]',
+      '[aria-label*="admits you"]'
     ],
     threshold: 1,
     checkVisibility: false

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -339,7 +339,12 @@ export class MeetProvider implements MeetingProviderInterface {
         const gracePeriodExpired =
           !leftWaitingRoomAt || Date.now() - leftWaitingRoomAt >= GRACE_PERIOD_MS
 
-        if (gracePeriodExpired) {
+        // Never confirm "in meeting" while this sample still sees the waiting
+        // room. Otherwise, because leftWaitingRoomAt stays null until we actually
+        // leave, gracePeriodExpired is true from the first iteration and the bot
+        // can confirm against lobby DOM and start recording the waiting screen
+        // (0 media tracks captured).
+        if (!nowInWaitingRoom && gracePeriodExpired) {
           const inMeeting = await isInMeeting(page)
           if (inMeeting) {
             botWasInMeeting = true
@@ -625,7 +630,20 @@ async function isInMeeting(page: Page): Promise<boolean> {
       return false
     }
 
-    // Check for meeting presence indicators FIRST
+    // Waiting room takes precedence — check it FIRST and short-circuit before
+    // sampling the in-meeting indicators. The Google Meet lobby renders the same
+    // call-control DOM (mic / camera / hang-up, the "Call controls" region,
+    // reactions) that satisfies the in-meeting threshold, so a threshold match
+    // alone is NOT proof we are in the meeting. If the lobby is detected we are
+    // still waiting to be admitted, regardless of any indicator count. The
+    // waiting-room patterns are specific lobby texts Google removes on
+    // admission, so they do not linger as "stale" DOM after a genuine join.
+    if (await isInWaitingRoom(page)) {
+      console.log("✗ In waiting room - not in meeting yet")
+      return false
+    }
+
+    // Not in the lobby → now evaluate the in-meeting presence indicators.
     const result = await meetStateDetector.isInMeeting(page)
     const selectorCount = MEET_STATE_CONFIG.inMeetingPattern.selectors.length
     const threshold = MEET_STATE_CONFIG.inMeetingPattern.threshold
@@ -633,18 +651,10 @@ async function isInMeeting(page: Page): Promise<boolean> {
       `Meeting presence indicators: ${result.count}/${selectorCount} visible (threshold: ${threshold}, matched: ${result.matched})`
     )
 
-    // If we have strong meeting indicators (threshold met), we're definitely in the meeting
-    // This overrides any stale waiting room DOM elements that might still be present
+    // Strong meeting indicators AND not in the waiting room → in the meeting.
     if (result.matched) {
       console.log(`✓ Threshold reached: ${result.count} >= ${threshold} - Confirming in meeting`)
       return true
-    }
-
-    // Only if meeting indicators are weak/absent, check if we're in waiting room
-    // This prevents false positives from stale waiting room elements after joining
-    if (await isInWaitingRoom(page)) {
-      console.log("✗ Threshold not met but in waiting room - Not in meeting yet")
-      return false
     }
 
     // Not enough meeting indicators and not in waiting room


### PR DESCRIPTION
## Problem
A Google Meet bot recorded ~19 minutes of the **waiting-room screen** and captured **no participant audio or video** — `0` media tracks for the entire call. The output was a placeholder/lobby video with no audio track.

## Root cause — join-detection false positive
1. The lobby wording **"Please wait until a meeting host admits you to the call"** was not in `waitingRoomPattern` (only the `"...brings you into the call"` variant was), so `isInWaitingRoom()` returned `false` for it.
2. `isInMeeting()` returned `true` as soon as the in-meeting selector **threshold** was met, **before** checking the waiting room. But the Meet lobby renders the same call-control DOM (`Call controls` region, mic/camera/hang-up, reactions) that crosses that threshold → the bot "confirmed" it was in the meeting **while still in the lobby**, started recording, and was never actually admitted.
3. In the join loop, `gracePeriodExpired` is `true` from the first iteration while in the waiting room (`leftWaitingRoomAt` stays `null`), so confirmation was attempted against lobby DOM.

## Fix
- Add the `"admits you to the call"` lobby wording (substring `text=` + `aria-label`) to `waitingRoomPattern`.
- In `isInMeeting()`, **check the waiting room first** and return `false` if detected, regardless of the in-meeting indicator count. The waiting-room patterns are specific lobby texts Google removes on admission, so they don't linger as stale DOM after a genuine join.
- In the join loop, don't attempt in-meeting confirmation while the current sample still sees the waiting room.

**Net effect:** the bot can no longer start recording until it has genuinely left the waiting room and is in the live meeting. An un-admitted bot now ends via the waiting-room timeout instead of producing a silent, empty recording.

## Evidence
Bot `3ff58776` (2026-06-26): Meet lobby screen captured in `raw_video.mp4`, log shows 333× `Subscribed but no audio tracks detected yet (0 tracks)`, ended `botRemoved`.

## Test plan
- Lobby-enabled Meet (host delays admit): bot stays in the waiting loop, does **not** start recording; if never admitted → waiting-room timeout, not an empty recording.
- Normal auto-admit Meet: bot joins and records as before (no regression).
- Bot admitted after a delay: records from admission onward.

## Release Notes
Fixed a Google Meet issue where a bot held in the waiting room could start recording the lobby screen and capture no participant audio or video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)