### PR TITLE
fix(browser): restore a working rasterizer for screen-share capture

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -4,6 +4,27 @@ import { GLOBAL } from "../singleton"
 import { formatError } from "../utils/Logger"
 import { getExitGeo } from "../proxy/toggle-proxy"
 
+// Chromium's GPU stack. CloakBrowser launches through Playwright with
+// ignoreDefaultArgs = ["--enable-automation", "--enable-unsafe-swiftshader"],
+// so it drops the SwiftShader flag Playwright normally passes, and adds
+// --ignore-gpu-blocklist in headed mode. Stacking --disable-gpu +
+// --disable-software-rasterizer + --disable-gpu-compositing on top of that
+// leaves no rasterizer able to handle a large surface: a Teams screen-share
+// track renders as row-shifted garbage in the X framebuffer while small camera
+// tiles still paint (bot cdb011f5, 2026-07-09). "swiftshader" is the coherent
+// software stack: no hardware GPU, SwiftShader rasters everything.
+// NB: --enable-unsafe-swiftshader is deliberately absent. Playwright applies
+// ignoreDefaultArgs as a filter over the *whole* arg list (user args included,
+// coreBundle.js:38322), so passing it here would just be stripped again. It
+// only gates WebGL anyway — ANGLE-SwiftShader raster/compositing works without.
+const GPU_MODES: Record<string, string[]> = {
+  swiftshader: ["--disable-gpu", "--use-gl=angle", "--use-angle=swiftshader"],
+  // Pre-2026-07-02 plain-Chrome behaviour: pass nothing, let Chromium decide.
+  none: [],
+  // The broken combo. Kept only to reproduce the corruption on demand.
+  legacy: ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
+}
+
 export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: BrowserContext }> {
   // Resolution configuration from environment variable
   // Defaults to 720p if RESOLUTION is not set or invalid
@@ -97,7 +118,7 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
   ]
 
   const platform = GLOBAL.get().meeting_platform
-  const gpuArgs = ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
+  const gpuArgs = GPU_MODES[envVars.BROWSER_GPU_MODE] ?? GPU_MODES.swiftshader
   try {
     console.log(`Launching CloakBrowser persistent context (${platform})...`)
 

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -29,6 +29,12 @@ export const envVars = cleanEnv(process.env, {
   VIDEO_DEVICE: str({ default: "/dev/video10" }),
   EFS_MOUNT_POINT: str({ default: "/mnt/efs" }),
   RESOLUTION: str({ choices: ["720", "1080"], default: "720" }),
+  // Chromium GPU flag set (see GPU_MODES in browser/browser.ts). Env-selectable
+  // so a bad rasterizer config can be swapped in preprod without a rebuild.
+  BROWSER_GPU_MODE: str({
+    choices: ["swiftshader", "none", "legacy"],
+    default: "swiftshader"
+  }),
   UPLOAD_AUDIO_CHUNKS: bool({ default: false }),
   UPLOAD_RAW_VIDEO: bool({ default: false }),
   // Override output directory for serverless mode (e.g., when using run_bot.sh)


### PR DESCRIPTION
## Problem

Teams recordings turn into row-shifted garbage the moment someone screen-shares. Confirmed on prod bot `cdb011f5-9530-4a3c-81af-5ef42baaaafa` (2026-07-09, customer-reported): clean for the first 3 min, then 46 minutes of unusable video — and **zero errors logged**. Corruption is present in `raw_video.mp4`, i.e. at capture, so ffmpeg/branding is not involved. The Teams DOM overlay stays crisp, so x11grab is fine — Chromium is painting the video surfaces as garbage.

Reproduced live on prod today with a fresh bot + screen share.

## Cause

`f531646` (Jul 2) moved Teams from plain Chrome to CloakBrowser, carrying over these flags:

```
--disable-gpu --disable-software-rasterizer --disable-gpu-compositing
```

CloakBrowser launches through Playwright with `ignoreDefaultArgs = ["--enable-automation", "--enable-unsafe-swiftshader"]` (its `config.js`), so it drops the SwiftShader flag Playwright normally passes, and adds `--ignore-gpu-blocklist` in headed mode. Result: no hardware GPU, no SwiftShader, no GPU compositing — but the blocklist ignored. Nothing is left that can raster a large surface. Small camera tiles still paint; a full-size share track does not.

The pre-Jul-2 Chrome path passed **no** GPU flags and **kept** `--enable-unsafe-swiftshader`, which is why this never happened before. Meet has run this same broken combo since Jun 2 — its screen-shares are likely affected too, just unreported.

## Fix

`BROWSER_GPU_MODE` env var selects the flag set (`browser/browser.ts`):

| mode | flags |
|---|---|
| `swiftshader` (default) | `--disable-gpu --use-gl=angle --use-angle=swiftshader` |
| `none` | *(none — pre-Jul-2 plain-Chrome behaviour)* |
| `legacy` | the broken combo, kept to reproduce on demand |

Env-selectable so preprod can bisect the three variants without rebuilding the image.

Note: `--enable-unsafe-swiftshader` is deliberately **not** passed — Playwright applies `ignoreDefaultArgs` as a filter over the whole arg list, user args included (`coreBundle.js:38322`), so it would just be stripped again. It only gates WebGL; ANGLE-SwiftShader raster/compositing works without it.

## Test plan

- [ ] Preprod Teams bot + screen share on `swiftshader` → clean capture
- [ ] If still corrupt, flip `BROWSER_GPU_MODE=none` (no rebuild) → clean capture
- [ ] Confirm Meet join/record unaffected (Meet keeps CloakBrowser)
- [ ] Then promote to prod and re-check a real screen-shared meeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)