### PR TITLE
Keep Teams setup off the recording path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,11 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-# Teams (and any non-Meet) use official Playwright Chromium via
-# /usr/bin/google-chrome; Meet uses CloakBrowser's own stealth Chromium fork
-# (baked below). Both are installed so browser.ts can pick per provider.
-RUN npx playwright install chromium && \
-    find /root/.cache/ms-playwright -name chrome -type f -executable | head -1 | xargs -I {} ln -sf {} /usr/bin/google-chrome
-# CloakBrowser (Meet): pin the cache dir + disable runtime auto-update so the
+# CloakBrowser ships its own stealth Chromium fork; both Meet and Teams launch
+# through it. Install Chromium system dependencies without downloading
+# Playwright's browser binary.
+RUN npx playwright install-deps chromium
+# CloakBrowser: pin the cache dir + disable runtime auto-update so the
 # baked binary is the one used; otherwise each ephemeral pod fetches ~200MB on
 # first launch.
 ENV CLOAKBROWSER_CACHE_DIR=/opt/cloakbrowser

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -9,6 +9,25 @@ function buildChromeArgs(
     windowHeight: number,
     proxyUrl?: string | null,
 ): string[] {
+    const disabledFeatures = [
+        'AudioServiceSandbox',
+        'SigninInterception',
+        'IdentityConsistency',
+        'ChromeBrowserCloudManagement',
+        'SignInPromo',
+        'ChromeWhatsNewUI',
+        'AccountConsistency',
+        'TranslateUI',
+        'AutofillServerCommunication',
+        'MediaRouter',
+        'TrustedScriptTypes',
+        'TrustedHTML',
+    ]
+    const disabledBlinkFeatures = [
+        'AutomationControlled',
+        'TrustedDOMTypes',
+    ]
+
     return [
         // Window size and position - must match Xvfb display exactly
         `--window-size=${windowWidth},${windowHeight}`,
@@ -26,7 +45,6 @@ function buildChromeArgs(
         '--use-pulseaudio', // Force Chromium to use PulseAudio
         '--enable-audio-service-sandbox=false', // Disable audio service sandbox for virtual devices
         '--audio-buffer-size=2048', // Set buffer size for better audio handling
-        '--disable-features=AudioServiceSandbox', // Additional sandbox disable
         '--autoplay-policy=no-user-gesture-required', // Allow autoplay for meeting platforms
 
         // WebRTC optimizations (required for meeting audio/video capture)
@@ -43,30 +61,28 @@ function buildChromeArgs(
         '--disable-sync',
         '--disable-component-update',
         '--disable-signin',
-        '--disable-features=SigninInterception,IdentityConsistency,ChromeBrowserCloudManagement,SignInPromo,ChromeWhatsNewUI,AccountConsistency',
 
         // Performance and resource management optimizations
-        '--disable-blink-features=AutomationControlled',
         '--disable-background-timer-throttling',
         '--enable-features=SharedArrayBuffer',
         '--memory-pressure-off', // Disable memory pressure handling for consistent performance
         '--max_old_space_size=4096', // Increase V8 heap size to 4GB for large meetings
         '--disable-background-networking', // Reduce background network activity
-        '--disable-features=TranslateUI', // Disable translation features to save resources
-        '--disable-features=AutofillServerCommunication', // Disable autofill to reduce network usage
         '--disable-component-extensions-with-background-pages', // Reduce background extension overhead
         '--disable-default-apps', // Disable default Chrome apps
         '--renderer-process-limit=4', // Limit renderer processes to prevent resource exhaustion
         '--disable-ipc-flooding-protection', // Improve IPC performance for high-frequency operations
         '--aggressive-cache-discard', // Enable aggressive cache management for memory efficiency
-        '--disable-features=MediaRouter', // Disable media router for reduced overhead
 
         // Certificate and security optimizations for meeting platforms
         '--ignore-certificate-errors',
         '--allow-insecure-localhost',
-        '--disable-blink-features=TrustedDOMTypes',
-        '--disable-features=TrustedScriptTypes',
-        '--disable-features=TrustedHTML',
+
+        // Chromium command-line switches are single-valued: repeated
+        // --disable-features / --disable-blink-features entries are overwritten
+        // by the last occurrence, so keep each list merged into one flag.
+        `--disable-features=${disabledFeatures.join(',')}`,
+        `--disable-blink-features=${disabledBlinkFeatures.join(',')}`,
 
         // Additional audio debugging (remove in production)
         '--enable-logging=stderr',

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -1,4 +1,4 @@
-import { BrowserContext, chromium } from '@playwright/test'
+import { BrowserContext } from '@playwright/test'
 import { GLOBAL } from '../singleton'
 import { formatError } from '../utils/Logger'
 
@@ -35,6 +35,15 @@ function buildChromeArgs(
         '--disable-webrtc-hw-encoding',
         '--enable-webrtc-capture-audio', // Ensure WebRTC can capture audio
         '--force-webrtc-ip-handling-policy=default', // Better WebRTC handling
+
+        // Suppress Chrome's "Sign in to Chrome?" / "Turn on sync" dialogs that
+        // can appear when an authenticated browser session is used.
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-sync',
+        '--disable-component-update',
+        '--disable-signin',
+        '--disable-features=SigninInterception,IdentityConsistency,ChromeBrowserCloudManagement,SignInPromo,ChromeWhatsNewUI,AccountConsistency',
 
         // Performance and resource management optimizations
         '--disable-blink-features=AutomationControlled',
@@ -88,69 +97,42 @@ export async function openBrowser(
     const windowHeight = resolution === '1080' ? 1220 : 860
 
     const args = buildChromeArgs(windowWidth, windowHeight, proxyUrl)
+    const platform = GLOBAL.get().meetingProvider
+    const gpuArgs = [
+        '--disable-gpu',
+        '--disable-software-rasterizer',
+        '--disable-gpu-compositing',
+    ]
 
     try {
-        // --- Google Meet: CloakBrowser (stealth Chromium + humanized input) ---
-        // Meet's reCAPTCHA-Enterprise-style join scoring blocks plain Chromium/CDP
-        // input, so Meet alone uses CloakBrowser with humanize. dehumanize() is
-        // applied once admitted (see WaitingRoomState).
-        if (GLOBAL.get().meetingProvider === 'Meet') {
-            console.log('Launching CloakBrowser persistent context (Meet)...')
-            // esbuild converts import() to require() under "module: commonjs",
-            // which breaks ESM-only packages. The Function constructor prevents
-            // that transpilation.
-            const dynamicImport = new Function(
-                'specifier',
-                'return import(specifier)',
-            )
-            const { launchPersistentContext } =
-                await dynamicImport('cloakbrowser')
-            const context = await launchPersistentContext({
-                userDataDir: '',
-                headless: false,
-                viewport: { width, height },
-                locale: 'en-US',
-                humanize: true,
-                ...(proxyUrl ? { proxy: proxyUrl } : {}),
-                args: [
-                    ...args,
-                    '--disable-gpu',
-                    '--disable-software-rasterizer',
-                    '--disable-gpu-compositing',
-                ],
-                contextOptions: {
-                    permissions: ['microphone', 'camera'],
-                    ignoreHTTPSErrors: true,
-                    acceptDownloads: true,
-                    bypassCSP: true,
-                },
-            })
-            console.log('✅ CloakBrowser launched (Meet)')
-            return { browser: context as unknown as BrowserContext }
-        }
-
-        // --- Teams / everything else: official Chrome (unchanged legacy path) ---
-        // Teams does not have Meet's anti-bot join scoring, so it keeps the
-        // proven official-Chrome launch (no CloakBrowser, no humanize).
-        const chromePath = process.env.CHROME_PATH || '/usr/bin/google-chrome'
         console.log(
-            `Launching official Chrome persistent context (${GLOBAL.get().meetingProvider}) at ${chromePath}...`,
+            `Launching CloakBrowser persistent context (${platform})...`,
         )
-        const context = await chromium.launchPersistentContext('', {
+        // esbuild converts import() to require() under "module: commonjs",
+        // which breaks ESM-only packages. The Function constructor prevents
+        // that transpilation.
+        const dynamicImport = new Function(
+            'specifier',
+            'return import(specifier)',
+        )
+        const { launchPersistentContext } = await dynamicImport('cloakbrowser')
+        const context = await launchPersistentContext({
+            userDataDir: '',
             headless: false,
             viewport: { width, height },
-            executablePath: chromePath,
-            locale: 'en-US', // Set locale for Playwright context
-            args,
-            permissions: ['microphone', 'camera'],
-            ignoreHTTPSErrors: true,
-            acceptDownloads: true,
-            bypassCSP: true,
-            timeout: 120000,
+            locale: 'en-US',
+            humanize: true,
+            ...(proxyUrl ? { proxy: proxyUrl } : {}),
+            args: [...args, ...gpuArgs],
+            contextOptions: {
+                permissions: ['microphone', 'camera'],
+                ignoreHTTPSErrors: true,
+                acceptDownloads: true,
+                bypassCSP: true,
+            },
         })
-
-        console.log('✅ Chromium launched with PulseAudio configuration')
-        return { browser: context }
+        console.log(`✅ CloakBrowser launched (${platform})`)
+        return { browser: context as unknown as BrowserContext }
     } catch (error) {
         console.error('Failed to open browser:', formatError(error))
         throw error

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -10,7 +10,10 @@ import { sleep } from '../utils/sleep'
 import { createStateDetector } from '../utils/meeting-state-detector'
 import { TEAMS_STATE_CONFIG } from './teams-state-config'
 import { formatError } from '../utils/Logger'
-import { enableTeamsAudioCapture, verifyTeamsAudioCapture } from './teams/audio-capture'
+import {
+    enableTeamsAudioCapture,
+    verifyTeamsAudioCapture,
+} from './teams/audio-capture'
 
 // Create a singleton detector instance for Microsoft Teams
 const teamsStateDetector = createStateDetector(TEAMS_STATE_CONFIG)
@@ -48,17 +51,173 @@ export class TeamsProvider implements MeetingProviderInterface {
             origin: url.origin,
         })
 
+        await page.addInitScript(() => {
+            const ALLOWED = /^(https?|about|blob|data|filesystem):/i
+            const isExternal = (raw: string | null | undefined): boolean => {
+                if (!raw) return false
+                const s = String(raw).trim()
+                if (s === '' || /^[#?/]/.test(s)) return false
+                if (!/^[a-z][a-z0-9+.-]*:/i.test(s)) return false
+                return !ALLOWED.test(s)
+            }
+            const log = (vector: string, url: string): void => {
+                try {
+                    console.warn(
+                        `[Teams DeepLinkBlock] blocked ${vector} -> ${url}`,
+                    )
+                } catch (_e) {
+                    // console may be unavailable during early init.
+                }
+            }
+
+            try {
+                const nativeOpen = window.open.bind(window)
+                window.open = ((url?: string | URL, ...rest: unknown[]) => {
+                    if (isExternal(typeof url === 'string' ? url : url?.href)) {
+                        log('window.open', String(url))
+                        return null
+                    }
+                    return (nativeOpen as (...a: unknown[]) => Window | null)(
+                        url,
+                        ...rest,
+                    )
+                }) as typeof window.open
+            } catch (_e) {}
+
+            try {
+                const nativeAssign = window.location.assign.bind(
+                    window.location,
+                )
+                window.location.assign = (url: string | URL) => {
+                    if (isExternal(String(url))) {
+                        log('location.assign', String(url))
+                        return
+                    }
+                    nativeAssign(url as string)
+                }
+            } catch (_e) {}
+
+            try {
+                const nativeReplace = window.location.replace.bind(
+                    window.location,
+                )
+                window.location.replace = (url: string | URL) => {
+                    if (isExternal(String(url))) {
+                        log('location.replace', String(url))
+                        return
+                    }
+                    nativeReplace(url as string)
+                }
+            } catch (_e) {}
+
+            try {
+                const hrefDesc = Object.getOwnPropertyDescriptor(
+                    Location.prototype,
+                    'href',
+                )
+                if (hrefDesc?.set && hrefDesc.get) {
+                    const nativeSet = hrefDesc.set
+                    const nativeGet = hrefDesc.get
+                    Object.defineProperty(Location.prototype, 'href', {
+                        configurable: true,
+                        enumerable: hrefDesc.enumerable,
+                        get(): string {
+                            return nativeGet.call(this) as string
+                        },
+                        set(v: string): void {
+                            if (isExternal(v)) {
+                                log('location.href', String(v))
+                                return
+                            }
+                            nativeSet.call(this, v)
+                        },
+                    })
+                }
+            } catch (_e) {}
+
+            try {
+                const srcDesc = Object.getOwnPropertyDescriptor(
+                    HTMLIFrameElement.prototype,
+                    'src',
+                )
+                if (srcDesc?.set && srcDesc.get) {
+                    const nativeSet = srcDesc.set
+                    const nativeGet = srcDesc.get
+                    Object.defineProperty(HTMLIFrameElement.prototype, 'src', {
+                        configurable: true,
+                        enumerable: srcDesc.enumerable,
+                        get(): string {
+                            return nativeGet.call(this) as string
+                        },
+                        set(v: string): void {
+                            if (isExternal(v)) {
+                                log('iframe.src', String(v))
+                                return
+                            }
+                            nativeSet.call(this, v)
+                        },
+                    })
+                }
+            } catch (_e) {}
+
+            try {
+                const nativeSetAttr = Element.prototype.setAttribute
+                Element.prototype.setAttribute = function (
+                    name: string,
+                    value: string,
+                ): void {
+                    const n = typeof name === 'string' ? name.toLowerCase() : ''
+                    if (
+                        ((n === 'src' && this.tagName === 'IFRAME') ||
+                            (n === 'href' && this.tagName === 'A')) &&
+                        isExternal(value)
+                    ) {
+                        log(`setAttribute:${n}`, String(value))
+                        return
+                    }
+                    nativeSetAttr.call(this, name, value)
+                }
+            } catch (_e) {}
+
+            document.addEventListener(
+                'click',
+                (e: Event) => {
+                    const path = (e.composedPath?.() ?? []) as EventTarget[]
+                    for (const t of path) {
+                        const el = t as HTMLAnchorElement
+                        if (
+                            el?.tagName === 'A' &&
+                            isExternal(el.getAttribute?.('href'))
+                        ) {
+                            log('anchor.click', String(el.getAttribute('href')))
+                            e.preventDefault()
+                            e.stopImmediatePropagation()
+                            return
+                        }
+                    }
+                },
+                true,
+            )
+        })
+
         // Enable Web Audio mixing for clean streaming (KISS approach!)
         // Check config directly, not Streaming.instance (which may not be instantiated yet)
         if (GLOBAL.get().streaming_output) {
             try {
                 await enableTeamsAudioCapture(page)
-                console.log('[Teams] ✅ Web Audio capture enabled for streaming')
+                console.log(
+                    '[Teams] ✅ Web Audio capture enabled for streaming',
+                )
             } catch (error) {
-                console.error('[Teams] Failed to enable audio capture, continuing without it:', formatError(error))
+                console.error(
+                    '[Teams] Failed to enable audio capture, continuing without it:',
+                    formatError(error),
+                )
             }
         } else {
-            console.log('[Teams] ℹ️ Streaming not configured, skipping audio capture setup')
+            console.log(
+                '[Teams] ℹ️ Streaming not configured, skipping audio capture setup',
+            )
         }
 
         try {
@@ -144,7 +303,9 @@ export class TeamsProvider implements MeetingProviderInterface {
 
             // Teams now almost always renders in light mode, so we accept it and continue
             if (isLightInterface) {
-                console.log('🥕 Light interface detected (expected), continuing...')
+                console.log(
+                    '🥕 Light interface detected (expected), continuing...',
+                )
             }
 
             return page
@@ -152,7 +313,9 @@ export class TeamsProvider implements MeetingProviderInterface {
             console.error('Error in openMeetingPage:', formatError(error))
             // Mark as retryable - bot hasn't joined yet, so retrying is safe
             // Worst case: 3 attempts (1 initial + 2 retries) before giving up
-            console.log('🔄 Error occurred before joining - marking as retryable')
+            console.log(
+                '🔄 Error occurred before joining - marking as retryable',
+            )
             GLOBAL.setShouldRetry(true)
             throw error
         }
@@ -369,7 +532,9 @@ export class TeamsProvider implements MeetingProviderInterface {
 
         // Final stop check before the irreversible "Join now" click
         if (cancelCheck()) {
-            console.log('Stop request detected before clicking Join now — aborting')
+            console.log(
+                'Stop request detected before clicking Join now — aborting',
+            )
             GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
             throw new Error('Bot stopped before joining meeting')
         }
@@ -430,7 +595,10 @@ export class TeamsProvider implements MeetingProviderInterface {
             try {
                 await verifyTeamsAudioCapture(page)
             } catch (error) {
-                console.error('[Teams] Failed to verify audio capture post-join:', formatError(error))
+                console.error(
+                    '[Teams] Failed to verify audio capture post-join:',
+                    formatError(error),
+                )
             }
         }
 
@@ -480,7 +648,10 @@ export class TeamsProvider implements MeetingProviderInterface {
                 }
             }
         } catch (e) {
-            console.error('Error handling "View" or "Speaker" mode:', formatError(e))
+            console.error(
+                'Error handling "View" or "Speaker" mode:',
+                formatError(e),
+            )
         }
     }
 
@@ -589,7 +760,7 @@ async function clickWithInnerText(
             }
 
             continueButton = await page.evaluate(
-                ({ innerText, htmlType, i, click }) => {
+                ({ innerText, htmlType, i }) => {
                     let elements: Element[] = []
                     const iframes = document.querySelectorAll('iframe')
 
@@ -615,18 +786,32 @@ async function clickWithInnerText(
                         )
                     }
 
-                    for (const elem of elements) {
-                        if (elem.textContent?.trim() === innerText) {
-                            if (click) {
-                                ;(elem as HTMLElement).click()
-                            }
-                            return true
-                        }
-                    }
-                    return false
+                    return elements.some(
+                        (elem) => elem.textContent?.trim() === innerText,
+                    )
                 },
-                { innerText, htmlType, i, click },
+                { innerText, htmlType, i },
             )
+
+            if (continueButton && click) {
+                const humanizeActive = Boolean(
+                    (page as unknown as { _original?: unknown })._original,
+                )
+                const humanized =
+                    humanizeActive &&
+                    (await clickButtonHumanized(page, htmlType, innerText))
+                if (!humanized) {
+                    await page.evaluate(
+                        ({ innerText, htmlType }) => {
+                            const el = Array.from(
+                                document.querySelectorAll(htmlType),
+                            ).find((e) => e.textContent?.trim() === innerText)
+                            ;(el as HTMLElement | undefined)?.click()
+                        },
+                        { innerText, htmlType },
+                    )
+                }
+            }
         } catch (e) {
             if (i === iterations - 1) {
                 console.error(
@@ -650,6 +835,29 @@ async function clickWithInnerText(
         i++
     }
     return continueButton
+}
+
+async function clickButtonHumanized(
+    page: Page,
+    htmlType: string,
+    innerText: string,
+): Promise<boolean> {
+    const escaped = innerText.replace(/"/g, '\\"')
+    const selectors = [
+        `${htmlType}:text-is("${escaped}")`,
+        `${htmlType}:has-text("${escaped}")`,
+    ]
+    for (const selector of selectors) {
+        try {
+            const locator = page.locator(selector).first()
+            if ((await locator.count()) === 0) continue
+            await locator.click({ timeout: 2000 })
+            return true
+        } catch {
+            // Try next selector, then caller DOM-click fallback.
+        }
+    }
+    return false
 }
 
 async function typeBotName(
@@ -683,7 +891,10 @@ async function typeBotName(
 
             await page.waitForTimeout(500)
         } catch (e) {
-            console.error(`Error typing bot name (attempt ${i + 1}):`, formatError(e))
+            console.error(
+                `Error typing bot name (attempt ${i + 1}):`,
+                formatError(e),
+            )
         }
     }
     throw new Error('Failed to type bot name')
@@ -728,7 +939,10 @@ async function isRemovedFromTheMeeting(page: Page): Promise<boolean> {
         }
         return false
     } catch (error) {
-        console.error('Error while checking meeting status:', formatError(error))
+        console.error(
+            'Error while checking meeting status:',
+            formatError(error),
+        )
         return false
     }
 }
@@ -743,9 +957,12 @@ async function isBotNotAccepted(page: Page): Promise<boolean> {
     const result = await teamsStateDetector.isDenied(page)
     if (result.matched) {
         const reason =
-            (result.pattern && 'reason' in result.pattern ? result.pattern.reason : undefined) ??
-            MeetingEndReason.BotNotAccepted
-        console.log(`Teams denial detected: "${result.matchedText}" -> ${reason}`)
+            (result.pattern && 'reason' in result.pattern
+                ? result.pattern.reason
+                : undefined) ?? MeetingEndReason.BotNotAccepted
+        console.log(
+            `Teams denial detected: "${result.matchedText}" -> ${reason}`,
+        )
         GLOBAL.setError(reason)
         return true
     }

--- a/src/meeting/teams/htmlCleaner.ts
+++ b/src/meeting/teams/htmlCleaner.ts
@@ -48,6 +48,27 @@ export class TeamsHtmlCleaner {
                 return document
             }
 
+            const CLEANUP_STYLE_ID = 'mbaas-teams-cleanup-style'
+            function injectCleanupStylesheet(documentRoot: Document) {
+                if (documentRoot.getElementById(CLEANUP_STYLE_ID)) return
+                const style = documentRoot.createElement('style')
+                style.id = CLEANUP_STYLE_ID
+                style.textContent = `
+                    [data-tid^="ufd_"],
+                    [data-tid^="callingAlert"],
+                    [data-tid$="-alert-container"],
+                    [data-severity],
+                    [role="alert"],
+                    .fui-Toast,
+                    .fui-Toaster { display: none !important; }
+                `
+                const head = documentRoot.head || documentRoot.documentElement
+                if (head) {
+                    head.appendChild(style)
+                    console.log('[Teams] Cleanup stylesheet injected')
+                }
+            }
+
             // Teams "light" web client (teams.live.com) uses a different DOM than
             // the classic client targeted above: there is no
             // app-layout-area--header, the video tiles are not 137x245, and the
@@ -154,6 +175,7 @@ export class TeamsHtmlCleaner {
                 console.log('[Teams] Starting removeInitialShityHtml')
                 await new Promise((resolve) => setTimeout(resolve, 1000))
                 const documentRoot = getDocumentRoot()
+                injectCleanupStylesheet(documentRoot)
                 try {
                     const meetingControls = documentRoot.querySelectorAll(
                         `div[data-tid="app-layout-area--header"]`,
@@ -203,6 +225,7 @@ export class TeamsHtmlCleaner {
             function removeShityHtml() {
                 console.log('[Teams] Starting removeShityHtml')
                 const documentRoot = getDocumentRoot()
+                injectCleanupStylesheet(documentRoot)
                 try {
                     const menus = documentRoot.querySelectorAll('[role="menu"]')
                     const menu = menus[0] || menus

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -125,7 +125,9 @@ export class ScreenRecorder extends EventEmitter {
     private config: ScreenRecordingConfig
     private isRecording: boolean = false
     private filesUploaded: boolean = false
+    private recordingStartTime: number = 0
     private meetingStartTime: number = 0
+    private syncSignalTimestamp: number = 0
     private gracePeriodActive: boolean = false
     private rawAudioPath: string = ''
     private streamingSampleRate: number = DEFAULT_STREAMING_SAMPLE_RATE
@@ -198,7 +200,8 @@ export class ScreenRecorder extends EventEmitter {
             })
 
             this.isRecording = true
-            GLOBAL.setRecordingStartTime(Date.now())
+            this.recordingStartTime = Date.now()
+            GLOBAL.setRecordingStartTime(this.recordingStartTime)
             this.gracePeriodActive = false
             this.logMemoryUsage('Starting recording')
             this.setupProcessMonitoring()
@@ -215,6 +218,7 @@ export class ScreenRecorder extends EventEmitter {
                 )
                 return
             }
+            this.syncSignalTimestamp = Date.now()
             await generateSyncSignal(page, {
                 duration: 800, // Much longer signal for reliable detection
                 frequency: 1000, // Keep 1000Hz for consistency
@@ -1190,13 +1194,21 @@ export class ScreenRecorder extends EventEmitter {
             console.warn('⚠️ Raw audio file not found:', rawAudioPath)
         }
 
-        // 1. Calculate sync offset (using your existing calculation)
+        const expectedSyncSec =
+            this.syncSignalTimestamp > 0
+                ? (this.syncSignalTimestamp - this.recordingStartTime) / 1000
+                : FLASH_SCREEN_SLEEP_TIME / 1000
+        console.log(
+            `🎯 Sync signal expected at ${expectedSyncSec.toFixed(3)}s into recording`,
+        )
+
         const syncResult = await calculateVideoOffset(
             rawAudioPath,
             rawVideoPath,
+            expectedSyncSec,
         )
         console.log(
-            `🎯 Calculated sync offset: ${syncResult.offsetSeconds.toFixed(3)}s`,
+            `🎯 Calculated A/V stream offset: ${syncResult.offsetSeconds.toFixed(3)}s`,
         )
         const hasMeetingStartTime = this.meetingStartTime > 0
 
@@ -1230,13 +1242,9 @@ export class ScreenRecorder extends EventEmitter {
             }
         }
 
-        // 3. Calculate final trim points using meeting timing
-        const calcOffsetVideo =
-            syncResult.videoTimestamp +
-            (this.meetingStartTime -
-                GLOBAL.getRecordingStartTime() -
-                FLASH_SCREEN_SLEEP_TIME) /
-                1000
+        const rawCalcOffsetVideo =
+            (this.meetingStartTime - this.recordingStartTime) / 1000
+        const calcOffsetVideo = Math.max(0, rawCalcOffsetVideo)
 
         console.log(`📊 Debug values:`)
         console.log(
@@ -1245,12 +1253,17 @@ export class ScreenRecorder extends EventEmitter {
         console.log(
             `   syncResult.audioTimestamp: ${syncResult.audioTimestamp}s`,
         )
+        console.log(`   expectedSyncSec: ${expectedSyncSec.toFixed(3)}s`)
         console.log(`   meetingStartTime: ${this.meetingStartTime}`)
-        console.log(`   recordingStartTime: ${GLOBAL.getRecordingStartTime()}`)
-        console.log(`   FLASH_SCREEN_SLEEP_TIME: ${FLASH_SCREEN_SLEEP_TIME}`)
+        console.log(`   recordingStartTime: ${this.recordingStartTime}`)
         console.log(
-            `   Time diff: ${(this.meetingStartTime - GLOBAL.getRecordingStartTime() - FLASH_SCREEN_SLEEP_TIME) / 1000}s`,
+            `   calcOffsetVideo (raw): ${rawCalcOffsetVideo.toFixed(3)}s -> clamped: ${calcOffsetVideo.toFixed(3)}s`,
         )
+        if (rawCalcOffsetVideo < 0) {
+            console.warn(
+                `⚠️ meetingStartTime preceded recordingStartTime by ${(-rawCalcOffsetVideo).toFixed(3)}s. Trimming from t=0.`,
+            )
+        }
 
         // 4. Calculate audio padding needed (can be negative for trimming)
         const audioPadding =

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -85,66 +85,56 @@ export class InCallState extends BaseState {
             throw new Error('Playwright page not initialized')
         }
 
-        try {
-            console.log(
-                'Setting up browser components with integrated HTML cleanup...',
-            )
+        console.log(
+            'Setting up browser components with integrated HTML cleanup...',
+        )
 
-            // Set meetingStartTime for clean video output
-            // This is set here (not in joinMeeting) to ensure clean video output
-            const startTime = Date.now()
-            this.context.startTime = startTime
-            ScreenRecorderManager.getInstance().setMeetingStartTime(startTime)
-            console.log(
-                `Meeting start time set to: ${startTime} (${new Date(startTime).toISOString()})`,
-            )
+        // Set meetingStartTime for clean video output
+        // This is set here (not in joinMeeting) to ensure clean video output
+        const startTime = Date.now()
+        this.context.startTime = startTime
+        ScreenRecorderManager.getInstance().setMeetingStartTime(startTime)
+        console.log(
+            `Meeting start time set to: ${startTime} (${new Date(startTime).toISOString()})`,
+        )
 
-
-            // OPTIMIZATION: Start HTML Cleaner FIRST to surface video on top
-            // This ensures video is at z-index: 900000 before other actions
-            await this.startHtmlCleaning()
-
-            // Start speakers observation in all cases
-            // Speakers observation is independent of video recording
-            try {
-                await this.startSpeakersObservation()
-            } catch (error) {
+        // Make HTML cleanup non-blocking so as to avoid aborting a valid
+        // recording when Teams' page is slow, broken, or unresponsive during setup.
+        // Speakers observation is also independent of recording, so keep it off the
+        // critical setup path and let RecordingState decide when the bot should leave.
+        void this.startHtmlCleaning()
+            .catch((error) =>
                 console.error(
-                    'Failed to start speakers observation:',
+                    'HTML cleanup failed (non-fatal, continuing):',
                     formatError(error),
-                )
-                // Continue even if speakers observation fails
-            }
-
-            // OPTIMIZATION: Move entry message and audio verification to async (non-blocking)
-            // These run after video is surfaced and recording has started
-            this.performNonBlockingActions().catch((err) => {
-                console.error(
-                    'Error in non-blocking actions:',
-                    formatError(err),
-                )
-            })
-
-            // Final gate: if a stop request arrived during setup, bail out
-            // before firing the recording event and transitioning to Recording state
-            if (GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord) {
-                throw new Error('Stop requested during recording setup — exiting before record')
-            }
-
-            // Notify that recording has started
-            Events.inCallRecording({ start_time: this.context.startTime })
-        } catch (error) {
-            console.error(
-                'Error in setupBrowserComponents:',
-                formatError(error, {
-                    hasPlaywrightPage: !!this.context.playwrightPage,
-                    recordingMode: GLOBAL.get().recording_mode,
-                    meetingProvider: GLOBAL.get().meetingProvider,
-                    botName: GLOBAL.get().bot_name,
-                }),
+                ),
             )
-            throw new Error(`Browser component setup failed: ${error as Error}`)
+            .then(() =>
+                this.startSpeakersObservation().catch((error) =>
+                    console.error(
+                        'Speakers observation failed (non-fatal, continuing):',
+                        formatError(error),
+                    ),
+                ),
+            )
+
+        // OPTIMIZATION: Move entry message and audio verification to async (non-blocking)
+        // These run after video is surfaced and recording has started
+        this.performNonBlockingActions().catch((err) => {
+            console.error(
+                'Error in non-blocking actions:',
+                formatError(err),
+            )
+        })
+
+        // Final gate: if a stop request arrived during setup, bail out
+        // before firing the recording event and transitioning to Recording state
+        if (GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord) {
+            throw new Error('Stop requested during recording setup — exiting before record')
         }
+
+        // Notify that recording has started
+        Events.inCallRecording({ start_time: this.context.startTime })
     }
 
     /**

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -193,7 +193,17 @@ export class RecordingState extends BaseState {
                         : String(error)
             }
 
-            GLOBAL.setError(MeetingEndReason.StreamingSetupFailed, errorMessage)
+            const existingReason = GLOBAL.getEndReason()
+            if (existingReason) {
+                console.log(
+                    `Preserving existing end_reason ${existingReason} instead of overriding with StreamingSetupFailed`,
+                )
+            } else {
+                GLOBAL.setError(
+                    MeetingEndReason.StreamingSetupFailed,
+                    errorMessage,
+                )
+            }
             this.isProcessing = false
         })
 

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -78,7 +78,9 @@ export class WaitingRoomState extends BaseState {
 
             // Start recording early to capture entire bot lifecycle
             // Recording will be cropped based on meetingStartTime anyway
-            ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
+            ScreenRecorderManager.getInstance().startRecording(
+                this.context.playwrightPage,
+            )
 
             // Send waiting room event after the page is open
             Events.inWaitingRoom()
@@ -162,7 +164,8 @@ export class WaitingRoomState extends BaseState {
 
         const cancelCheck = () =>
             GLOBAL.getEndReason() === MeetingEndReason.ApiRequest ||
-            GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord
+            GLOBAL.getEndReason() ===
+                MeetingEndReason.ExitingMeetingBeforeRecord
 
         // Run the slow, humanised pre-join interactions (dismiss dialogs, type
         // bot name, toggle mic/cam) BEFORE the scheduled-time wait below, so that
@@ -183,19 +186,26 @@ export class WaitingRoomState extends BaseState {
         // (e.g. "You can't join this video call" → auto-redirect to workspace.google.com).
         // Only check for Meet — Teams URLs are on a different domain and would false-positive.
         const isMeet = GLOBAL.get().meetingProvider === 'Meet'
-        const startTime = await handleTimingControl(GLOBAL.get().start_time, isMeet ? async () => {
-            const url = this.context.playwrightPage?.url() ?? ''
-            if (url && !url.includes('meet.google.com')) {
-                console.log(`Page navigated away from Meet during timing wait: ${url}`)
-                GLOBAL.setShouldRetry(true)
-                GLOBAL.setError(
-                    MeetingEndReason.BotNotAccepted,
-                    'Google Meet denied entry - page redirected during scheduled wait',
-                )
-                return true
-            }
-            return false
-        } : undefined)
+        const startTime = await handleTimingControl(
+            GLOBAL.get().start_time,
+            isMeet
+                ? async () => {
+                      const url = this.context.playwrightPage?.url() ?? ''
+                      if (url && !url.includes('meet.google.com')) {
+                          console.log(
+                              `Page navigated away from Meet during timing wait: ${url}`,
+                          )
+                          GLOBAL.setShouldRetry(true)
+                          GLOBAL.setError(
+                              MeetingEndReason.BotNotAccepted,
+                              'Google Meet denied entry - page redirected during scheduled wait',
+                          )
+                          return true
+                      }
+                      return false
+                  }
+                : undefined,
+        )
 
         // If the abort check detected a denial during the wait, bail out immediately
         if (GLOBAL.getEndReason() === MeetingEndReason.BotNotAccepted) {
@@ -228,7 +238,8 @@ export class WaitingRoomState extends BaseState {
                 if (
                     GLOBAL.getEndReason() === MeetingEndReason.ApiRequest ||
                     GLOBAL.getEndReason() === MeetingEndReason.LoginRequired ||
-                    GLOBAL.getEndReason() === MeetingEndReason.ExitingMeetingBeforeRecord
+                    GLOBAL.getEndReason() ===
+                        MeetingEndReason.ExitingMeetingBeforeRecord
                 ) {
                     clearInterval(checkStopSignal)
                     clearTimeout(timeout)
@@ -244,13 +255,9 @@ export class WaitingRoomState extends BaseState {
                     () => {
                         joinSuccessful = true
                         console.log('Join successful notification received')
-                        // Disable humanize immediately now that we're admitted
-                        // (Meet only — Teams/Zoom are never humanized). Restores
-                        // native Playwright page methods for fast in-meeting ops.
-                        if (
-                            this.context.playwrightPage &&
-                            GLOBAL.get().meetingProvider === 'Meet'
-                        ) {
+                        // Restore native Playwright page methods for fast
+                        // in-meeting ops. Safe no-op if page was not humanized.
+                        if (this.context.playwrightPage) {
                             dehumanize(this.context.playwrightPage)
                         }
                         // Stop routing through the residential upstream now

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -11,7 +11,9 @@ const execAsync = promisify(exec)
 
 // Configuration constants
 const EXPECTED_FREQUENCY = 1000
-const ANALYSIS_WINDOW = 10 // Analyze first 10 seconds
+const ANALYSIS_WINDOW = 10 // Analyze first 10 seconds (used as fallback upper bound)
+const SYNC_WINDOW_HALF_WIDTH_SEC = 0.5
+const VIDEO_SYNC_WINDOW_BACK_SEC = 2.0
 
 interface SyncOffset {
     /** Audio signal timestamp in seconds */
@@ -33,16 +35,26 @@ interface SyncOffset {
 export async function calculateVideoOffset(
     audioPath: string,
     videoPath: string,
+    expectedSyncSec: number,
 ): Promise<SyncOffset> {
-    console.log(`🔍 Analyzing sync signals (first ${ANALYSIS_WINDOW}s only)...`)
+    const searchMin = Math.max(0, expectedSyncSec - SYNC_WINDOW_HALF_WIDTH_SEC)
+    const searchMax = expectedSyncSec + SYNC_WINDOW_HALF_WIDTH_SEC
+    const videoSearchMin = Math.max(
+        0,
+        expectedSyncSec - VIDEO_SYNC_WINDOW_BACK_SEC,
+    )
+    const videoSearchMax = searchMax
+
+    console.log(
+        `🔍 Analyzing sync signals (audio ${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s, video ${videoSearchMin.toFixed(2)}s – ${videoSearchMax.toFixed(2)}s)...`,
+    )
     console.log(`   Audio: ${audioPath}`)
     console.log(`   Video: ${videoPath}`)
 
     try {
-        // Analyze both files in parallel
         const [audioTimestamp, videoTimestamp] = await Promise.all([
-            detectAudioBeep(audioPath),
-            detectVideoFlash(videoPath),
+            detectAudioBeep(audioPath, searchMin, searchMax),
+            detectVideoFlash(videoPath, videoSearchMin, videoSearchMax),
         ])
 
         // Validate that we found both signals
@@ -57,17 +69,27 @@ export async function calculateVideoOffset(
             )
         }
 
-        // If either signal is missing, use default values
         if (audioTimestamp <= 0 || videoTimestamp <= 0) {
-            const defaultResult: SyncOffset = {
-                audioTimestamp: audioTimestamp > 0 ? audioTimestamp : 0,
-                videoTimestamp: videoTimestamp > 0 ? videoTimestamp : 0,
+            const bothMissing = audioTimestamp <= 0 && videoTimestamp <= 0
+            const detected =
+                audioTimestamp > 0 ? audioTimestamp : videoTimestamp
+            const fallbackResult: SyncOffset = {
+                audioTimestamp: bothMissing ? 0 : detected,
+                videoTimestamp: bothMissing ? 0 : detected,
                 offsetSeconds: 0.0,
-                confidence: 0.1,
+                confidence: bothMissing ? 0.1 : 0.3,
             }
 
-            console.log(`✅ Using default offset: 0.000s (confidence: 10.0%)`)
-            return defaultResult
+            if (bothMissing) {
+                console.warn(
+                    '⚠️ Neither sync signal detected — assuming zero A/V offset',
+                )
+            } else {
+                console.warn(
+                    `⚠️ Only the ${audioTimestamp > 0 ? 'audio beep' : 'video flash'} was detected (at ${detected.toFixed(3)}s). Assuming simultaneous beep+flash → zero offset, no audio shift.`,
+                )
+            }
+            return fallbackResult
         }
 
         const offsetSeconds = videoTimestamp - audioTimestamp
@@ -107,14 +129,20 @@ export async function calculateVideoOffset(
 /**
  * Detect 1000Hz beep in audio file using FFmpeg spectral analysis
  */
-async function detectAudioBeep(audioPath: string): Promise<number> {
+async function detectAudioBeep(
+    audioPath: string,
+    searchMin: number,
+    searchMax: number,
+): Promise<number> {
     console.log(
-        `🔊 Detecting ${EXPECTED_FREQUENCY}Hz beep in first ${ANALYSIS_WINDOW}s of audio...`,
+        `🔊 Detecting ${EXPECTED_FREQUENCY}Hz beep in window [${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s]...`,
     )
+
+    const scanUntil = searchMax + 1
 
     try {
         // Method 1: Use silence detection to find audio activity
-        const silenceCmd = `ffmpeg -i "${audioPath}" -af "silencedetect=noise=-35dB:duration=0.01" -f null -t ${ANALYSIS_WINDOW} - 2>&1 | grep "silence_"`
+        const silenceCmd = `ffmpeg -i "${audioPath}" -af "silencedetect=noise=-35dB:duration=0.01" -f null -t ${scanUntil} - 2>&1 | grep "silence_"`
 
         try {
             const { stdout: silenceOutput } = await execAsync(silenceCmd)
@@ -122,19 +150,13 @@ async function detectAudioBeep(audioPath: string): Promise<number> {
                 .split('\n')
                 .filter((line) => line.includes('silence_'))
 
-            console.log(
-                `   Silence detection found ${lines.length} events in first ${ANALYSIS_WINDOW}s`,
-            )
-
-            // Look for the first significant audio activity (silence_end)
             for (const line of lines) {
                 const endMatch = line.match(/silence_end: ([0-9.]+)/)
                 if (endMatch) {
                     const time = parseFloat(endMatch[1])
-                    if (time > 0.01 && time < ANALYSIS_WINDOW) {
-                        // Avoid very early noise
+                    if (time >= searchMin && time <= searchMax) {
                         console.log(
-                            `   Found audio activity (likely bip) at ${time.toFixed(3)}s`,
+                            `   Found audio activity (likely beep) at ${time.toFixed(3)}s`,
                         )
                         return time
                     }
@@ -146,49 +168,34 @@ async function detectAudioBeep(audioPath: string): Promise<number> {
             )
         }
 
-        // Method 2: Use volume analysis to find the first significant audio peak
-        const volumeCmd = `ffmpeg -i "${audioPath}" -af "volumedetect" -f null -t ${ANALYSIS_WINDOW} - 2>&1`
-        const { stdout: volumeOutput } = await execAsync(volumeCmd)
+        const detailedCmd = `ffmpeg -i "${audioPath}" -af "silencedetect=noise=-50dB:duration=0.005" -f null -t ${scanUntil} - 2>&1 | grep "silence_end"`
+        try {
+            const { stdout: detailedOutput } = await execAsync(detailedCmd)
+            const detailedLines = detailedOutput
+                .split('\n')
+                .filter((line) => line.includes('silence_end'))
 
-        const maxVolumeMatch = volumeOutput.match(/max_volume: (-?[0-9.]+) dB/)
-        if (maxVolumeMatch) {
-            const maxVolume = parseFloat(maxVolumeMatch[1])
-            console.log(
-                `   Audio levels in first ${ANALYSIS_WINDOW}s: max=${maxVolume.toFixed(1)}dB`,
-            )
-
-            // If there's significant audio, use a more detailed analysis
-            if (maxVolume > -60) {
-                // Use a more sensitive silence detection
-                const detailedCmd = `ffmpeg -i "${audioPath}" -af "silencedetect=noise=-50dB:duration=0.005" -f null -t ${ANALYSIS_WINDOW} - 2>&1 | grep "silence_end"`
-                try {
-                    const { stdout: detailedOutput } =
-                        await execAsync(detailedCmd)
-                    const detailedLines = detailedOutput
-                        .split('\n')
-                        .filter((line) => line.includes('silence_end'))
-
-                    for (const line of detailedLines) {
-                        const match = line.match(/silence_end: ([0-9.]+)/)
-                        if (match) {
-                            const time = parseFloat(match[1])
-                            if (time > 0.01 && time < ANALYSIS_WINDOW) {
-                                console.log(
-                                    `   Found audio activity with detailed analysis at ${time.toFixed(3)}s`,
-                                )
-                                return time
-                            }
-                        }
+            for (const line of detailedLines) {
+                const match = line.match(/silence_end: ([0-9.]+)/)
+                if (match) {
+                    const time = parseFloat(match[1])
+                    if (time >= searchMin && time <= searchMax) {
+                        console.log(
+                            `   Found audio activity with detailed analysis at ${time.toFixed(3)}s`,
+                        )
+                        return time
                     }
-                } catch (e) {
-                    console.log(
-                        `   Detailed analysis failed: ${e instanceof Error ? e.message : 'Unknown error'}`,
-                    )
                 }
             }
+        } catch (e) {
+            console.log(
+                `   Detailed analysis failed: ${e instanceof Error ? e.message : 'Unknown error'}`,
+            )
         }
 
-        console.log(`   No sync bip detected in first ${ANALYSIS_WINDOW}s`)
+        console.log(
+            `   No beep detected in window [${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s]`,
+        )
         return 0
     } catch (error) {
         console.warn(`⚠️ Audio analysis failed: ${error}`)
@@ -200,14 +207,20 @@ async function detectAudioBeep(audioPath: string): Promise<number> {
  * Detect green flash in video file using color analysis
  * Much more reliable than scene detection for the specific green flash
  */
-async function detectVideoFlash(videoPath: string): Promise<number> {
+async function detectVideoFlash(
+    videoPath: string,
+    searchMin: number,
+    searchMax: number,
+): Promise<number> {
     console.log(
-        `💚 Detecting green flash using color analysis (first ${ANALYSIS_WINDOW}s)...`,
+        `💚 Detecting green flash in window [${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s]...`,
     )
+
+    const scanUntil = searchMax + 1
 
     try {
         // Use scene detection but filter by color characteristics
-        const sceneColorCmd = `ffmpeg -i "${videoPath}" -vf "select='gt(scene,0.02)',showinfo" -vsync 0 -f null -t ${ANALYSIS_WINDOW} - 2>&1 | grep -E "(pts_time|mean:)"`
+        const sceneColorCmd = `ffmpeg -i "${videoPath}" -vf "select='gt(scene,0.02)',showinfo" -vsync 0 -f null -t ${scanUntil} - 2>&1 | grep -E "(pts_time|mean:)"`
 
         try {
             const { stdout: sceneColorOutput } = await execAsync(sceneColorCmd)
@@ -242,8 +255,8 @@ async function detectVideoFlash(videoPath: string): Promise<number> {
                             Y < 160 &&
                             U < 80 &&
                             V < 60 &&
-                            currentTime > 1.0 &&
-                            currentTime < ANALYSIS_WINDOW
+                            currentTime >= searchMin &&
+                            currentTime <= searchMax
                         ) {
                             console.log(
                                 `   Found green flash at ${currentTime.toFixed(3)}s (color analysis)`,
@@ -264,16 +277,12 @@ async function detectVideoFlash(videoPath: string): Promise<number> {
 
         // Fallback: Use traditional scene detection if color analysis fails
         try {
-            const sceneCmd = `ffmpeg -i "${videoPath}" -vf "select='gt(scene,0.05)',showinfo" -f null -t ${ANALYSIS_WINDOW} - 2>&1 | grep "pts_time"`
+            const sceneCmd = `ffmpeg -i "${videoPath}" -vf "select='gt(scene,0.05)',showinfo" -f null -t ${scanUntil} - 2>&1 | grep "pts_time"`
 
             const { stdout: sceneResult } = await execAsync(sceneCmd)
             const lines = sceneResult
                 .split('\n')
                 .filter((line) => line.includes('pts_time'))
-
-            console.log(
-                `   Fallback: Found ${lines.length} scene changes in first ${ANALYSIS_WINDOW}s`,
-            )
 
             let bestFlashTime = 0
             let bestSceneValue = 0
@@ -288,8 +297,8 @@ async function detectVideoFlash(videoPath: string): Promise<number> {
 
                     // Look for significant changes after 0.5s
                     if (
-                        time > 0.5 &&
-                        time < ANALYSIS_WINDOW &&
+                        time >= searchMin &&
+                        time <= searchMax &&
                         sceneValue > bestSceneValue
                     ) {
                         bestFlashTime = time
@@ -310,7 +319,9 @@ async function detectVideoFlash(videoPath: string): Promise<number> {
             )
         }
 
-        console.log(`   No green flash detected in first ${ANALYSIS_WINDOW}s`)
+        console.log(
+            `   No green flash detected in window [${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s]`,
+        )
         return 0
     } catch (error) {
         console.warn(`⚠️ Video analysis failed: ${error}`)
@@ -327,7 +338,7 @@ async function testWithSampleFiles(): Promise<SyncOffset> {
     const videoPath =
         '/Users/philippedrion/OutOfIcloud/meeting-baas/meeting_bot/recording_server/recordings/test/output.mp4'
 
-    return calculateVideoOffset(audioPath, videoPath)
+    return calculateVideoOffset(audioPath, videoPath, 4.5)
 }
 
 /**

--- a/src/utils/SyncSignal.ts
+++ b/src/utils/SyncSignal.ts
@@ -155,7 +155,7 @@ async function generateVisualFlash(
             z-index: 999999;
             pointer-events: none;
             box-shadow: inset 0 0 30px ${flashColor};
-            opacity: 0.9;
+            opacity: 1;
         `
 
             document.body.appendChild(flashDiv)


### PR DESCRIPTION
## Summary
- run Teams joins through CloakBrowser on the v1 branch
- remove the Chrome runtime dependency from the bot image
- keep post-join HTML cleanup and speaker observation non-blocking so a slow or unresponsive meeting page does not abort recording startup

## Validation
- `NPM_CONFIG_CACHE=/data/lazrossi/.npm npm run build`