### PR TITLE
perf: cut per-bot encoder CPU and fix dead V8 heap flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Live capture encode switched from x264 preset `fast` to `veryfast`: ~40% less
+  encoder CPU per bot at the same crf 23, near-identical quality on meeting
+  content, output ~10-15% larger.
+
+### Fixed
+- V8 heap cap for large meetings (`--max-old-space-size=4096`) was passed as a
+  bare Chromium argument and silently ignored; now passed via `--js-flags`.
+
 ### Added
 - Initial open source release
 - Comprehensive documentation and README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- Live capture encode switched from x264 preset `fast` to `veryfast`: ~40% less
-  encoder CPU per bot at the same crf 23, near-identical quality on meeting
-  content, output ~10-15% larger.
-
 ### Fixed
 - V8 heap cap for large meetings (`--max-old-space-size=4096`) was passed as a
   bare Chromium argument and silently ignored; now passed via `--js-flags`.
@@ -24,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker support for easy deployment
 
 ### Changed
+- Live capture encode switched from x264 preset `fast` to `veryfast`: ~40% less
+  encoder CPU per bot at the same crf 23, near-identical quality on meeting
+  content, output ~10-15% larger.
 - Translated all French comments to English
 - Updated project metadata for open source
 - Improved code organization and structure

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -67,7 +67,9 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
     "--disable-background-timer-throttling",
     "--enable-features=SharedArrayBuffer",
     "--memory-pressure-off", // Disable memory pressure handling for consistent performance
-    "--max_old_space_size=4096", // Increase V8 heap size to 4GB for large meetings
+    // V8 heap cap for large meetings. Must be passed via --js-flags: a bare
+    // --max_old_space_size argument is not a Chromium switch and is silently ignored.
+    "--js-flags=--max-old-space-size=4096",
     "--disable-background-networking", // Reduce background network activity
     "--disable-features=TranslateUI", // Disable translation features to save resources
     "--disable-features=AutofillServerCommunication", // Disable autofill to reduce network usage

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -366,7 +366,12 @@ export class ScreenRecorder extends EventEmitter {
       "-c:v",
       "libx264",
       "-preset",
-      "fast",
+      // veryfast: ~40% less encoder CPU than "fast" at the same crf, with
+      // near-identical visual quality on meeting content (mostly static
+      // talking heads / shared screens). Output is ~10-15% larger, which is
+      // cheap S3 vs compute: the encoder is the biggest steady CPU draw of
+      // the bot, and lower per-bot CPU lets more bots share a node.
+      "veryfast",
       "-crf",
       "23",
       "-profile:v",


### PR DESCRIPTION
- x264 live-capture preset `fast` → `veryfast`: ~40% less encoder CPU at the same crf 23; near-identical quality on meeting content; output ~10–15% larger (S3 ≪ compute). Prod sampling caught bots pegged at their 4-CPU limit with `fast` — those recordings are CFS-throttled today; this relieves them and is a prerequisite for higher bot density per node.
- `--max_old_space_size=4096` was passed as a bare Chromium arg — not a Chromium switch, silently ignored. Now `--js-flags=--max-old-space-size=4096` so the intended 4GB V8 heap cap actually applies. Note: first time this cap becomes active; prod-observed bot RSS max 1.9Gi, pod limit 8Gi.

Validation: packed-node 4h-meeting A/B harness in meeting-baas-v2 `feat/recording-optimization` (`scripts/preprod-pack-test.sh`); edge cases VF-1..3 / JS-1 in the matrix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)