### PR TITLE
fix(sync): robust A/V sync signal detection and correction

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -116,6 +116,8 @@ export class ScreenRecorder extends EventEmitter {
   private recordingStartTime = 0
   private meetingStartTime = 0
   private syncSignalTimestamp = 0 // wall-clock ms when generateSyncSignal was actually called
+  private audioBeepWallMs = 0 // wall-clock ms when the WebAudio beep actually started
+  private videoFlashWallMs = 0 // wall-clock ms when the flash paint committed
   private gracePeriodActive = false
   private rawAudioPath = ""
   private soundMonitorRemainder: Buffer = Buffer.alloc(0)
@@ -188,11 +190,15 @@ export class ScreenRecorder extends EventEmitter {
       // Stamp the exact wall-clock time before emitting the signal so post-processing
       // knows precisely where to look in the raw recordings — no heuristic needed.
       this.syncSignalTimestamp = Date.now()
-      await generateSyncSignal(page, {
+      const syncTimestamps = await generateSyncSignal(page, {
         duration: 800, // Much longer signal for reliable detection
         frequency: 1000, // Keep 1000Hz for consistency
         volume: 0.95 // Higher volume for better detection
       })
+      // Per-signal wall-clock anchors; fall back to the fire time when a
+      // signal could not report its own timestamp.
+      this.audioBeepWallMs = syncTimestamps.audioBeepWallMs ?? this.syncSignalTimestamp
+      this.videoFlashWallMs = syncTimestamps.videoFlashWallMs ?? this.syncSignalTimestamp
 
       console.log("Native recording started successfully")
       this.emit("started", {
@@ -1325,9 +1331,26 @@ export class ScreenRecorder extends EventEmitter {
     const expectedSyncSec = this.syncSignalTimestamp > 0
       ? (this.syncSignalTimestamp - this.recordingStartTime) / 1000
       : FLASH_SCREEN_SLEEP_TIME / 1000 // fallback: should never happen in normal operation
-    console.log(`🎯 Sync signal expected at ${expectedSyncSec.toFixed(3)}s into recording`)
+    // Per-signal anchors: both signals ride the page.evaluate queue and can
+    // fire seconds after syncSignalTimestamp under load. Anchoring each
+    // detection window on its own real emission time — and subtracting the
+    // emission gap in the offset math — isolates pure capture-start skew.
+    const expectedAudioSyncSec = this.audioBeepWallMs > 0
+      ? (this.audioBeepWallMs - this.recordingStartTime) / 1000
+      : expectedSyncSec
+    const expectedVideoSyncSec = this.videoFlashWallMs > 0
+      ? (this.videoFlashWallMs - this.recordingStartTime) / 1000
+      : expectedSyncSec
+    console.log(
+      `🎯 Sync signal fired at ${expectedSyncSec.toFixed(3)}s into recording (beep started ${expectedAudioSyncSec.toFixed(3)}s, flash painted ${expectedVideoSyncSec.toFixed(3)}s)`
+    )
 
-    const syncResult = await calculateVideoOffset(rawAudioPath, rawVideoPath, expectedSyncSec)
+    const syncResult = await calculateVideoOffset(
+      rawAudioPath,
+      rawVideoPath,
+      expectedAudioSyncSec,
+      expectedVideoSyncSec
+    )
     console.log(`🎯 Calculated A/V stream offset: ${syncResult.offsetSeconds.toFixed(3)}s`)
     if (syncResult.confidence < 0.9) {
       // Alertable marker: sync-signal detection failed (fully or partially), so the
@@ -1375,13 +1398,12 @@ export class ScreenRecorder extends EventEmitter {
     //    recordingStartTime + startupDelay, not recordingStartTime. Without correcting
     //    for that, the whole video (and the diarization timeline, which counts from
     //    meetingStartTime) leads the media by the startup delay for the entire meeting.
-    //    The flash measurement gives us that delay directly: the sync signal was
-    //    emitted expectedSyncSec after recordingStartTime (wall clock) but appears at
-    //    videoTimestamp in the file (media time). Only trust it when both signals were
-    //    detected (confidence >= 0.9) — the single-signal fallback fabricates
-    //    videoTimestamp from the beep, which would poison this correction.
-    const measuredStartupDelaySec =
-      syncResult.confidence >= 0.9 ? expectedSyncSec - syncResult.videoTimestamp : 0
+    //    The flash measurement gives us that delay directly: videoCaptureDelaySec is
+    //    the flash's PAINT wall time minus its detected media time, so evaluate-queue
+    //    delay no longer masquerades as (or cancels out) capture delay, and the value
+    //    is valid even when only the flash was detected. It is 0 when the flash was
+    //    not detected at all.
+    const measuredStartupDelaySec = syncResult.videoCaptureDelaySec
     // x11grab startup can't be negative and is typically 0.1–0.5s; clamp against
     // detection outliers (VIDEO_SYNC_WINDOW_BACK_SEC allows matches up to 2s early).
     const startupDelaySec = Math.min(Math.max(measuredStartupDelaySec, 0), 2.0)

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -15,7 +15,7 @@ const ANALYSIS_WINDOW = 10 // Analyze first 10 seconds (used as fallback upper b
 // Half-width of the search window centred on the known sync-signal position.
 // Keep tight (±0.5 s) to avoid matching early meeting-UI content or noise, while
 // still tolerating normal system jitter on the sleep/page-evaluate path.
-const SYNC_WINDOW_HALF_WIDTH_SEC = 0.5
+
 // The audio beep can land far EARLIER in media time than the wall-clock
 // anchor: expectedSyncSec is relative to recordingStartTime, but the audio
 // media timeline starts only once ffmpeg's PulseAudio capture delivers its
@@ -25,6 +25,13 @@ const SYNC_WINDOW_HALF_WIDTH_SEC = 0.5
 // forward) for the beep; the 1kHz band-limited detector keeps early meeting
 // audio from false-positiving.
 const AUDIO_SYNC_WINDOW_BACK_SEC = 4.0
+// The beep can also land LATE: this codebase emits it via in-page WebAudio,
+// which rides the same page.evaluate queue as the flash — v1 measured that
+// queue delaying the flash paint by 1.7s under multi-bot node load, and the
+// WebAudio beep is subject to the same delay. (When beep and flash are both
+// delayed by the queue, the offset math cancels it — the window just has to
+// catch them.)
+const AUDIO_SYNC_WINDOW_FWD_SEC = 2.0
 // The video flash routinely lands EARLIER than the audio beep even though they
 // fire together: x11grab's capture pipeline starts with more latency than
 // PulseAudio, so the flash's video-stream timestamp is pulled below the tight
@@ -60,7 +67,7 @@ interface SyncOffset {
  * @param audioPath - Path to audio file (.wav)
  * @param videoPath - Path to video file (.webm, .mp4, etc.)
  * @param expectedSyncSec - Exact seconds-from-recording-start when generateSyncSignal was called.
- *   The audio window is [expectedSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC, expectedSyncSec + SYNC_WINDOW_HALF_WIDTH_SEC].
+ *   The audio window is [expectedSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC, expectedSyncSec + AUDIO_SYNC_WINDOW_FWD_SEC].
  *   Required — callers must pass the recorded syncSignalTimestamp offset so detection
  *   cannot be fooled by early meeting-UI content (authenticated bots) or noise.
  * @returns Promise<SyncOffset> - Synchronization information
@@ -71,7 +78,7 @@ export async function calculateVideoOffset(
   expectedSyncSec: number
 ): Promise<SyncOffset> {
   const searchMin = Math.max(0, expectedSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC)
-  const searchMax = expectedSyncSec + SYNC_WINDOW_HALF_WIDTH_SEC
+  const searchMax = expectedSyncSec + AUDIO_SYNC_WINDOW_FWD_SEC
   // Wider window for the flash (see VIDEO_SYNC_WINDOW_BACK_SEC / _FWD_SEC).
   const videoSearchMin = Math.max(0, expectedSyncSec - VIDEO_SYNC_WINDOW_BACK_SEC)
   const videoSearchMax = expectedSyncSec + VIDEO_SYNC_WINDOW_FWD_SEC

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -39,7 +39,10 @@ const VIDEO_SYNC_WINDOW_BACK_SEC = 2.0
 // missed entirely (shipping with zero A/V correction). Give the flash more
 // forward room too; the strict green + scene-change detector keeps false
 // positives unlikely (in-meeting content isn't fullscreen #00FF00).
-const VIDEO_SYNC_WINDOW_FWD_SEC = 1.0
+// v1 preprod measured a flash landing 1.7s late (6.2s vs a 4.5s anchor) under
+// multi-bot node load — past even the 1.0s forward room this constant used to
+// give. 4s matches the audio back-window's safety margin.
+const VIDEO_SYNC_WINDOW_FWD_SEC = 4.0
 
 interface SyncOffset {
   /** Audio signal timestamp in seconds */
@@ -275,10 +278,15 @@ async function detectVideoFlash(videoPath: string, searchMin: number, searchMax:
 
             // Green flash (#00FF00) in YUV: Y ≈ 149, U ≈ 43, V ≈ 21.
             // Only accept within the caller-supplied window.
-            if (Y < 160 && U < 80 && V < 60 && currentTime >= searchMin && currentTime <= searchMax) {
-              console.log(`   Found green flash at ${currentTime.toFixed(3)}s (color analysis)`)
-              console.log(`   YUV values: [${Y.toFixed(1)} ${U.toFixed(1)} ${V.toFixed(1)}]`)
-              return currentTime
+            if (Y < 160 && U < 80 && V < 60) {
+              if (currentTime >= searchMin && currentTime <= searchMax) {
+                console.log(`   Found green flash at ${currentTime.toFixed(3)}s (color analysis)`)
+                console.log(`   YUV values: [${Y.toFixed(1)} ${U.toFixed(1)} ${V.toFixed(1)}]`)
+                return currentTime
+              }
+              console.log(
+                `   Green frame at ${currentTime.toFixed(3)}s (YUV [${Y.toFixed(1)} ${U.toFixed(1)} ${V.toFixed(1)}]) outside window [${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s] — ignored`
+              )
             }
           }
         }

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -60,6 +60,14 @@ interface SyncOffset {
   offsetSeconds: number
   /** Quality/confidence of detection (0-1) */
   confidence: number
+  /**
+   * How long after recordingStartTime the video capture actually delivered its
+   * first frame (flash paint wall time minus detected flash media time).
+   * Wall-clock-derived cut points (trimming at meetingStartTime) must subtract
+   * this or they land this many seconds INTO the meeting. 0 when the flash was
+   * not detected (unknown).
+   */
+  videoCaptureDelaySec: number
 }
 
 /**
@@ -75,13 +83,20 @@ interface SyncOffset {
 export async function calculateVideoOffset(
   audioPath: string,
   videoPath: string,
-  expectedSyncSec: number
+  expectedAudioSyncSec: number,
+  expectedVideoSyncSec: number = expectedAudioSyncSec
 ): Promise<SyncOffset> {
-  const searchMin = Math.max(0, expectedSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC)
-  const searchMax = expectedSyncSec + AUDIO_SYNC_WINDOW_FWD_SEC
+  // Emission gap between the two signals (each rides the page.evaluate queue
+  // with its own delay). Media positions inherit this gap, so it must be
+  // subtracted from the raw flash-minus-beep difference — otherwise the
+  // correction is off by exactly the differential emission delay.
+  const emissionGapSec = expectedVideoSyncSec - expectedAudioSyncSec
+
+  const searchMin = Math.max(0, expectedAudioSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC)
+  const searchMax = expectedAudioSyncSec + AUDIO_SYNC_WINDOW_FWD_SEC
   // Wider window for the flash (see VIDEO_SYNC_WINDOW_BACK_SEC / _FWD_SEC).
-  const videoSearchMin = Math.max(0, expectedSyncSec - VIDEO_SYNC_WINDOW_BACK_SEC)
-  const videoSearchMax = expectedSyncSec + VIDEO_SYNC_WINDOW_FWD_SEC
+  const videoSearchMin = Math.max(0, expectedVideoSyncSec - VIDEO_SYNC_WINDOW_BACK_SEC)
+  const videoSearchMax = expectedVideoSyncSec + VIDEO_SYNC_WINDOW_FWD_SEC
 
   console.log(
     `🔍 Analyzing sync signals (audio ${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s, video ${videoSearchMin.toFixed(2)}s – ${videoSearchMax.toFixed(2)}s)...`
@@ -122,7 +137,10 @@ export async function calculateVideoOffset(
         audioTimestamp: bothMissing ? 0 : detected,
         videoTimestamp: bothMissing ? 0 : detected,
         offsetSeconds: 0.0,
-        confidence: bothMissing ? 0.1 : 0.3
+        confidence: bothMissing ? 0.1 : 0.3,
+        // The flash alone still measures the video capture delay.
+        videoCaptureDelaySec:
+          videoTimestamp > 0 ? Math.max(0, expectedVideoSyncSec - videoTimestamp) : 0
       }
 
       if (bothMissing) {
@@ -135,20 +153,30 @@ export async function calculateVideoOffset(
       return fallbackResult
     }
 
-    const offsetSeconds = videoTimestamp - audioTimestamp
+    // Subtract the known emission gap: what remains is pure capture-start
+    // skew between the audio and video pipelines. The corrected video
+    // timestamp is returned so downstream (audioPadding = video - audio)
+    // applies exactly this skew.
+    const correctedVideoTimestamp = videoTimestamp - emissionGapSec
+    const offsetSeconds = correctedVideoTimestamp - audioTimestamp
     const confidence = 0.9 // High confidence if both signals detected
+    const videoCaptureDelaySec = Math.max(0, expectedVideoSyncSec - videoTimestamp)
 
     const result: SyncOffset = {
       audioTimestamp,
-      videoTimestamp,
+      videoTimestamp: correctedVideoTimestamp,
       offsetSeconds,
-      confidence
+      confidence,
+      videoCaptureDelaySec
     }
 
     console.log("✅ Sync analysis complete:")
     console.log(`   Audio beep at: ${audioTimestamp.toFixed(3)}s`)
-    console.log(`   Video flash at: ${videoTimestamp.toFixed(3)}s`)
+    console.log(
+      `   Video flash at: ${videoTimestamp.toFixed(3)}s (emission gap ${emissionGapSec.toFixed(3)}s → corrected ${correctedVideoTimestamp.toFixed(3)}s)`
+    )
     console.log(`   Offset: ${offsetSeconds.toFixed(3)}s`)
+    console.log(`   Video capture delay: ${videoCaptureDelaySec.toFixed(3)}s`)
     console.log(`   Confidence: ${(confidence * 100).toFixed(1)}%`)
 
     return result
@@ -161,7 +189,8 @@ export async function calculateVideoOffset(
       audioTimestamp: 0,
       videoTimestamp: 0,
       offsetSeconds: 0.0,
-      confidence: 0.05 // Very low confidence for error case
+      confidence: 0.05, // Very low confidence for error case
+      videoCaptureDelaySec: 0
     }
 
     console.log("✅ Using fallback offset: 0.000s (confidence: 5.0%)")
@@ -381,7 +410,8 @@ async function testGreenFlashDetection(): Promise<SyncOffset> {
       audioTimestamp: 0, // Not testing audio
       videoTimestamp,
       offsetSeconds: 0,
-      confidence: videoTimestamp > 0 ? 0.95 : 0.1
+      confidence: videoTimestamp > 0 ? 0.95 : 0.1,
+      videoCaptureDelaySec: 0
     }
 
     console.log("✅ Green flash detection result:")
@@ -395,7 +425,8 @@ async function testGreenFlashDetection(): Promise<SyncOffset> {
       audioTimestamp: 0,
       videoTimestamp: 0,
       offsetSeconds: 0,
-      confidence: 0.05
+      confidence: 0.05,
+      videoCaptureDelaySec: 0
     }
   }
 }

--- a/src/utils/CalculVideoOffset.ts
+++ b/src/utils/CalculVideoOffset.ts
@@ -16,6 +16,15 @@ const ANALYSIS_WINDOW = 10 // Analyze first 10 seconds (used as fallback upper b
 // Keep tight (±0.5 s) to avoid matching early meeting-UI content or noise, while
 // still tolerating normal system jitter on the sleep/page-evaluate path.
 const SYNC_WINDOW_HALF_WIDTH_SEC = 0.5
+// The audio beep can land far EARLIER in media time than the wall-clock
+// anchor: expectedSyncSec is relative to recordingStartTime, but the audio
+// media timeline starts only once ffmpeg's PulseAudio capture delivers its
+// first samples — measured ~2.1s after spawn in the v1 production image
+// (0/6 test bots detected the beep with the ±0.5s window; the injected tone
+// sat at ~2.4s media time vs a 4.5s anchor). Search further back (but not
+// forward) for the beep; the 1kHz band-limited detector keeps early meeting
+// audio from false-positiving.
+const AUDIO_SYNC_WINDOW_BACK_SEC = 4.0
 // The video flash routinely lands EARLIER than the audio beep even though they
 // fire together: x11grab's capture pipeline starts with more latency than
 // PulseAudio, so the flash's video-stream timestamp is pulled below the tight
@@ -48,7 +57,7 @@ interface SyncOffset {
  * @param audioPath - Path to audio file (.wav)
  * @param videoPath - Path to video file (.webm, .mp4, etc.)
  * @param expectedSyncSec - Exact seconds-from-recording-start when generateSyncSignal was called.
- *   The search window is clamped to [expectedSyncSec ± SYNC_WINDOW_HALF_WIDTH_SEC].
+ *   The audio window is [expectedSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC, expectedSyncSec + SYNC_WINDOW_HALF_WIDTH_SEC].
  *   Required — callers must pass the recorded syncSignalTimestamp offset so detection
  *   cannot be fooled by early meeting-UI content (authenticated bots) or noise.
  * @returns Promise<SyncOffset> - Synchronization information
@@ -58,7 +67,7 @@ export async function calculateVideoOffset(
   videoPath: string,
   expectedSyncSec: number
 ): Promise<SyncOffset> {
-  const searchMin = Math.max(0, expectedSyncSec - SYNC_WINDOW_HALF_WIDTH_SEC)
+  const searchMin = Math.max(0, expectedSyncSec - AUDIO_SYNC_WINDOW_BACK_SEC)
   const searchMax = expectedSyncSec + SYNC_WINDOW_HALF_WIDTH_SEC
   // Wider window for the flash (see VIDEO_SYNC_WINDOW_BACK_SEC / _FWD_SEC).
   const videoSearchMin = Math.max(0, expectedSyncSec - VIDEO_SYNC_WINDOW_BACK_SEC)
@@ -168,6 +177,12 @@ async function detectAudioBeep(audioPath: string, searchMin: number, searchMax: 
   // speech/chimes are strongly attenuated.
   const beepBandFilter = `highpass=f=${EXPECTED_FREQUENCY - 150},lowpass=f=${EXPECTED_FREQUENCY + 150}`
 
+  const reportRejected = (time: number, method: string) => {
+    console.log(
+      `   Audio activity at ${time.toFixed(3)}s (${method}) outside window [${searchMin.toFixed(2)}s – ${searchMax.toFixed(2)}s] — ignored`
+    )
+  }
+
   try {
     // Method 1: Use silence detection to find audio activity in the beep band
     const silenceCmd = `ffmpeg -i "${audioPath}" -af "${beepBandFilter},silencedetect=noise=-35dB:duration=0.01" -f null -t ${scanUntil} - 2>&1 | grep "silence_"`
@@ -184,6 +199,7 @@ async function detectAudioBeep(audioPath: string, searchMin: number, searchMax: 
             console.log(`   Found audio activity (likely beep) at ${time.toFixed(3)}s`)
             return time
           }
+          reportRejected(time, "silencedetect")
         }
       }
     } catch (e) {
@@ -206,6 +222,7 @@ async function detectAudioBeep(audioPath: string, searchMin: number, searchMax: 
             console.log(`   Found audio activity with detailed analysis at ${time.toFixed(3)}s`)
             return time
           }
+          reportRejected(time, "detailed silencedetect")
         }
       }
     } catch (e) {

--- a/src/utils/SyncSignal.ts
+++ b/src/utils/SyncSignal.ts
@@ -30,22 +30,42 @@ interface SyncSignalOptions {
  * @param page - Playwright page instance
  * @param options - Optional configuration for the sync signal
  */
+export interface SyncSignalTimestamps {
+  /** Wall-clock ms when the WebAudio oscillator actually started. Null if unmeasured. */
+  audioBeepWallMs: number | null
+  /** Wall-clock ms when the flash paint committed (post-rAF). Null if unmeasured. */
+  videoFlashWallMs: number | null
+}
+
+/**
+ * Generate synchronization signal on the given page.
+ *
+ * Returns per-signal wall-clock emission timestamps: both signals ride the
+ * page.evaluate queue of a Chromium that is busy joining the meeting, and that
+ * queue has been measured delaying execution by up to ~3.9s under multi-bot
+ * node load. Anchoring each detection window on its own signal's real emission
+ * time — and subtracting the emission gap in the offset math — isolates pure
+ * capture-start skew from evaluate/paint delays.
+ */
 export async function generateSyncSignal(
   page: Page,
   options: SyncSignalOptions = {}
-): Promise<void> {
+): Promise<SyncSignalTimestamps> {
   const { duration = 150, frequency = 1000, flashColor = "#00FF00", volume = 0.9 } = options
 
   console.log(`🎯 Generating sync signal: ${frequency}Hz beep + flash (${duration}ms)`)
 
   try {
     // Generate audio beep and visual flash simultaneously
-    await Promise.all([
+    const [audioBeepWallMs, videoFlashWallMs] = await Promise.all([
       generateAudioBeep(page, frequency, duration, volume),
       generateVisualFlash(page, flashColor, duration)
     ])
 
-    console.log("✅ Sync signal generated successfully")
+    console.log(
+      `✅ Sync signal generated successfully (beep wall=${audioBeepWallMs ?? "n/a"}, flash paint wall=${videoFlashWallMs ?? "n/a"})`
+    )
+    return { audioBeepWallMs, videoFlashWallMs }
   } catch (error) {
     console.error("❌ Failed to generate sync signal:", formatError(error))
     throw error
@@ -60,70 +80,90 @@ async function generateAudioBeep(
   frequency: number,
   duration: number,
   volume: number
-): Promise<void> {
-  await page.evaluate(
-    ({ freq, dur, vol }) => {
-      if (window.__syncAudioContext) {
-        console.log("⚠️ AudioContext already exists, skipping duplicate beep")
-        return
-      }
+): Promise<number | null> {
+  try {
+    // Returns the wall-clock ms at which the oscillator started (the page
+    // clock and Node's Date.now() are the same machine clock). Null when the
+    // beep was skipped or failed.
+    const oscillatorStartWallMs: number | null = await page.evaluate(
+      ({ freq, dur, vol }) => {
+        if (window.__syncAudioContext) {
+          console.log("⚠️ AudioContext already exists, skipping duplicate beep")
+          return null
+        }
 
-      try {
-        const audioContext = new (window.AudioContext || window.webkitAudioContext)()
+        try {
+          const audioContext = new (window.AudioContext || window.webkitAudioContext)()
 
-        window.__syncAudioContext = audioContext
+          window.__syncAudioContext = audioContext
 
-        const oscillator = audioContext.createOscillator()
-        const gainNode = audioContext.createGain()
+          const oscillator = audioContext.createOscillator()
+          const gainNode = audioContext.createGain()
 
-        oscillator.connect(gainNode)
-        gainNode.connect(audioContext.destination)
+          oscillator.connect(gainNode)
+          gainNode.connect(audioContext.destination)
 
-        oscillator.frequency.setValueAtTime(freq, audioContext.currentTime)
-        oscillator.type = "sine"
+          oscillator.frequency.setValueAtTime(freq, audioContext.currentTime)
+          oscillator.type = "sine"
 
-        const durationSec = dur / 1000
-        gainNode.gain.setValueAtTime(0, audioContext.currentTime)
-        gainNode.gain.setValueAtTime(vol, audioContext.currentTime + 0.005)
-        gainNode.gain.setValueAtTime(vol, audioContext.currentTime + durationSec - 0.005)
-        gainNode.gain.setValueAtTime(0, audioContext.currentTime + durationSec)
+          const durationSec = dur / 1000
+          gainNode.gain.setValueAtTime(0, audioContext.currentTime)
+          gainNode.gain.setValueAtTime(vol, audioContext.currentTime + 0.005)
+          gainNode.gain.setValueAtTime(vol, audioContext.currentTime + durationSec - 0.005)
+          gainNode.gain.setValueAtTime(0, audioContext.currentTime + durationSec)
 
-        oscillator.start(audioContext.currentTime)
-        oscillator.stop(audioContext.currentTime + durationSec)
+          oscillator.start(audioContext.currentTime)
+          const startWallMs = Date.now()
+          oscillator.stop(audioContext.currentTime + durationSec)
 
-        setTimeout(() => {
-          try {
-            audioContext.close()
-            delete window.__syncAudioContext
-          } catch (e) {
-            console.warn("AudioContext cleanup warning:", e)
-          }
-        }, dur + 100)
+          setTimeout(() => {
+            try {
+              audioContext.close()
+              delete window.__syncAudioContext
+            } catch (e) {
+              console.warn("AudioContext cleanup warning:", e)
+            }
+          }, dur + 100)
 
-        console.log(`🔊 Audio beep: ${freq}Hz for ${dur}ms at volume ${vol}`)
-      } catch (error) {
-        console.error("Audio beep error:", formatError(error))
-        delete window.__syncAudioContext
-      }
-    },
-    { freq: frequency, dur: duration, vol: volume }
-  )
+          console.log(`🔊 Audio beep: ${freq}Hz for ${dur}ms at volume ${vol}`)
+          return startWallMs
+        } catch (error) {
+          console.error("Audio beep error:", error)
+          delete window.__syncAudioContext
+          return null
+        }
+      },
+      { freq: frequency, dur: duration, vol: volume }
+    )
+    return oscillatorStartWallMs
+  } catch (error) {
+    console.warn("⚠️ Audio beep timestamp unavailable:", formatError(error))
+    return null
+  }
 }
 
 /**
  * Generate visual flash overlay
  */
-async function generateVisualFlash(page: Page, color: string, duration: number): Promise<void> {
-  await page.evaluate(
-    ({ flashColor, dur }) => {
-      if (document.querySelector("#sync-flash-overlay")) {
-        console.log("⚠️ Flash overlay already exists, skipping duplicate")
-        return
-      }
+async function generateVisualFlash(
+  page: Page,
+  color: string,
+  duration: number
+): Promise<number | null> {
+  try {
+    // Returns the wall-clock ms at which the flash paint was committed (after
+    // two animation frames: the first fires before the frame containing the
+    // overlay is composited, the second after it is on screen).
+    const paintWallMs: number | null = await page.evaluate(
+      ({ flashColor, dur }) => {
+        if (document.querySelector("#sync-flash-overlay")) {
+          console.log("⚠️ Flash overlay already exists, skipping duplicate")
+          return null
+        }
 
-      const flashDiv = document.createElement("div")
-      flashDiv.id = "sync-flash-overlay"
-      flashDiv.style.cssText = `
+        const flashDiv = document.createElement("div")
+        flashDiv.id = "sync-flash-overlay"
+        flashDiv.style.cssText = `
             position: fixed;
             top: 0;
             left: 0;
@@ -136,13 +176,26 @@ async function generateVisualFlash(page: Page, color: string, duration: number):
             opacity: 1;
         `
 
-      document.body.appendChild(flashDiv)
-      console.log(`💡 Visual flash: ${flashColor} for ${dur}ms`)
+        document.body.appendChild(flashDiv)
+        console.log(`💡 Visual flash: ${flashColor} for ${dur}ms`)
 
-      setTimeout(() => {
-        flashDiv.remove()
-      }, dur)
-    },
-    { flashColor: color, dur: duration }
-  )
+        setTimeout(() => {
+          flashDiv.remove()
+        }, dur)
+
+        return new Promise<number>((resolve) => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              resolve(Date.now())
+            })
+          })
+        })
+      },
+      { flashColor: color, dur: duration }
+    )
+    return paintWallMs
+  } catch (error) {
+    console.warn("⚠️ Visual flash paint timestamp unavailable:", formatError(error))
+    return null
+  }
 }


### PR DESCRIPTION
## Problem

Recordings shipped desynced (audio seconds ahead of or behind video) because the sync beep/flash detection and correction chain made three faulty assumptions, each falsified by measurement on v1 preprod:

1. **Audio window too tight** — the beep search window was `expectedSyncSec ± 0.5s`, but ffmpeg's PulseAudio capture delivers its first samples ~2.1s after spawn (measured in-container), so the beep lands ~2s earlier in media time. 0/6 test bots detected it → zero-offset fallback → raw skew shipped.
2. **Video window too tight forward** — the flash paint rides the evaluate queue of a Chromium busy joining the meeting; measured paint delays: 0.45–3.9s on one node, minutes apart. The old +0.5s (later +1.0s) forward edge missed them.
3. **Signals assumed simultaneous** — the offset formula `flash − beep` conflates capture-start skew with differential emission delay. Correcting with it overshoots by the emission gap and can flip the desync direction. Same flaw silently disabled the startup-delay trim correction (`expectedSyncSec − videoTimestamp` goes negative under paint delay → clamps to 0).

## Fixes (in commit order)

- Audio window: 4s back (+2s forward — the WebAudio beep rides the same evaluate queue), 1kHz band-limit retained, rejected out-of-window hits logged
- Video window: 4s forward, rejected green frames logged
- **Per-signal wall-clock anchors**: WebAudio oscillator-start and flash paint-commit (double rAF) each timestamped; windows anchor per-signal; offset math subtracts the emission gap, leaving pure capture-start skew
- Trim correction uses `videoCaptureDelaySec` (paint wall time − detected media time) — immune to evaluate-queue delay, valid from the flash alone
- Latent bug: in-page beep catch handler called `formatError` (not defined in page context) → ReferenceError on that path

## Validation (v1 preprod, same code lineage)

5 rounds × 4 concurrent Teams bots on one freshly-scaled node (worst-case contention). End state: 4/4 both signals detected, offset spread across bots collapsed 0.46s → 0.09s, measured video capture delay 0.27–0.37s compensated in the trim, recordings confirmed in sync by eye. Full measurement narrative in the PR comment below.

v1 equivalents: `onprem/prod-parity-20260710` commits `48fd234c`, `c4495b3a`, `c694ec05`, `84406428` (v1 additionally anchors its Node-side pacat tone on pacat's `Stream started.` verbose marker — n/a here until this codebase adopts an injected tone, which is recommended since WebAudio is suppressible by the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)