### PR TITLE
fix(recording): correct A/V trim bias, harden sync detection, compensate drift

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -387,6 +387,12 @@ export class ScreenRecorder extends EventEmitter {
       "-map",
       "1:a:0",
       "-vn",
+      // Stretch/pad audio to match capture timestamps: PulseAudio xruns and
+      // sample-clock drift otherwise accumulate against the wall-clock-paced
+      // video (x11grab dups/drops frames to hold 30fps), desyncing long
+      // recordings even when the start was aligned perfectly.
+      "-af",
+      "aresample=async=1:first_pts=0",
       "-sample_fmt",
       "s16",
       "-ac",
@@ -1263,6 +1269,16 @@ export class ScreenRecorder extends EventEmitter {
 
     const syncResult = await calculateVideoOffset(rawAudioPath, rawVideoPath, expectedSyncSec)
     console.log(`🎯 Calculated A/V stream offset: ${syncResult.offsetSeconds.toFixed(3)}s`)
+    if (syncResult.confidence < 0.9) {
+      // Alertable marker: sync-signal detection failed (fully or partially), so the
+      // A/V offset and capture-startup corrections below run degraded. Grep-able as
+      // SYNC_CONFIDENCE_LOW in bot logs.
+      console.warn(
+        `⚠️ SYNC_CONFIDENCE_LOW confidence=${syncResult.confidence.toFixed(2)} ` +
+          `audioTs=${syncResult.audioTimestamp.toFixed(3)} videoTs=${syncResult.videoTimestamp.toFixed(3)} ` +
+          `expected=${expectedSyncSec.toFixed(3)} — proceeding without measured correction`
+      )
+    }
     const hasMeetingStartTime = this.meetingStartTime > 0
 
     // 2. Check if meetingStartTime is properly set - if not, bot was not accepted
@@ -1292,7 +1308,30 @@ export class ScreenRecorder extends EventEmitter {
     //    This is purely timestamp arithmetic — no heuristic needed.
     //    For authenticated bots, meetingStartTime can be < recordingStartTime (the bot
     //    joins before FFmpeg finishes initialising); clamp to 0 in that case.
-    const rawCalcOffsetVideo = (this.meetingStartTime - this.recordingStartTime) / 1000
+    //
+    //    (meetingStartTime - recordingStartTime) is wall-clock arithmetic, but the trim
+    //    offset is applied in MEDIA time. FFmpeg needs time after spawn() to open
+    //    x11grab and capture its first frame, so media t=0 corresponds to
+    //    recordingStartTime + startupDelay, not recordingStartTime. Without correcting
+    //    for that, the whole video (and the diarization timeline, which counts from
+    //    meetingStartTime) leads the media by the startup delay for the entire meeting.
+    //    The flash measurement gives us that delay directly: the sync signal was
+    //    emitted expectedSyncSec after recordingStartTime (wall clock) but appears at
+    //    videoTimestamp in the file (media time). Only trust it when both signals were
+    //    detected (confidence >= 0.9) — the single-signal fallback fabricates
+    //    videoTimestamp from the beep, which would poison this correction.
+    const measuredStartupDelaySec =
+      syncResult.confidence >= 0.9 ? expectedSyncSec - syncResult.videoTimestamp : 0
+    // x11grab startup can't be negative and is typically 0.1–0.5s; clamp against
+    // detection outliers (VIDEO_SYNC_WINDOW_BACK_SEC allows matches up to 2s early).
+    const startupDelaySec = Math.min(Math.max(measuredStartupDelaySec, 0), 2.0)
+    if (measuredStartupDelaySec !== startupDelaySec) {
+      console.warn(
+        `⚠️ Measured capture startup delay ${measuredStartupDelaySec.toFixed(3)}s outside [0, 2.0]s — clamped to ${startupDelaySec.toFixed(3)}s`
+      )
+    }
+    const rawCalcOffsetVideo =
+      (this.meetingStartTime - this.recordingStartTime) / 1000 - startupDelaySec
     const calcOffsetVideo = Math.max(0, rawCalcOffsetVideo)
 
     console.log("📊 Debug values:")
@@ -1301,10 +1340,11 @@ export class ScreenRecorder extends EventEmitter {
     console.log(`   expectedSyncSec: ${expectedSyncSec.toFixed(3)}s`)
     console.log(`   meetingStartTime: ${this.meetingStartTime}`)
     console.log(`   recordingStartTime: ${this.recordingStartTime}`)
+    console.log(`   capture startup delay: ${startupDelaySec.toFixed(3)}s`)
     console.log(`   calcOffsetVideo (raw): ${rawCalcOffsetVideo.toFixed(3)}s → clamped: ${calcOffsetVideo.toFixed(3)}s`)
     if (rawCalcOffsetVideo < 0) {
       console.warn(
-        `⚠️ meetingStartTime preceded recordingStartTime by ${(-rawCalcOffsetVideo).toFixed(3)}s (authenticated bot fast-join). Trimming from t=0.`
+        `⚠️ Meeting start precedes media t=0 by ${(-rawCalcOffsetVideo).toFixed(3)}s (authenticated bot fast-join and/or capture startup delay). Trimming from t=0.`
       )
     }
 

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -153,9 +153,17 @@ async function detectAudioBeep(audioPath: string, searchMin: number, searchMax: 
   // Scan slightly beyond the window to capture events right at the boundary.
   const scanUntil = searchMax + 1
 
+  // Band-limit around the 1000Hz sync tone before detecting activity. Without this,
+  // ANY audio above the threshold in the window is taken as the beep (a join chime,
+  // someone talking), and conversely continuous meeting audio before the beep means
+  // no silence_end ever fires and the beep is missed entirely. The beep is a pure
+  // near-full-scale 1kHz tone, so it survives the narrow band intact while broadband
+  // speech/chimes are strongly attenuated.
+  const beepBandFilter = `highpass=f=${EXPECTED_FREQUENCY - 150},lowpass=f=${EXPECTED_FREQUENCY + 150}`
+
   try {
-    // Method 1: Use silence detection to find audio activity
-    const silenceCmd = `ffmpeg -i "${audioPath}" -af "silencedetect=noise=-35dB:duration=0.01" -f null -t ${scanUntil} - 2>&1 | grep "silence_"`
+    // Method 1: Use silence detection to find audio activity in the beep band
+    const silenceCmd = `ffmpeg -i "${audioPath}" -af "${beepBandFilter},silencedetect=noise=-35dB:duration=0.01" -f null -t ${scanUntil} - 2>&1 | grep "silence_"`
 
     try {
       const { stdout: silenceOutput } = await execAsync(silenceCmd)
@@ -177,8 +185,8 @@ async function detectAudioBeep(audioPath: string, searchMin: number, searchMax: 
       )
     }
 
-    // Method 2: More sensitive silence detection
-    const detailedCmd = `ffmpeg -i "${audioPath}" -af "silencedetect=noise=-50dB:duration=0.005" -f null -t ${scanUntil} - 2>&1 | grep "silence_end"`
+    // Method 2: More sensitive silence detection (still band-limited to the tone)
+    const detailedCmd = `ffmpeg -i "${audioPath}" -af "${beepBandFilter},silencedetect=noise=-50dB:duration=0.005" -f null -t ${scanUntil} - 2>&1 | grep "silence_end"`
     try {
       const { stdout: detailedOutput } = await execAsync(detailedCmd)
       const detailedLines = detailedOutput.split("\n").filter((line) => line.includes("silence_end"))

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -24,6 +24,13 @@ const SYNC_WINDOW_HALF_WIDTH_SEC = 0.5
 // detector makes an early false positive very unlikely (pre-join UI isn't
 // fullscreen green).
 const VIDEO_SYNC_WINDOW_BACK_SEC = 2.0
+// The flash can also land LATE: on a heavy Meet page the paint is delayed by the
+// renderer/compositor. Prod logs show flashes up to ~450ms after the expected
+// timestamp — right at the old +0.5s edge — and recordings where the flash was
+// missed entirely (shipping with zero A/V correction). Give the flash more
+// forward room too; the strict green + scene-change detector keeps false
+// positives unlikely (in-meeting content isn't fullscreen #00FF00).
+const VIDEO_SYNC_WINDOW_FWD_SEC = 1.0
 
 interface SyncOffset {
   /** Audio signal timestamp in seconds */
@@ -53,9 +60,9 @@ export async function calculateVideoOffset(
 ): Promise<SyncOffset> {
   const searchMin = Math.max(0, expectedSyncSec - SYNC_WINDOW_HALF_WIDTH_SEC)
   const searchMax = expectedSyncSec + SYNC_WINDOW_HALF_WIDTH_SEC
-  // Wider, downward-biased window for the flash (see VIDEO_SYNC_WINDOW_BACK_SEC).
+  // Wider window for the flash (see VIDEO_SYNC_WINDOW_BACK_SEC / _FWD_SEC).
   const videoSearchMin = Math.max(0, expectedSyncSec - VIDEO_SYNC_WINDOW_BACK_SEC)
-  const videoSearchMax = searchMax
+  const videoSearchMax = expectedSyncSec + VIDEO_SYNC_WINDOW_FWD_SEC
 
   console.log(
     `🔍 Analyzing sync signals (audio ${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s, video ${videoSearchMin.toFixed(2)}s – ${videoSearchMax.toFixed(2)}s)...`


### PR DESCRIPTION
## Problem

Three A/V sync defects in the recording pipeline:

1. **Systematic trim bias (whole-meeting lead).** `calcOffsetVideo` assumes video file t=0 equals `recordingStartTime` (`Date.now()` right after `spawn()`), but FFmpeg takes 100–500ms to open x11grab and capture its first frame — media t=0 is later than `recordingStartTime`. The final video therefore actually starts *after* `meetingStartTime`, while `diarization.jsonl` timestamps are `(wallClock − meetingStartTime)`, so speaker segments lead the media by the startup delay, constantly, for the entire meeting.

2. **Detection failure → silently zero correction.** Beep detection was `silencedetect` on the raw capture: any activity above −35dB in the ±0.5s window (a Meet join chime, someone talking) was taken as the beep; conversely, continuous meeting audio before the beep meant no `silence_end` ever fired and the beep was missed → offset 0, confidence 0.1. The caller ignored confidence and proceeded as if synced, shipping the raw pulse-vs-x11grab capture offset uncorrected, with no alertable signal.

3. **One-shot sync, no drift correction.** The beep/flash only aligns t≈4.5s. Audio length follows the Pulse sample clock; video follows wall clock (x11grab dups/drops frames to hold 30fps). Pulse xruns / sample-rate drift accumulate over long meetings — fine at start, off by hundreds of ms after an hour.

## Fix

1. Apply the flash-measured startup delay to the final trim: `startupDelay = expectedSyncSec − syncResult.videoTimestamp`, subtracted from `calcOffsetVideo`. Gated on `confidence >= 0.9` (the single-signal fallback fabricates `videoTimestamp` from the beep, which would poison the correction) and clamped to `[0, 2]s` (x11grab startup can't be negative; `VIDEO_SYNC_WINDOW_BACK_SEC` allows matches up to 2s early).

2. Band-limit beep detection to 1000Hz ± 150Hz (`highpass`/`lowpass` before `silencedetect`) — the pure, near-full-scale sync tone survives intact while broadband speech/chimes are strongly attenuated, and in-band silence before the beep is restored so `silence_end` fires. Log a grep-able `SYNC_CONFIDENCE_LOW` warning with all measured values whenever `confidence < 0.9` instead of silently proceeding.

3. Add `-af aresample=async=1:first_pts=0` to the raw-audio capture output so audio samples are stretched/padded to match capture timestamps instead of drifting against the wall-clock-paced video.

## Known limitations (deliberately not addressed)

- Beep and flash aren't perfectly simultaneous at the source (`AudioContext` output latency ~20–50ms vs next-paint ~16–33ms). Constant bias of a few tens of ms, below perception; not worth chasing here.
- `finalTrimFromOffset` uses `-ss` + stream copy, so the video head is only decodable from the next keyframe (1s GOP) — up to ~1s frozen/black head, not drift. Snapping the trim to a keyframe without also shifting the diarization timeline would trade a cosmetic head for a real sync error, so left as-is.

## Testing

- `tsc --skipLibCheck -p tsconfig.release.json` clean.
- Jest: the 18 failures in `src/urlParser/*` fail identically on a clean `v2-improvements` checkout (verified via stash) — pre-existing, unrelated to this diff.
- No existing test coverage for the sync path; verification needs a real bot recording — check the new `capture startup delay` / `SYNC_CONFIDENCE_LOW` log lines on preprod.

## Field data: prod + preprod, Teams and Meet

Sampled sync logs from recent prod and preprod recordings (the currently shipped code already logs `expectedSyncSec` / beep / flash, so the correction this PR applies can be measured directly).

### Teams

| expected sync | flash (video) | beep (audio) | startup delay (exp − flash) | A/V offset applied |
|---|---|---|---|---|
| 4.502s | 4.467s | 4.376s | **35ms** | 90ms |
| 4.503s | 4.467s | 4.359s | **36ms** | 108ms |
| 4.503s | 4.433s | 4.396s | **70ms** | 37ms |
| 4.502s | 4.467s | 4.384s | **35ms** | 82ms |
| 4.502s | 4.467s | 4.370s | **35ms** | 96ms |

Tight and systematic: **35–70ms, mean ~42ms**, identical prod vs preprod. Teams recordings currently ship with the diarization timeline leading the media by that amount. (Flash timestamps quantize to 30fps frames, so granularity is ±33ms.)

### Meet

Noisier than Teams. Startup delay in the sample: typical **68–157ms, median ~102ms**, plus two instructive outliers:

- One recording measured **−452ms**: the flash painted at expected+452ms (heavy page at join time) → the `[0, 2]s` clamp correctly yields "no correction" instead of a wrong-direction trim.
- One recording where **neither signal was detected**: the meeting shipped with zero A/V offset and no way to correct — finding 2 observed live in prod.

Audio capture lag (expected − beep, handled by the existing `audioPadding` path): median ~160ms, up to 421ms. One recording's beep landed at the very edge of the search window with a 320ms offset applied — consistent with the false-positive pattern the bandpass in fix 2 targets (unprovable post-hoc without the raw audio).

### Averages across the sample

| metric | Teams | Meet | overall |
|---|---|---|---|
| startup delay = diarization lead removed by this PR (mean, after clamp) | **42ms** | **92ms** | **79ms** |
| audio capture lag (mean, handled by existing `audioPadding`) | 127ms | 167ms | 156ms |
| A/V offset applied (mean) | 83ms | 107ms | 101ms |

### What the data changed in this PR

- **Flash forward window widened to +1s** (follow-up commit): the −452ms recording's flash painted at the old +0.5s search edge, and the both-signals-missed recording is consistent with a flash landing beyond it. The strict green + scene-change detector keeps forward false positives unlikely — same rationale as the existing 2s backward widening.
- The `[0, 2]s` clamp proved itself on real data: late-paint recordings measure negative (`captureStartup − renderLatency`) and get "no correction" instead of a wrong-direction trim. The correction is a lower bound — it removes the systematic lead and never overshoots.
- Detection confidence was 0.9 on all but one sampled recording; that miss ships silently today and becomes an alertable `SYNC_CONFIDENCE_LOW` with this PR.

**Summary: recordings currently ship with speaker labels leading the media by ~35–70ms on Teams (systematic) and ~70–160ms typical on Meet (median ~100ms), with occasional full detection misses on Meet that ship uncorrected and unobserved. This PR removes the measurable bias, widens the flash window that the misses point at, alerts on the rest, and stops long-meeting drift from accumulating on top.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)




