### PR TITLE
fix(meet): hide bottom control-bar strip left as white border

### DIFF
--- a/src/meeting/meet/htmlCleaner.ts
+++ b/src/meeting/meet/htmlCleaner.ts
@@ -81,6 +81,9 @@ export class MeetHtmlCleaner {
         // Hide visitor indicator bar
         hideVisitorIndicator()
 
+        // Hide the bottom control-bar strip (white border in recordings)
+        hideBottomBarStrip()
+
         // People panel cleanup (check once, skip if not found)
         try {
           const root: HTMLElement | null = Array.from(document.querySelectorAll("div")).find(
@@ -229,6 +232,35 @@ export class MeetHtmlCleaner {
 
         // Hide visitor indicator bar
         hideVisitorIndicator()
+
+        // Hide the bottom control-bar strip (white border in recordings)
+        hideBottomBarStrip()
+      }
+
+      // The size/color heuristics above hide the button cluster INSIDE
+      // Meet's bottom control bar, but the bar's own container (inline style
+      // `bottom: 0px; left: 0px; right: 0px`) stays visible as an empty white
+      // strip across the bottom of the recording (the color heuristic also
+      // targets the old dark theme). Anchor on the stable "Call controls"
+      // region (bot browser locale is always English) and hide the positioned
+      // strip itself. Verified against a live bot's html_snapshots.
+      function hideBottomBarStrip(): void {
+        try {
+          const controls = document.querySelector(
+            '[aria-label="Call controls"]'
+          ) as HTMLElement | null
+          if (!controls) {
+            return
+          }
+          let el: HTMLElement | null = controls
+          while (el) {
+            if (el.style && el.style.bottom === "0px" && el.style.left === "0px") {
+              el.style.display = "none"
+              return
+            }
+            el = el.parentElement
+          }
+        } catch (e) {}
       }
 
       function hideVisitorIndicator(): void {

--- a/src/meeting/meet/htmlCleaner.ts
+++ b/src/meeting/meet/htmlCleaner.ts
@@ -247,14 +247,24 @@ export class MeetHtmlCleaner {
       function hideBottomBarStrip(): void {
         try {
           const controls = document.querySelector(
-            '[aria-label="Call controls"]'
+            'div[role="region"][aria-label="Call controls"]'
           ) as HTMLElement | null
           if (!controls) {
             return
           }
           let el: HTMLElement | null = controls
           while (el) {
-            if (el.style && el.style.bottom === "0px" && el.style.left === "0px") {
+            // Computed style (not inline) and the full strip geometry —
+            // positioned, anchored to bottom/left/right — so a coincidental
+            // partial inline match on a larger wrapper can't get hidden
+            // instead of the control-bar strip.
+            const style = window.getComputedStyle(el)
+            if (
+              style.position !== "static" &&
+              style.bottom === "0px" &&
+              style.left === "0px" &&
+              style.right === "0px"
+            ) {
               el.style.display = "none"
               return
             }


### PR DESCRIPTION
White strip across the bottom of every Meet recording: the cleaner hides the buttons inside the bottom control bar but never the bar's own bottom-anchored container (and its color heuristic targets the retired dark theme). Fix anchors on the `[aria-label="Call controls"]` region and hides the positioned strip. Validated on v1 preprod by measuring the recording's bottom-band luma: ~186–224 (white) before, 80–114 (content) after. Port of v1 `1441e925`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)