### PR TITLE
fix: recover audio routing when capture goes silent

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -29,6 +29,7 @@ const MIN_AUDIO_CHUNK_SIZE = 100 * 1024 // 100KB
 // Environment variables for display and virtual speaker monitor
 const DISPLAY = envVars.DISPLAY
 const VIRTUAL_SPEAKER_MONITOR = envVars.VIRTUAL_SPEAKER_MONITOR
+const VIRTUAL_SPEAKER = envVars.VIRTUAL_SPEAKER
 
 const UPLOAD_AUDIO_CHUNKS = envVars.UPLOAD_AUDIO_CHUNKS
 const UPLOAD_RAW_VIDEO = envVars.UPLOAD_RAW_VIDEO
@@ -118,6 +119,8 @@ export class ScreenRecorder extends EventEmitter {
   private gracePeriodActive = false
   private rawAudioPath = ""
   private soundMonitorRemainder: Buffer = Buffer.alloc(0)
+  private lastAudioRecoveryAt = 0
+  private audioRecoveryAttempts = 0
 
   constructor(config: Partial<ScreenRecordingConfig> = {}) {
     super()
@@ -715,6 +718,13 @@ export class ScreenRecorder extends EventEmitter {
             console.warn(
               `⚠️ WARNING: Raw audio file has not grown for ${consecutiveNoGrowthCount * (FILE_SIZE_CHECK_INTERVAL / 1000)}s! Current: ${sizeMB} MB (${currentSize} bytes) | Recording: ${recordingDurationSeconds.toFixed(1)}s. This may indicate a silent write failure.`
             )
+            // Dead audio is usually Chrome's stream sitting on the wrong PulseAudio
+            // sink (startup race, or a mid-call detach) so FFmpeg reads silence from
+            // virtual_speaker.monitor. Try to re-home the browser audio onto the
+            // monitored sink instead of just logging — this is what actually recovers
+            // the recording (silent audio otherwise produces a mute file and a false
+            // noSpeaker leave).
+            this.attemptAudioRecovery(recordingDurationSeconds)
           } else {
             console.log(
               `📊 Raw audio file size: ${sizeMB} MB (${currentSize} bytes) | Recording: ${recordingDurationSeconds.toFixed(1)}s | No growth detected (${consecutiveNoGrowthCount}/${MAX_CONSECUTIVE_NO_GROWTH})`
@@ -731,6 +741,70 @@ export class ScreenRecorder extends EventEmitter {
         }
       }
     }, FILE_SIZE_CHECK_INTERVAL)
+  }
+
+  /**
+   * Re-route the browser's audio onto the monitored PulseAudio sink.
+   *
+   * FFmpeg records from `virtual_speaker.monitor`. Chrome is meant to output to
+   * `virtual_speaker` (the default sink), but its audio stream can bind to the
+   * wrong sink — a race between `pulseaudio --start` / `set-default-sink` and
+   * Chrome creating its stream at startup, or a mid-call renegotiation (common on
+   * the Teams web client) that detaches and re-attaches the audio element. When
+   * that happens the monitor sees no samples, the raw file never grows, and the
+   * recording is silent. Re-assert the default sink (so any *new* streams route
+   * correctly) and move every live sink-input onto `virtual_speaker` (so the
+   * *current* stream flows into the monitor again). Throttled to one attempt per
+   * check interval; best-effort — failures are logged, never thrown.
+   */
+  private attemptAudioRecovery(recordingDurationSeconds: number): void {
+    const now = Date.now()
+    // Throttle: at most one attempt per file-size check window (30s).
+    if (now - this.lastAudioRecoveryAt < 30_000) {
+      return
+    }
+    this.lastAudioRecoveryAt = now
+    this.audioRecoveryAttempts++
+
+    try {
+      // Re-assert the monitored sink as default for any newly-created streams.
+      execSync(`pactl set-default-sink ${VIRTUAL_SPEAKER}`, {
+        timeout: 5000,
+        stdio: "ignore"
+      })
+
+      // Move every existing sink-input onto the monitored sink. Chrome is the only
+      // audio-producing app in the container, so re-homing all inputs is safe and
+      // catches the case where its stream is stuck on a fallback/auto_null sink.
+      const listing = execSync("pactl list sink-inputs short", { timeout: 5000 })
+        .toString()
+        .trim()
+      const inputIds = listing
+        ? listing
+            .split("\n")
+            .map((line) => line.split("\t")[0])
+            .filter((id) => id.length > 0)
+        : []
+
+      let moved = 0
+      for (const id of inputIds) {
+        try {
+          execSync(`pactl move-sink-input ${id} ${VIRTUAL_SPEAKER}`, {
+            timeout: 5000,
+            stdio: "ignore"
+          })
+          moved++
+        } catch {
+          // A sink-input can disappear between listing and moving — ignore.
+        }
+      }
+
+      console.warn(
+        `🔧 [audio-recovery] Attempt ${this.audioRecoveryAttempts}: re-asserted default sink '${VIRTUAL_SPEAKER}' and moved ${moved}/${inputIds.length} sink-input(s) onto it (raw audio not growing at ${recordingDurationSeconds.toFixed(0)}s)`
+      )
+    } catch (error) {
+      console.warn(`⚠️ [audio-recovery] Failed to re-route audio: ${formatError(error)}`)
+    }
   }
 
   private async uploadAudioChunks(chunksDir: string, botUuid: string): Promise<void> {

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -647,6 +647,27 @@ export class RecordingState extends BaseState {
 
     const shouldEnd = silenceDurationSeconds >= silenceTimeoutSeconds
     if (shouldEnd) {
+      // The silence timer is driven purely by the audio pipeline (sound level from
+      // FFmpeg). When audio capture dies — e.g. Chrome's audio never lands on the
+      // virtual PulseAudio sink — the sound level reads 0 forever even while people
+      // are actively talking, so this "silence" is spurious. Leaving here ends the
+      // call mid-meeting and reports it as completed. Cross-check the DOM speaker
+      // observer, which detects speech independently of the audio pipeline: if it saw
+      // an active speaker within the silence window, treat the silence as an audio
+      // capture failure and do NOT leave. Genuinely empty/quiet meetings (no recent
+      // DOM speech) still end here; populated meetings still end via
+      // allParticipantsLeft / alone-in-meeting / botRemoved once people actually leave.
+      const lastSpeakerTime = this.context.lastSpeakerTime
+      const domSpeechAgeMs = lastSpeakerTime ? now - lastSpeakerTime : null
+      if (domSpeechAgeMs !== null && domSpeechAgeMs < silenceTimeoutSeconds * 1000) {
+        if (now - this.lastNoSpeakerLogTime >= 30000) {
+          console.warn(
+            `[checkNoSpeaker] Audio silent for ${silenceDurationSeconds}s but DOM speaker observer saw speech ${Math.floor(domSpeechAgeMs / 1000)}s ago — audio capture likely failed; NOT ending on noSpeaker`
+          )
+          this.lastNoSpeakerLogTime = now
+        }
+        return false
+      }
       console.log(
         `[checkNoSpeaker] No sound activity detected for ${silenceDurationSeconds} seconds, ending meeting`
       )

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -657,9 +657,19 @@ export class RecordingState extends BaseState {
       // capture failure and do NOT leave. Genuinely empty/quiet meetings (no recent
       // DOM speech) still end here; populated meetings still end via
       // allParticipantsLeft / alone-in-meeting / botRemoved once people actually leave.
+      // Only trust the DOM signal when the observer is healthy (delivered a callback
+      // recently), mirroring checkAloneInMeeting — a dead observer's stale
+      // lastSpeakerTime must not suppress the leave indefinitely.
       const lastSpeakerTime = this.context.lastSpeakerTime
+      const lastCallbackTime = SpeakerManager.getInstance().getLastCallbackTime()
+      const speakerObserverHealthy =
+        lastCallbackTime !== null && now - lastCallbackTime < SPEAKER_OBSERVER_HEALTH_WINDOW_MS
       const domSpeechAgeMs = lastSpeakerTime ? now - lastSpeakerTime : null
-      if (domSpeechAgeMs !== null && domSpeechAgeMs < silenceTimeoutSeconds * 1000) {
+      if (
+        speakerObserverHealthy &&
+        domSpeechAgeMs !== null &&
+        domSpeechAgeMs < silenceTimeoutSeconds * 1000
+      ) {
         if (now - this.lastNoSpeakerLogTime >= 30000) {
           console.warn(
             `[checkNoSpeaker] Audio silent for ${silenceDurationSeconds}s but DOM speaker observer saw speech ${Math.floor(domSpeechAgeMs / 1000)}s ago — audio capture likely failed; NOT ending on noSpeaker`


### PR DESCRIPTION
## Problem

Customer report: bots join, record a few minutes, then leave mid-meeting — the portal shows **"meeting completed."** Recording is silent and truncated.

## Root cause — two stacked defects

**1. Audio capture produces zero bytes (the trigger).**
Chrome launches with PulseAudio and the app logs `✅ Audio device ready`, but the browser's meeting audio never lands on the `virtual_speaker` sink that FFmpeg records from. The raw audio file (`raw.flac`) stays **0 bytes for the whole meeting**. The existing raw-audio watchdog *detects* this (`⚠️ Raw audio file has not grown …`) but only logs a warning — no recovery, no state change. So the recording stays mute.

Why the sink can be wrong: Chrome's audio stream can bind to the wrong sink — a startup race between `pulseaudio --start` / `set-default-sink` and Chrome creating its stream, or a mid-call renegotiation on the Teams web client that detaches/re-attaches the audio element. `set-default-sink` only affects streams at connect time; an already-connected stream stays put, and there was no remediation.

**2. Silence auto-leave has no cross-check (the premature exit).**
`SoundLevelMonitor` reads that dead FFmpeg stream → sound level `0` forever. `checkNoSpeaker` keys **only** on sound level, so it hits `silence_timeout` and ends the call as `noSpeaker` — a *normal* end reason → portal renders **"meeting completed."** Meanwhile the DOM speaker observer *knew* people were speaking (`isSpeaking: true` in `speaker_separation.log`) — that signal was ignored by the leave logic.

## What this PR changes

**`ScreenRecorder` — recover the routing (the real fix).**
On confirmed raw-audio no-growth, re-assert the default sink and `move-sink-input` every live sink-input onto `virtual_speaker`, so the browser audio flows into the monitored sink again. Throttled to one attempt per check window, best-effort (failures logged, never thrown). Chrome is the only audio-producing app in the container, so re-homing all inputs is safe.

**`recording-state` — don't false-leave while recovering.**
Before ending on silence, `checkNoSpeaker` cross-checks `context.lastSpeakerTime` (DOM speaker observer, independent of the audio pipeline). If it saw an active speaker within the silence window, the "silence" is a capture failure, not an empty meeting → don't leave. Genuinely empty/quiet meetings still end here; populated meetings still end via `allParticipantsLeft` / `alone-in-meeting` / `botRemoved` once people actually leave.

## Evidence (S3 recorder logs)

Signature confirmed across multiple prod bots over recent weeks: `sound.log` flat `0` the entire recording (raw audio 0-growth), DOM `speaker_separation.log` showing `isSpeaking: true`, exit reason `noSpeaker`. Mostly **Teams**, one **Meet** — so audio-capture-failure is Teams-dominant but not exclusive.

Representative bots:
- `49ba6210-df6d-4f6a-890c-625d46b16fd7` — Teams, silent the whole meeting (audio stuck on wrong sink), DOM showed active speaker, left `noSpeaker`. The watchdog logged `Raw audio file has not grown` from 90s to 510s and took no action.
- `61b22efe-a0fc-4e4b-8f71-333258c36178` — Teams, audio was **intermittent**: 0 bytes for ~330s, then resumed, then stalled again. Proves the stream can re-home on its own — a forced re-route should recover it faster.

## Notes / caveats

- **Not yet run live.** Types + build check clean, but this needs a preprod bot to confirm `move-sink-input` actually re-homes Chrome's stream and audio starts flowing. Recovery is best-effort by design.
- The existing `audioWarning` event (FFmpeg PulseAudio stderr errors) is a *different, log-only* detector — complementary, no conflict with this change.

@coderabbitai please review — particularly the PulseAudio `move-sink-input` recovery (correctness/safety of moving all sink-inputs, throttling, failure handling) and whether the `checkNoSpeaker` DOM cross-check could keep a bot in a genuinely-ended meeting longer than intended.
