### PR TITLE
Feat/zoom browser recording v2

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -97,7 +97,19 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
   ]
 
   const platform = GLOBAL.get().meeting_platform
-  const gpuArgs = ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
+  // Zoom Web renders via SwiftShader software-WebGL + a software video decoder;
+  // vexa measured the standalone gpu-process at ~357% CPU. --in-process-gpu
+  // folds that into the renderer and drops per-bot demand from ~4.4 cores to
+  // ~115%. Meet/Teams don't need it, so scope it to Zoom.
+  const gpuArgs =
+    platform === "zoom"
+      ? [
+          "--disable-gpu",
+          "--disable-software-rasterizer",
+          "--disable-gpu-compositing",
+          "--in-process-gpu"
+        ]
+      : ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
   try {
     console.log(`Launching CloakBrowser persistent context (${platform})...`)
 

--- a/src/chat-manager.ts
+++ b/src/chat-manager.ts
@@ -257,7 +257,15 @@ export class ChatManager {
 
       // Real keyboard events + Enter — Zoom's chat editor validates like the
       // pre-join name field, so focus+type is the reliable path.
-      await page.locator(activeSelector).first().click({ timeout: 3000 })
+      //
+      // Focus via JS rather than a real .click(): the Zoom recording cleaner moves
+      // the right dock (which holds the chat editor) OFF-SCREEN so it stays out of
+      // frame, and a real click would land at off-screen coordinates and time out
+      // ("element is outside of the viewport"). Focusing the contenteditable
+      // directly still routes keyboard input to it.
+      await page.evaluate((sel) => {
+        ;(document.querySelector(sel) as HTMLElement | null)?.focus()
+      }, activeSelector)
       await page.keyboard.type(message, { delay: 20 })
       await page.keyboard.press("Enter")
 

--- a/src/chat-manager.ts
+++ b/src/chat-manager.ts
@@ -100,6 +100,10 @@ export class ChatManager {
       return this.sendViaTeams(page, message)
     }
 
+    if (platform === "zoom") {
+      return this.sendViaZoom(page, message)
+    }
+
     return { success: false, error: `Unsupported platform: ${platform}`, status: 400 }
   }
 
@@ -174,6 +178,94 @@ export class ChatManager {
     } catch (error) {
       console.error("[ChatManager] Meet send failed:", formatError(error))
       return { success: false, error: "Failed to send chat message via Meet", status: 500 }
+    }
+  }
+
+  private async sendViaZoom(page: Page, message: string): Promise<SendBotMessageResult> {
+    try {
+      // Zoom mounts the chat INPUT only while the panel is open (the message
+      // LIST can already be in the DOM, which is why "list found but input
+      // missing" is the normal closed-panel state — don't read that as chat
+      // being disabled).
+      // Zoom's chat composer is a TipTap/ProseMirror contenteditable (confirmed
+      // live: `div.tiptap.ProseMirror.ProseMirror-focused`), NOT a textarea.
+      // The legacy textarea selectors are kept as fallbacks for older builds.
+      const inputSelectors = [
+        'div.ProseMirror[contenteditable="true"]',
+        'div.tiptap[contenteditable="true"]',
+        'div.chat-rtf-box__editor[contenteditable="true"]',
+        "textarea.chat-box__chat-textarea",
+        'textarea[aria-label*="chat" i]',
+        'div[contenteditable="true"][aria-label*="chat" i]',
+        'textarea[placeholder*="message" i]'
+      ]
+      // Visibility via getClientRects(), NOT offsetParent: offsetParent is null
+      // for position:fixed elements, and Zoom's chat panel is fixed — so an
+      // offsetParent check rejects the very editor we're looking for.
+      const findInput = async () =>
+        page.evaluate((sels) => {
+          for (const s of sels) {
+            const el = document.querySelector(s) as HTMLElement | null
+            if (el && el.getClientRects().length > 0) return s
+          }
+          return null
+        }, inputSelectors)
+
+      let activeSelector = await findInput()
+      if (!activeSelector) {
+        // Open the panel. Match the EXACT toggle: a substring match on "chat"
+        // hits "Chat Settings" first in DOM order and opens the settings menu
+        // instead of the panel.
+        const opened = await page.evaluate(() => {
+          const btn =
+            (document.querySelector(
+              'button[aria-label="open the chat panel"]'
+            ) as HTMLElement | null) ??
+            (Array.from(document.querySelectorAll("button")).find((b) => {
+              const al = (b.getAttribute("aria-label") || "").toLowerCase()
+              return al.includes("chat") && !al.includes("setting")
+            }) as HTMLElement | undefined)
+          if (!btn) return false
+          btn.click()
+          return true
+        })
+        if (!opened) {
+          return { success: false, error: "Zoom chat toggle not found", status: 400 }
+        }
+        await page.waitForSelector(inputSelectors.join(", "), { timeout: 5000 }).catch(() => {})
+        activeSelector = await findInput()
+      }
+
+      if (!activeSelector) {
+        // Forensics: dump every editable element so the next run tells us the
+        // real selector instead of failing blind again.
+        const probe = await page
+          .evaluate(() =>
+            Array.from(
+              document.querySelectorAll('textarea,[contenteditable="true"],input[type="text"]')
+            )
+              .slice(0, 15)
+              .map((e) => {
+                const el = e as HTMLElement
+                return `${el.tagName.toLowerCase()}.${String(el.className).slice(0, 60)}[aria=${el.getAttribute("aria-label") || ""}]`
+              })
+          )
+          .catch(() => [])
+        console.error("[ChatManager] Zoom chat input not found. Editable elements:", probe)
+        return { success: false, error: "Zoom chat input not found", status: 400 }
+      }
+
+      // Real keyboard events + Enter — Zoom's chat editor validates like the
+      // pre-join name field, so focus+type is the reliable path.
+      await page.locator(activeSelector).first().click({ timeout: 3000 })
+      await page.keyboard.type(message, { delay: 20 })
+      await page.keyboard.press("Enter")
+
+      this.persistBotSentMessage(message)
+      return { success: true }
+    } catch (error) {
+      console.error("[ChatManager] Zoom send failed:", formatError(error))
+      return { success: false, error: "Chat is not available in this meeting", status: 400 }
     }
   }
 

--- a/src/meeting/chatObserver.ts
+++ b/src/meeting/chatObserver.ts
@@ -3,10 +3,11 @@ import type { MeetingProvider } from "../types"
 import { formatError } from "../utils/Logger"
 import { MeetChatObserver } from "./meet/chatObserver"
 import { TeamsChatObserver } from "./teams/chatObserver"
+import { ZoomChatObserver } from "./zoom/chatObserver"
 
 export class ChatObserver {
   private meetingProvider: MeetingProvider
-  private observer: MeetChatObserver | TeamsChatObserver | null = null
+  private observer: MeetChatObserver | TeamsChatObserver | ZoomChatObserver | null = null
   private isObserving = false
 
   constructor(meetingProvider: MeetingProvider) {
@@ -25,6 +26,9 @@ export class ChatObserver {
         break
       case "teams":
         this.observer = new TeamsChatObserver(page)
+        break
+      case "zoom":
+        this.observer = new ZoomChatObserver(page)
         break
       default:
         console.warn(`[ChatObserver] Unknown meeting provider: ${this.meetingProvider}`)

--- a/src/meeting/htmlCleaner.ts
+++ b/src/meeting/htmlCleaner.ts
@@ -2,10 +2,11 @@ import type { Page } from "@playwright/test"
 import type { MeetingProvider, RecordingMode } from "../types"
 import { MeetHtmlCleaner } from "./meet/htmlCleaner"
 import { TeamsHtmlCleaner } from "./teams/htmlCleaner"
+import { ZoomHtmlCleaner } from "./zoom/htmlCleaner"
 
 export class HtmlCleaner {
   private meetingProvider: MeetingProvider
-  private cleaner: MeetHtmlCleaner | TeamsHtmlCleaner | null = null
+  private cleaner: MeetHtmlCleaner | TeamsHtmlCleaner | ZoomHtmlCleaner | null = null
   private isRunning = false
 
   constructor(page: Page, meetingProvider: MeetingProvider, recordingMode: RecordingMode) {
@@ -19,6 +20,10 @@ export class HtmlCleaner {
 
       case "teams":
         this.cleaner = new TeamsHtmlCleaner(page, recordingMode)
+        break
+
+      case "zoom":
+        this.cleaner = new ZoomHtmlCleaner(page, recordingMode)
         break
 
       default:

--- a/src/meeting/speakersObserver.ts
+++ b/src/meeting/speakersObserver.ts
@@ -3,10 +3,12 @@ import type { MeetingProvider, RecordingMode, SpeakerData } from "../types"
 import { formatError } from "../utils/Logger"
 import { MeetSpeakersObserver } from "./meet/speakersObserver"
 import { TeamsSpeakersObserver } from "./teams/speakersObserver"
+import { ZoomSpeakersObserver } from "./zoom/speakersObserver"
 
 export class SpeakersObserver {
   private meetingProvider: MeetingProvider
-  private observer: MeetSpeakersObserver | TeamsSpeakersObserver | null = null
+  private observer: MeetSpeakersObserver | TeamsSpeakersObserver | ZoomSpeakersObserver | null =
+    null
   private isObserving = false
   private retryCount = 0
   private maxRetries = 3
@@ -36,6 +38,10 @@ export class SpeakersObserver {
 
       case "teams":
         this.observer = new TeamsSpeakersObserver(page, recordingMode, botName, onSpeakersChange)
+        break
+
+      case "zoom":
+        this.observer = new ZoomSpeakersObserver(page, recordingMode, botName, onSpeakersChange)
         break
 
       default:

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -1,0 +1,87 @@
+import { MeetingEndReason } from "../state-machine/types"
+import type { StateDetectionConfig } from "../utils/meeting-state-detector"
+
+/**
+ * Zoom Web Client (browser) state-detection configuration.
+ *
+ * Selectors/text ported from vexa `join/zoom/selectors.ts` (live-DOM-verified).
+ * Consumed by createStateDetector() the same way MEET_STATE_CONFIG /
+ * TEAMS_STATE_CONFIG are.
+ *
+ * Two hard subtleties baked into the ZoomProvider, not this config:
+ *  1. The anti-bot wall ("automated bots aren't allowed … must use Zoom RTMS")
+ *     maps to a NON-RETRYABLE ZoomRequiresRtms — see denialPatterns below.
+ *  2. Zoom renders the waiting room INSIDE `.meeting-app`, and mic-preview audio
+ *     stays live across pre-join → waiting-room, so `.meeting-app`/audio presence
+ *     alone false-positives as "in meeting". The in-meeting signal here is
+ *     therefore the Leave button ONLY (footer-only, never renders pre-join or in
+ *     the waiting room); the provider runs the waiting-room text check first.
+ */
+export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
+  providerName: "Zoom Web",
+  denialPatterns: [
+    {
+      // Post-Join anti-bot wall. Keyed to the meeting/account (verified identical
+      // from datacenter AND residential IPs), so retrying always re-hits it.
+      texts: [
+        "automated bots aren't allowed",
+        "automated bots aren’t allowed", // curly-apostrophe variant Zoom renders
+        "must use Zoom RTMS",
+        "detected you may be a bot"
+      ],
+      reason: MeetingEndReason.ZoomRequiresRtms,
+      logPrefix: "XXXXXXXXXXXXXXXXXX Zoom anti-bot wall (RTMS required)",
+      errorMessage:
+        "Zoom blocks automated browser joins for this meeting and requires RTMS"
+    },
+    {
+      // Host-restricted entry: only authenticated Zoom users may join. The
+      // #input-for-name field never renders, so fail fast as LoginRequired.
+      texts: [
+        "sign in to join this meeting",
+        "only authenticated users can join",
+        "this meeting requires authentication"
+      ],
+      reason: MeetingEndReason.LoginRequired,
+      logPrefix: "Zoom requires an authenticated account to join",
+      errorMessage: "Zoom meeting restricted to authenticated users"
+    },
+    {
+      texts: [
+        "This meeting has been ended by host",
+        "host ended the meeting",
+        "ended by the host",
+        "removed from the meeting",
+        "You have been removed",
+        "meeting has ended",
+        "Meeting has ended"
+      ],
+      reason: MeetingEndReason.BotRemoved,
+      logPrefix: "XXXXXXXXXXXXXXXXXX Zoom removed the bot / meeting ended",
+      errorMessage: "Bot removed or Zoom meeting ended"
+    }
+  ],
+  waitingRoomPattern: {
+    // Zoom waiting room has no unique CSS class — only text strings. Substring
+    // match (unquoted text=) survives minor copy changes.
+    selectors: [
+      "text=Please wait, the meeting host will let you in soon",
+      "text=Please wait",
+      "text=Waiting for the host to start this meeting",
+      "text=Waiting for the host to start the meeting",
+      "text=waiting room",
+      "text=Host has joined"
+    ],
+    threshold: 1,
+    checkVisibility: false
+  },
+  inMeetingPattern: {
+    // Leave button ONLY. This footer control never renders pre-join or in the
+    // waiting room, so a single reliable indicator beats a threshold of weaker
+    // ones (which false-positive inside `.meeting-app`). checkVisibility=true so
+    // a hidden-but-present Leave button in the pre-join DOM can't match.
+    selectors: ['button[aria-label="Leave"]'],
+    threshold: 1,
+    checkVisibility: true
+  }
+}

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -303,21 +303,40 @@ export class ZoomProvider implements MeetingProviderInterface {
       throw new Error("Bot stopped before clicking Join")
     }
 
-    // Click Join via the DOM to bypass Playwright's pointer-event hit-test —
-    // `.preview-meeting-info` overlays the Join button and makes a Playwright
-    // .click() time out after 30s; the React handler fires regardless.
-    console.log("[Zoom] Clicking Join (DOM-direct)...")
-    const clicked = await page.evaluate((sel: string) => {
-      const btn = document.querySelector(sel) as HTMLButtonElement | null
-      if (!btn || btn.classList.contains("disabled") || btn.disabled) return false
-      btn.click()
-      return true
-    }, JOIN_BUTTON)
+    // Click Join through Playwright, NOT via a DOM .click().
+    //
+    // This is the most bot-scrutinised action in the whole flow, and an in-page
+    // `element.click()` is a free tell: the MouseEvent it produces has
+    // isTrusted === false, which any anti-bot layer can read in one line.
+    // Playwright dispatches through CDP, so the event is genuinely trusted
+    // (isTrusted === true) AND it routes through CloakBrowser's humanize patches
+    // (real mouse movement, human timing) — the same reason teams.ts prefers a
+    // humanized click and treats a raw DOM click as making "the join look
+    // robotic".
+    //
+    // `force: true` is what lets us keep the trusted path: it skips Playwright's
+    // actionability/hit-test checks — which is why we reached for a DOM click in
+    // the first place, since `.preview-meeting-info` overlays the button and
+    // intercepts pointer events — while still sending real input.
+    //
+    // The DOM click stays ONLY as a last-resort fallback, matching Teams.
+    console.log("[Zoom] Clicking Join (Playwright, trusted + humanized)...")
+    let clicked = false
+    try {
+      await page.locator(JOIN_BUTTON).first().click({ force: true, timeout: 10_000 })
+      clicked = true
+    } catch (e) {
+      console.warn("[Zoom] Humanized Join click failed, falling back to DOM click:", formatError(e))
+    }
     if (!clicked) {
-      console.warn("[Zoom] DOM Join click failed; falling back to Playwright click")
-      const joinBtn = page.locator(JOIN_BUTTON)
-      await joinBtn.waitFor({ state: "visible", timeout: 10_000 }).catch(() => {})
-      await joinBtn.click({ force: true, timeout: 10_000 }).catch(() => {})
+      await page
+        .evaluate((sel: string) => {
+          const btn = document.querySelector(sel) as HTMLButtonElement | null
+          if (!btn || btn.classList.contains("disabled") || btn.disabled) return false
+          btn.click()
+          return true
+        }, JOIN_BUTTON)
+        .catch(() => false)
     }
     console.log("[Zoom] Join clicked — waiting for admission...")
     await sleep(3000)

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -1,0 +1,504 @@
+import type { BrowserContext, Page } from "@playwright/test"
+import { listenPage } from "../browser/page-logger"
+import { HtmlSnapshotService } from "../services/html-snapshot-service"
+import { GLOBAL } from "../singleton"
+import { MeetingEndReason } from "../state-machine/types"
+import type { MeetingProviderInterface } from "../types"
+import { buildZoomWebClientUrl, parseZoomMeetingUrl } from "../urlParser/zoomUrlParser"
+import { formatError } from "../utils/Logger"
+import { createStateDetector } from "../utils/meeting-state-detector"
+import { sleep } from "../utils/sleep"
+import { ZOOM_STATE_CONFIG } from "./zoom-state-config"
+
+// Zoom Web Client selectors (ported from vexa join/zoom/selectors.ts — verified
+// against the live DOM). Two client variants co-exist and Zoom picks per-meeting:
+//   React client  (app.zoom.us/wc/<id>/join):  #input-for-name, .preview-join-button
+//   Classic client(app.zoom.us/wc/join/<id>):  #inputname,       #joinBtn
+const NAME_INPUT = '#input-for-name, #inputname, input[placeholder="Your Name" i]'
+const JOIN_BUTTON = "button.preview-join-button, #joinBtn"
+const PREVIEW_MUTE = "#preview-audio-control-button"
+const PREVIEW_VIDEO = "#preview-video-control-button"
+const LEAVE_BUTTON = 'button[aria-label="Leave"]'
+const LEAVE_CONFIRM = "button.leave-meeting-options__btn--danger"
+const PERMISSION_DISMISS = 'button:has-text("Continue without microphone and camera")'
+const PASSCODE_INPUT =
+  'input[placeholder*="passcode" i], input[placeholder*="password" i], input[type="password"]'
+
+// Post-Join anti-bot wall phrases — scanned case-insensitively against body text.
+//
+// Deliberately does NOT include "sign in to join". That phrase appears both on
+// the anti-bot wall AND on an ordinary auth-required meeting, and matching it
+// here would report every login-gated meeting as ZoomRequiresRtms. That metric
+// is exactly what decides whether browser Zoom is viable at all, so polluting it
+// would corrupt the decision. Auth-required is already classified correctly as
+// LoginRequired by ZOOM_STATE_CONFIG.denialPatterns.
+const BOT_BLOCK_TEXTS = [
+  "automated bots aren't allowed",
+  "automated bots aren’t allowed",
+  "must use zoom rtms",
+  "detected you may be a bot"
+]
+
+const HOST_NOT_STARTED_RETRY_MS = 15_000
+const HOST_NOT_STARTED_MAX_WAIT_MS = 10 * 60 * 1000
+
+// Removal debounce. Zoom auto-hides the footer that holds the Leave button, and
+// recording-state ends the meeting on a single findEndMeeting()===true, so a
+// bare "Leave button missing" check would eject the bot from a live meeting on
+// any transient repaint.
+const LEAVE_MISS_THRESHOLD = 3
+const LEAVE_GRACE_MS = 20_000
+
+const zoomStateDetector = createStateDetector(ZOOM_STATE_CONFIG)
+
+export class ZoomProvider implements MeetingProviderInterface {
+  // Cached from getMeetingLink so joinMeeting can fill a passcode field if one
+  // renders despite the ?pwd= in the URL.
+  private passcode = ""
+  // Removal debounce state (see findEndMeeting).
+  private leaveButtonMisses = 0
+  private inMeetingSince: number | null = null
+
+  async parseMeetingUrl(meeting_url: string) {
+    return parseZoomMeetingUrl(meeting_url)
+  }
+
+  getMeetingLink(
+    meeting_id: string,
+    password: string,
+    _role: number,
+    _bot_name: string,
+    _enter_message?: string
+  ): string {
+    this.passcode = password || ""
+    // meeting_id here is what parseMeetingUrl returned: a numeric id for
+    // canonical hosts, or the raw URL for white-label portals.
+    const seed = /^\d+$/.test(meeting_id)
+      ? `https://zoom.us/j/${meeting_id}${password ? `?pwd=${password}` : ""}`
+      : meeting_id
+    return buildZoomWebClientUrl(seed, password)
+  }
+
+  async openMeetingPage(
+    browserContext: BrowserContext,
+    link: string,
+    _streaming_input: string | undefined
+  ): Promise<Page> {
+    const page = await browserContext.newPage()
+    page.setDefaultTimeout(30_000)
+    page.setDefaultNavigationTimeout(60_000)
+
+    // Forward in-page console output to the bot log. Without this every
+    // console.log inside page.evaluate() — including the speaker observer's
+    // selector forensics — is silently discarded, which is exactly how the
+    // stale-diarization dump went missing on the first live run.
+    listenPage(page)
+
+    try {
+      await browserContext.grantPermissions(["microphone", "camera"], {
+        origin: new URL(link).origin
+      })
+    } catch (e) {
+      console.warn("[Zoom] grantPermissions failed (continuing):", formatError(e))
+    }
+
+    // Host-not-started retry loop: before the host starts, Zoom serves
+    // title="Error - Zoom" + "This meeting link is invalid (3,001)". Poll until
+    // the pre-join page renders (or the auth wall / anti-bot wall appears).
+    const startTime = Date.now()
+    while (true) {
+      try {
+        await page.goto(link, { waitUntil: "domcontentloaded", timeout: 60_000 })
+        // Clear the retry flag once navigation succeeds. Leaving it set is a
+        // real bug: shouldAttemptRetry() only looks at the flag + count, not at
+        // WHICH failure set it — so one flaky goto followed by a deliberately
+        // NON-retryable terminal failure (the RTMS wall, BotRemoved) would
+        // requeue the job, send a second bot into the same wall, and double-count
+        // the wall in our metrics.
+        GLOBAL.setShouldRetry(false)
+      } catch (e) {
+        console.warn("[Zoom] goto failed, will retry:", formatError(e))
+        GLOBAL.setShouldRetry(true)
+      }
+      await sleep(2000)
+
+      // Auth-required fail-fast: the sign-in page never renders #input-for-name,
+      // so without this the bot waits the full name-input timeout for a field
+      // that never appears. isDenied maps the matched text to the end reason.
+      const denied = await zoomStateDetector.isDenied(page)
+      if (denied.matched) {
+        const reason =
+          (denied.pattern && "reason" in denied.pattern ? denied.pattern.reason : undefined) ??
+          MeetingEndReason.BotNotAccepted
+        console.log(`[Zoom] Denial on pre-join: "${denied.matchedText}" -> ${reason}`)
+        GLOBAL.setError(reason)
+        // ZoomRequiresRtms / LoginRequired are NOT retryable on the same meeting.
+        throw new Error(`Zoom pre-join denial: ${reason}`)
+      }
+
+      const title = await page.title().catch(() => "")
+      const isHostNotStarted = title === "Error - Zoom" || title === "error - Zoom"
+      if (!isHostNotStarted) break
+
+      if (Date.now() - startTime >= HOST_NOT_STARTED_MAX_WAIT_MS) {
+        GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
+        throw new Error("[Zoom] Host did not start the meeting within the wait timeout")
+      }
+      console.log(
+        `[Zoom] Host not started (title="${title}"). Retrying in ${HOST_NOT_STARTED_RETRY_MS / 1000}s`
+      )
+      await sleep(HOST_NOT_STARTED_RETRY_MS)
+    }
+
+    return page
+  }
+
+  async joinMeeting(
+    page: Page,
+    cancelCheck: () => boolean,
+    onJoinSuccess: () => void
+  ): Promise<void> {
+    const htmlSnapshot = HtmlSnapshotService.getInstance()
+    await htmlSnapshot.captureSnapshot(page, "zoom_join_meeting_start")
+
+    // Dismiss OneTrust cookie banner. On the CLASSIC client it overlays the
+    // pre-join card and intercepts pointer events, so the name input can't be
+    // focused and Join never enables. No-op on the React client.
+    for (const otSel of ["#onetrust-accept-btn-handler", "#onetrust-reject-all-handler"]) {
+      try {
+        const btn = page.locator(otSel).first()
+        if (await btn.isVisible({ timeout: 1500 })) {
+          await btn.click()
+          console.log(`[Zoom] Dismissed cookie banner (${otSel})`)
+          await sleep(400)
+          break
+        }
+      } catch {
+        /* no banner */
+      }
+    }
+
+    // Media-permission dialog(s): Zoom shows "Allow" up to twice (camera+mic,
+    // then mic-only). The bot MUST click Allow to join the audio channel — else
+    // Zoom never creates <audio> elements for participants and PulseAudio
+    // capture gets silence. The bot mutes its own mic in preview below.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const allowBtn = page.locator('button:has-text("Allow")').first()
+        if (await allowBtn.isVisible({ timeout: 4000 })) {
+          await allowBtn.click()
+          console.log(`[Zoom] Granted media permission (attempt ${attempt + 1})`)
+          await sleep(600)
+          continue
+        }
+        const dismissBtn = page.locator(PERMISSION_DISMISS).first()
+        if (await dismissBtn.isVisible({ timeout: 1000 })) {
+          console.warn("[Zoom] No Allow button — dismissing; audio capture may fail")
+          await dismissBtn.click()
+          await sleep(600)
+        } else {
+          break
+        }
+      } catch {
+        break
+      }
+    }
+
+    if (cancelCheck()) {
+      GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
+      throw new Error("Bot stopped before joining Zoom meeting")
+    }
+
+    // Wait for the pre-join name input.
+    try {
+      await page.waitForSelector(NAME_INPUT, { timeout: 30_000 })
+    } catch {
+      // The wall can render here instead of a name field — check before failing.
+      const wall = await this.detectBotWall(page)
+      if (wall) {
+        GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)
+        throw new Error(`[Zoom] zoom_requires_rtms: ${wall}`)
+      }
+      GLOBAL.setError(MeetingEndReason.CannotJoinMeeting)
+      throw new Error("[Zoom] Pre-join name input never appeared")
+    }
+
+    // Passcode: usually auto-applied from ?pwd= in the URL. If a passcode field
+    // is still visible, fill from the cached value, else fail fast (Join would
+    // stay disabled forever).
+    const passField = page.locator(PASSCODE_INPUT).first()
+    if (await passField.isVisible({ timeout: 1000 }).catch(() => false)) {
+      if (this.passcode) {
+        await passField.fill(this.passcode)
+        console.log("[Zoom] Filled passcode field")
+      } else {
+        GLOBAL.setError(MeetingEndReason.ZoomPasscodeRequired)
+        throw new Error("[Zoom] zoom_passcode_required: passcode field present, none supplied")
+      }
+    }
+
+    // Name entry via REAL keyboard events. A synthetic setter/input event does
+    // NOT satisfy Zoom's React form validation — the Join button stays disabled
+    // (class "...preview-join-button disabled...") and a Playwright click times
+    // out on `.preview-meeting-info intercepts pointer events`. focus+type
+    // drives Zoom's full validation pipeline and enables Join.
+    const botName = GLOBAL.get().bot_name
+    await page.locator(NAME_INPUT).first().click({ timeout: 5000 }).catch(() => {})
+    await page.locator(NAME_INPUT).first().fill("")
+    await page.keyboard.type(botName, { delay: 30 })
+    console.log(`[Zoom] Name typed: "${botName}"`)
+
+    // Before waiting on Join, detect the human-gated walls (reCAPTCHA on the
+    // classic client, or the sign-in / anti-bot wall). These cannot be cleared
+    // by automation — fail fast rather than holding the browser.
+    const wall = await this.detectBotWall(page)
+    if (wall) {
+      GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)
+      throw new Error(`[Zoom] zoom_requires_rtms: ${wall}`)
+    }
+
+    // Wait for Join to enable (React enables within ~1-2s of valid name).
+    await page
+      .waitForFunction(
+        (sel: string) => {
+          const btn = document.querySelector(sel) as HTMLButtonElement | null
+          return !!btn && !btn.classList.contains("disabled") && !btn.disabled
+        },
+        JOIN_BUTTON,
+        { timeout: 8000 }
+      )
+      .catch(() => console.warn("[Zoom] Join still disabled after wait; attempting click anyway"))
+
+    // Mic: a recorder bot only RECEIVES audio, so mute it. But a bot with
+    // streaming_input speaks INTO the meeting (its audio is pumped to the
+    // virtual mic) — muting that bot means nobody ever hears it, which is how
+    // Meet/Teams gate this too. Only mute when we have no input stream.
+    const hasStreamingInput = !!GLOBAL.get().streaming_input
+    try {
+      const muteBtn = page.locator(PREVIEW_MUTE)
+      const label = await muteBtn.getAttribute("aria-label")
+      if (!hasStreamingInput && label === "Mute") {
+        await muteBtn.click()
+        console.log("[Zoom] Muted mic in preview (receive-only recorder bot)")
+      } else if (hasStreamingInput && label === "Unmute") {
+        await muteBtn.click()
+        console.log("[Zoom] Unmuted mic in preview (streaming_input — bot speaks)")
+      }
+    } catch {
+      /* not present */
+    }
+    // Stop video in preview.
+    try {
+      const videoBtn = page.locator(PREVIEW_VIDEO)
+      if ((await videoBtn.getAttribute("aria-label")) === "Stop Video") {
+        await videoBtn.click()
+        console.log("[Zoom] Stopped video in preview")
+      }
+    } catch {
+      /* already off / not present */
+    }
+
+    if (cancelCheck()) {
+      GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
+      throw new Error("Bot stopped before clicking Join")
+    }
+
+    // Click Join via the DOM to bypass Playwright's pointer-event hit-test —
+    // `.preview-meeting-info` overlays the Join button and makes a Playwright
+    // .click() time out after 30s; the React handler fires regardless.
+    console.log("[Zoom] Clicking Join (DOM-direct)...")
+    const clicked = await page.evaluate((sel: string) => {
+      const btn = document.querySelector(sel) as HTMLButtonElement | null
+      if (!btn || btn.classList.contains("disabled") || btn.disabled) return false
+      btn.click()
+      return true
+    }, JOIN_BUTTON)
+    if (!clicked) {
+      console.warn("[Zoom] DOM Join click failed; falling back to Playwright click")
+      const joinBtn = page.locator(JOIN_BUTTON)
+      await joinBtn.waitFor({ state: "visible", timeout: 10_000 }).catch(() => {})
+      await joinBtn.click({ force: true, timeout: 10_000 }).catch(() => {})
+    }
+    console.log("[Zoom] Join clicked — waiting for admission...")
+    await sleep(3000)
+
+    await this.waitForAdmission(page, cancelCheck)
+
+    onJoinSuccess()
+    console.log("[Zoom] ✅ onJoinSuccess called")
+    await htmlSnapshot.captureSnapshot(page, "zoom_join_meeting_success")
+  }
+
+  /**
+   * Poll until the bot is admitted (Leave button visible) or a terminal state
+   * appears. The waiting-room text check runs BEFORE the in-meeting check
+   * because Zoom renders the waiting room inside `.meeting-app` and the bot's
+   * own mic-preview audio stays live across the transition — either would
+   * false-positive as "admitted" (observed vexa meeting_id=36).
+   */
+  private async waitForAdmission(page: Page, cancelCheck: () => boolean): Promise<void> {
+    const timeoutMs = (GLOBAL.get().waiting_room_timeout ?? 600) * 1000
+    const start = Date.now()
+
+    while (Date.now() - start < timeoutMs) {
+      if (cancelCheck()) {
+        if (!GLOBAL.getEndReason()) GLOBAL.setError(MeetingEndReason.ApiRequest)
+        throw new Error("API request to stop Zoom recording")
+      }
+
+      // Terminal anti-bot wall — can stream in a beat after Join. Non-retryable.
+      const wall = await this.detectBotWall(page)
+      if (wall) {
+        GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)
+        throw new Error(`[Zoom] zoom_requires_rtms: ${wall}`)
+      }
+
+      // Rejected / meeting ended.
+      const denied = await zoomStateDetector.isDenied(page)
+      if (denied.matched) {
+        const reason =
+          (denied.pattern && "reason" in denied.pattern ? denied.pattern.reason : undefined) ??
+          MeetingEndReason.BotNotAccepted
+        GLOBAL.setError(reason)
+        throw new Error(`[Zoom] Rejected during admission: ${reason}`)
+      }
+
+      // Waiting room first (see method doc).
+      const waiting = await zoomStateDetector.isWaitingRoom(page)
+      if (!waiting.matched) {
+        const inMeeting = await zoomStateDetector.isInMeeting(page)
+        if (inMeeting.matched) {
+          console.log("[Zoom] Admitted — Leave button visible")
+          return
+        }
+      }
+
+      console.log(`[Zoom] Waiting for admission... ${Math.round((Date.now() - start) / 1000)}s`)
+      await sleep(2000)
+    }
+
+    GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
+    throw new Error(`[Zoom] Not admitted within ${timeoutMs}ms`)
+  }
+
+  private async detectBotWall(page: Page): Promise<string | null> {
+    try {
+      return await page.evaluate((phrases: string[]) => {
+        const body = (document.body?.innerText || "").toLowerCase()
+        for (const p of phrases) if (body.includes(p)) return p
+        return null
+      }, BOT_BLOCK_TEXTS)
+    } catch {
+      return null
+    }
+  }
+
+  async findEndMeeting(page: Page, _opts?: { ignoreAloneSignals?: boolean }): Promise<boolean> {
+    // Page freeze → meeting almost certainly ended (mirrors Meet/Teams).
+    try {
+      await Promise.race([
+        page.evaluate(() => document.readyState),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("freeze")), 20_000)
+        )
+      ])
+    } catch {
+      console.log("[Zoom] Page frozen 20s — meeting likely ended")
+      return true
+    }
+
+    // URL left the meeting (sign-in / non-meeting /wc/ / off-domain).
+    const url = page.url()
+    const offZoom =
+      !!url &&
+      !url.startsWith("about:") &&
+      !/zoom\.(us|com|eu|com\.cn|com\.br|com\.au|de|fr|jp|ca|co\.uk)\b/.test(url)
+    if (offZoom || url.includes("/signin") || url.includes("/login")) {
+      console.log(`[Zoom] Navigated away from meeting: ${url}`)
+      return true
+    }
+
+    // Removal / meeting-ended modal text.
+    const denied = await zoomStateDetector.isDenied(page)
+    if (denied.matched) {
+      console.log(`[Zoom] End detected: "${denied.matchedText}"`)
+      return true
+    }
+
+    // Leave button gone → probably removed. But recording-state ends the meeting
+    // on a SINGLE true (`if (botRemovedResult) return getBotRemovedReason()`),
+    // and Zoom AUTO-HIDES its footer toolbar — so one transient repaint would
+    // make the bot declare itself removed and abandon a live meeting.
+    // Require N consecutive misses, and ignore misses during the post-join
+    // window while Zoom's audio-init redirects settle. (vexa's removal monitor
+    // carried the same two guards; they were lost when its polling loop was
+    // collapsed into this one-shot check.)
+    const leaveVisible = await page
+      .locator(LEAVE_BUTTON)
+      .first()
+      .isVisible({ timeout: 300 })
+      .catch(() => false)
+
+    if (leaveVisible) {
+      this.leaveButtonMisses = 0
+      if (this.inMeetingSince === null) this.inMeetingSince = Date.now()
+      return false
+    }
+
+    // Never trust a miss before we've confirmed the footer once, or during the
+    // grace window right after it appeared.
+    if (
+      this.inMeetingSince === null ||
+      Date.now() - this.inMeetingSince < LEAVE_GRACE_MS
+    ) {
+      return false
+    }
+
+    this.leaveButtonMisses++
+    if (this.leaveButtonMisses < LEAVE_MISS_THRESHOLD) {
+      console.log(
+        `[Zoom] Leave button miss ${this.leaveButtonMisses}/${LEAVE_MISS_THRESHOLD} — not treating as removal yet`
+      )
+      return false
+    }
+    console.log(`[Zoom] Leave button gone ${this.leaveButtonMisses}x — treating as removal`)
+    return true
+  }
+
+  async closeMeeting(page: Page): Promise<void> {
+    console.log("[Zoom] Leaving meeting")
+    // Click via the DOM, not Playwright: HtmlCleaner sets the footer to
+    // opacity:0, and Playwright's actionability check refuses to click an
+    // element it considers invisible — so locator.click() would stall until
+    // timeout on every normal exit. A DOM .click() fires the React handler
+    // regardless. Meet does the same thing for the same reason.
+    const domClick = (sel: string) =>
+      page.evaluate((s: string) => {
+        const btn = document.querySelector(s) as HTMLElement | null
+        if (!btn) return false
+        btn.click()
+        return true
+      }, sel)
+
+    // Whole sequence is bounded: cleanup must not hang if Zoom's UI wedges.
+    await Promise.race([
+      (async () => {
+        try {
+          if (await domClick(LEAVE_BUTTON)) {
+            // Confirm dialog: "Leave Meeting" danger button (aria-label is
+            // empty, so it can only be matched on its class).
+            await sleep(500)
+            await domClick(LEAVE_CONFIRM)
+            console.log("[Zoom] Left meeting")
+            return
+          }
+          console.log("[Zoom] Leave button not found — navigating to about:blank")
+          await page.goto("about:blank").catch(() => {})
+        } catch (error) {
+          console.error("[Zoom] Error leaving meeting:", formatError(error))
+        }
+      })(),
+      sleep(5000)
+    ])
+  }
+}

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -1,4 +1,5 @@
 import type { BrowserContext, Page } from "@playwright/test"
+import { envVars } from "../config/env-vars"
 import { listenPage } from "../browser/page-logger"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
@@ -87,6 +88,21 @@ export class ZoomProvider implements MeetingProviderInterface {
     const page = await browserContext.newPage()
     page.setDefaultTimeout(30_000)
     page.setDefaultNavigationTimeout(60_000)
+
+    // Pin the viewport to the exact ffmpeg capture size. The page provably
+    // renders full-width (single-main-container__video-frame = 1280x720, right
+    // rail collapsed to 0px), so the black band on the right is the *viewport*
+    // being narrower than the fixed 1280-wide x11grab capture — CloakBrowser's
+    // humanize mode can randomize the viewport for anti-fingerprinting. Re-assert
+    // the intended size so Zoom's video fills the whole recorded frame.
+    try {
+      const width = envVars.RESOLUTION === "1080" ? 1920 : 1280
+      const height = envVars.RESOLUTION === "1080" ? 1080 : 720
+      await page.setViewportSize({ width, height })
+      console.log(`[Zoom] Viewport pinned to ${width}x${height} to match capture`)
+    } catch (e) {
+      console.warn("[Zoom] Failed to pin viewport size:", formatError(e))
+    }
 
     // Forward in-page console output to the bot log. Without this every
     // console.log inside page.evaluate() — including the speaker observer's

--- a/src/meeting/zoom/chatObserver.ts
+++ b/src/meeting/zoom/chatObserver.ts
@@ -124,7 +124,8 @@ export class ZoomChatObserver {
       ]
 
       const seenNodes = new WeakSet<Element>()
-      const seenHashes = new Set<string>()
+      const seenHashes = new Map<string, number>()
+      const HASH_TTL_MS = 5000
       let matchedContainer: Element | null = null
 
       const firstText = (root: Element, selectors: string[]): string => {
@@ -197,8 +198,10 @@ export class ZoomChatObserver {
         if (!msg) return
         if (isSystemMessage(msg)) return
         const hash = `${msg.sender} ${msg.text}`
-        if (seenHashes.has(hash)) return
-        seenHashes.add(hash)
+        const now = Date.now()
+        const last = seenHashes.get(hash)
+        if (last !== undefined && now - last < HASH_TTL_MS) return
+        seenHashes.set(hash, now)
         try {
           window.zoomChatMessage?.(msg)
         } catch {

--- a/src/meeting/zoom/chatObserver.ts
+++ b/src/meeting/zoom/chatObserver.ts
@@ -1,0 +1,261 @@
+import type { Page } from "@playwright/test"
+import { ChatManager } from "../../chat-manager"
+import { GLOBAL } from "../../singleton"
+import type { ChatMessageData } from "../../types"
+
+declare global {
+  interface Window {
+    zoomChatCleanup?: () => void
+    zoomChatMessage?: (msg: { sender: string; text: string }) => void
+  }
+}
+
+/**
+ * Zoom Web chat reader — DOM observation (no network). Ported from vexa
+ * `zoom-capture/zoom-chat.ts`: defensive multi-candidate selectors because
+ * Zoom's chat DOM shifts across builds, plus a heuristic fallback (short text =
+ * sender, long text = body). The chat panel must be OPEN for messages to exist
+ * in the DOM — Zoom mounts/unmounts it on toggle, so the in-page code polls for
+ * the container and re-attaches.
+ *
+ * Messages cross back to Node via exposeFunction and flow into ChatManager,
+ * matching MeetChatObserver. sender_id stays null (no participant-id mapping
+ * from Zoom's DOM); message_id is synthesised from sender+text.
+ */
+export class ZoomChatObserver {
+  private page: Page
+  private isObserving = false
+  private counter = 0
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  public async startObserving(): Promise<void> {
+    if (this.isObserving) return
+
+    const botName = GLOBAL.get().bot_name
+
+    // Open the chat panel. Zoom mounts the message list ONLY while the panel is
+    // open, so without this the observer polls forever for a container that
+    // never appears and any bot with no entry_message silently produces an empty
+    // chat_messages.json. (Previously the panel only ever opened as a
+    // side-effect of sendViaZoom, i.e. only when an entry_message was set.)
+    // Teams does the same thing explicitly. Match the EXACT toggle — a substring
+    // match on "chat" hits "Chat Settings" first and opens the settings menu.
+    // HtmlCleaner keeps the panel out of the recording visually (opacity), so it
+    // can stay open without polluting the video.
+    try {
+      await this.page.evaluate(() => {
+        const alreadyOpen = document.querySelector(
+          '[aria-label="Chat Message List"], .chat-virtuoso-wrapper'
+        )
+        if (alreadyOpen) return
+        const btn =
+          (document.querySelector(
+            'button[aria-label="open the chat panel"]'
+          ) as HTMLElement | null) ??
+          (Array.from(document.querySelectorAll("button")).find((b) => {
+            const al = (b.getAttribute("aria-label") || "").toLowerCase()
+            return al.includes("chat") && !al.includes("setting")
+          }) as HTMLElement | undefined)
+        btn?.click()
+      })
+    } catch (error) {
+      console.warn("[ZoomChatObserver] Could not open chat panel:", error)
+    }
+
+    await this.page.exposeFunction(
+      "zoomChatMessage",
+      async (msg: { sender: string; text: string }) => {
+        try {
+          // Zoom renders the bot's OWN messages with sender "You". Drop them:
+          // ChatManager.persistBotSentMessage already records anything the bot
+          // sends, and it writes via addChatMessage() directly — bypassing the
+          // dedup in handleChatMessage — so an echo captured here is stored as a
+          // SECOND copy no matter what sender we give it (observed live: the
+          // entry message appeared twice in chat_messages.json). Skipping self
+          // is the only place the duplicate can be cut.
+          if (msg.sender === "You" || msg.sender === botName) return
+          const data: ChatMessageData = {
+            text: msg.text,
+            sender_name: msg.sender || "Unknown",
+            sender_id: null,
+            timestamp: new Date().toISOString(),
+            message_id: `zoom-${Date.now()}-${this.counter++}`
+          }
+          await ChatManager.getInstance().handleChatMessage(data)
+        } catch (error) {
+          console.error("[ZoomChatObserver] Error handling message:", error)
+        }
+      }
+    )
+
+    await this.page.evaluate(() => {
+      const CONTAINER_SELECTORS = [
+        '[aria-label="Chat Message List"]',
+        ".chat-virtuoso-wrapper",
+        "#chat-list-content",
+        ".chat-list-content",
+        ".chat-container__chat-list",
+        '[class*="chat-list"]',
+        '[class*="chat-message-list"]'
+      ]
+      const MESSAGE_SELECTORS = [
+        '[id^="chat-message-"]',
+        ".new-chat-message__container",
+        '[class*="chat-message-item"]',
+        '[class*="chatMessage"]',
+        "div[data-index]"
+      ]
+      const SENDER_SELECTORS = [
+        ".chat-message-text__user-name",
+        '[class*="user-name"]',
+        '[class*="userName"]',
+        '[class*="sender"]',
+        '[class*="display-name"]'
+      ]
+      const TEXT_SELECTORS = [
+        '[class*="chat-message-text"]',
+        '[class*="message-text"]',
+        '[class*="messageText"]',
+        ".text-wrapper",
+        '[class*="text-content"]'
+      ]
+
+      const seenNodes = new WeakSet<Element>()
+      const seenHashes = new Set<string>()
+      let matchedContainer: Element | null = null
+
+      const firstText = (root: Element, selectors: string[]): string => {
+        for (const s of selectors) {
+          const t = root.querySelector(s)?.textContent?.trim()
+          if (t) return t
+        }
+        return ""
+      }
+
+      const senderFromAria = (node: Element): string => {
+        let cur: Element | null = node
+        for (let i = 0; i < 4 && cur; i++, cur = cur.parentElement) {
+          const al = cur.getAttribute?.("aria-label") || ""
+          const m = al.match(/^(.+?)\s+(?:said|to\s+Everyone|to\s+[A-Z])/i)
+          if (m && m[1].trim()) return m[1].trim()
+        }
+        return ""
+      }
+
+      const extract = (node: Element): { sender: string; text: string } | null => {
+        let text = firstText(node, TEXT_SELECTORS)
+        let sender = firstText(node, SENDER_SELECTORS)
+        if (!sender) {
+          let cur: Element | null = node.parentElement
+          for (let i = 0; i < 4 && cur && !sender; i++, cur = cur.parentElement)
+            sender = firstText(cur, SENDER_SELECTORS)
+        }
+        if (!sender) sender = senderFromAria(node)
+        if (!text) {
+          const frags = Array.from(node.querySelectorAll("*"))
+            .map((e) => (e.childElementCount === 0 ? (e.textContent || "").trim() : ""))
+            .filter((t) => t.length > 0)
+          if (!frags.length) return null
+          const longest = frags.reduce((a, b) => (b.length > a.length ? b : a), "")
+          text = longest
+          if (!sender) {
+            const shortName = frags.find(
+              (f) => f !== longest && f.length <= 40 && !/^\d{1,2}:\d{2}/.test(f)
+            )
+            if (shortName) sender = shortName
+          }
+        }
+        sender = sender.replace(/\s*\d{1,2}:\d{2}\s*(AM|PM)?\s*$/i, "").trim() || "Unknown"
+        if (!text) return null
+        return { sender, text }
+      }
+
+      // Zoom injects system notices into the same message list as human chat
+      // (the group-chat banner, join/leave events). They carry no sender, so
+      // they'd land in the artifact as sender_name "Unknown" — observed live:
+      // "Messages addressed to \"Meeting Group Chat\" will also appear…" and
+      // "Recording Bot left". Drop them: a chat artifact must contain only what
+      // participants actually typed.
+      const SYSTEM_TEXT_PATTERNS = [
+        /^messages addressed to/i,
+        /will also appear in the meeting group chat/i,
+        /^\s*.+\s+(joined|left)\s*$/i,
+        /^this meeting is being recorded/i,
+        /^recording (started|stopped)/i,
+        /^who can see your messages\?/i
+      ]
+      const isSystemMessage = (m: { sender: string; text: string }): boolean =>
+        m.sender === "Unknown" && SYSTEM_TEXT_PATTERNS.some((re) => re.test(m.text.trim()))
+
+      const emit = (node: Element) => {
+        if (seenNodes.has(node)) return
+        seenNodes.add(node)
+        const msg = extract(node)
+        if (!msg) return
+        if (isSystemMessage(msg)) return
+        const hash = `${msg.sender} ${msg.text}`
+        if (seenHashes.has(hash)) return
+        seenHashes.add(hash)
+        try {
+          window.zoomChatMessage?.(msg)
+        } catch {
+          /* never break capture */
+        }
+      }
+
+      const scanMessages = (root: ParentNode) => {
+        for (const sel of MESSAGE_SELECTORS) {
+          const nodes = root.querySelectorAll(sel)
+          if (nodes.length) {
+            nodes.forEach((n) => emit(n))
+            return
+          }
+        }
+      }
+
+      const findContainer = (): Element | null => {
+        for (const sel of CONTAINER_SELECTORS) {
+          const el = document.querySelector(sel)
+          if (el) return el
+        }
+        return null
+      }
+
+      const observer = new MutationObserver(() => {
+        if (matchedContainer) scanMessages(matchedContainer)
+      })
+      const attach = () => {
+        const found = findContainer()
+        if (found && found !== matchedContainer) {
+          matchedContainer = found
+          observer.disconnect()
+          observer.observe(matchedContainer, { childList: true, subtree: true })
+          scanMessages(matchedContainer)
+        } else if (found) {
+          scanMessages(matchedContainer!)
+        }
+      }
+      attach()
+      const poll = window.setInterval(attach, 2000)
+      window.zoomChatCleanup = () => {
+        window.clearInterval(poll)
+        observer.disconnect()
+      }
+    })
+
+    this.isObserving = true
+    console.log("[ZoomChatObserver] Chat observation started")
+  }
+
+  public stopObserving(): void {
+    if (!this.isObserving) return
+    this.page
+      ?.evaluate(() => window.zoomChatCleanup?.())
+      .catch((e) => console.error("[ZoomChatObserver] Error stopping:", e))
+    this.isObserving = false
+    console.log("[ZoomChatObserver] Chat observation stopped")
+  }
+}

--- a/src/meeting/zoom/htmlCleaner.ts
+++ b/src/meeting/zoom/htmlCleaner.ts
@@ -1,0 +1,85 @@
+import type { Page } from "@playwright/test"
+import type { RecordingMode } from "../../types"
+
+declare global {
+  interface Window {
+    zoomHtmlCleanerInterval?: NodeJS.Timeout
+  }
+}
+
+/**
+ * Zoom Web recording cleaner — hides the browser-client chrome (footer toolbar,
+ * header, reaction/notification toasts, "you are viewing" banners) so the
+ * ffmpeg x11grab capture shows the video tiles / active speaker, not Zoom's UI.
+ *
+ * First-cut selectors from the live Zoom Web DOM; runs on an interval like
+ * MeetHtmlCleaner because Zoom mounts toasts and banners dynamically. Anchors
+ * on stable class prefixes and leaves the video surface untouched.
+ */
+export class ZoomHtmlCleaner {
+  private page: Page
+  private recordingMode: RecordingMode
+
+  constructor(page: Page, recordingMode: RecordingMode) {
+    this.page = page
+    this.recordingMode = recordingMode
+  }
+
+  public async start(): Promise<void> {
+    console.log("[Zoom] Starting HTML cleaner")
+    await this.page.evaluate(() => {
+      const HIDE_SELECTORS = [
+        ".footer",
+        "#foot-bar",
+        ".footer__inner",
+        "#wc-footer",
+        ".full-screen-icon",
+        ".meeting-header",
+        "#meeting-header",
+        ".meeting-info-container",
+        ".notification-message-wrap",
+        ".toast-list",
+        ".sharee-container__viewing-status",
+        ".new-caption-box", // live-caption overlay
+        ".reaction-animate-container",
+        ".zmwebsdk-makeStyles-toast-1",
+        // The chat panel is deliberately held OPEN for the whole meeting —
+        // Zoom only mounts the message list while it's open, so closing it would
+        // kill chat capture. Hide it visually instead. opacity (not display) is
+        // essential: unmounting the panel would unmount the messages with it.
+        ".chat-container",
+        "#chat-container",
+        '[aria-label="Chat Message List"]'
+      ]
+      // Hide with opacity ONLY — never `pointer-events: none`, and never
+      // display:none. The Leave button lives inside `.footer`, and closeMeeting
+      // clicks it to end the call: pointer-events:none makes Playwright's
+      // hit-target check fail, so every normal meeting end hangs until timeout
+      // and the bot never actually leaves. (Meet hit this exact trap — see the
+      // evaluate-click comment in meet.ts.) Elements must stay in the layout and
+      // stay clickable; they just must not be visible in the recording.
+      const clean = () => {
+        for (const sel of HIDE_SELECTORS) {
+          document.querySelectorAll(sel).forEach((el) => {
+            ;(el as HTMLElement).style.opacity = "0"
+          })
+        }
+      }
+      clean()
+      window.zoomHtmlCleanerInterval = setInterval(clean, 500)
+    })
+    console.log("[Zoom] HTML cleaner started")
+  }
+
+  public async stop(): Promise<void> {
+    await this.page
+      .evaluate(() => {
+        if (window.zoomHtmlCleanerInterval) {
+          clearInterval(window.zoomHtmlCleanerInterval)
+          delete window.zoomHtmlCleanerInterval
+        }
+      })
+      .catch((e) => console.error("[Zoom] HTML cleaner stop error:", e))
+    console.log("[Zoom] HTML cleaner stopped")
+  }
+}

--- a/src/meeting/zoom/htmlCleaner.ts
+++ b/src/meeting/zoom/htmlCleaner.ts
@@ -58,6 +58,41 @@ export class ZoomHtmlCleaner {
       // and the bot never actually leaves. (Meet hit this exact trap — see the
       // evaluate-click comment in meet.ts.) Elements must stay in the layout and
       // stay clickable; they just must not be visible in the recording.
+      // Inject CSS (once) that (a) forces the Zoom speaker video to fill the whole
+      // recorded frame — killing the black band, and covering the participants
+      // panel when we open it to read the roster — and (b) hides the name/network
+      // label overlaid on the tile. Uses opacity:0 for the name so the speaker
+      // observer can still read its text (display:none would keep it readable too,
+      // but opacity is safe and consistent with the rest of the cleaner).
+      const STYLE_ID = "baas-zoom-rec-fix"
+      if (!document.getElementById(STYLE_ID)) {
+        const style = document.createElement("style")
+        style.id = STYLE_ID
+        style.textContent = [
+          "#video-share-layout video-player {",
+          "  position: fixed !important; inset: 0 !important;",
+          "  top: 0 !important; left: 0 !important;",
+          "  width: 100vw !important; height: 100vh !important;",
+          "  z-index: 2147483000 !important;",
+          "}",
+          "#video-share-layout video-player video {",
+          "  width: 100% !important; height: 100% !important;",
+          "  object-fit: cover !important;",
+          "}",
+          ".video-avatar__avatar-footer { opacity: 0 !important; }",
+          // The speaker observer opens the participants pane to read the roster
+          // (so the log can show Speaker 1/2/3). Force that pane OFF-SCREEN and out
+          // of flow so it never appears in the recording and never squeezes the
+          // video — but keep it sized/rendered so its names stay readable in the DOM.
+          "#wc-container-right {",
+          "  position: fixed !important; left: -100000px !important; top: 0 !important;",
+          "  width: 360px !important; height: 100vh !important;",
+          "  opacity: 0 !important; pointer-events: none !important; z-index: -1 !important;",
+          "}"
+        ].join("\n")
+        document.head.appendChild(style)
+      }
+
       const clean = () => {
         for (const sel of HIDE_SELECTORS) {
           document.querySelectorAll(sel).forEach((el) => {

--- a/src/meeting/zoom/speakersObserver.ts
+++ b/src/meeting/zoom/speakersObserver.ts
@@ -1,0 +1,271 @@
+import type { Page } from "@playwright/test"
+import type { RecordingMode, SpeakerData } from "../../types"
+
+declare global {
+  interface Window {
+    zoomObserverCleanup?: () => void
+    zoomSpeakersChanged?: (speakers: SpeakerData[]) => void
+    zoomSpeakerForensics?: (report: string) => void
+  }
+}
+
+/**
+ * Zoom Web speaker attribution — TEMPORAL, DOM-based.
+ *
+ * Unlike Meet (per-participant <audio> → per-track vote/lock) and unlike our
+ * Meet/Teams network-interception path, the Zoom Web client exposes only a
+ * mixed audio stream (captured out-of-band by PulseAudio → ffmpeg, same as
+ * every platform here). So attribution is temporal: read who Zoom is CURRENTLY
+ * rendering as the active speaker from the DOM and label the mixed audio with
+ * that name by timestamp.
+ *
+ * Logic + selectors ported verbatim from vexa `zoom-capture/zoom-speakers.ts`
+ * (active-speaker containers + avatar footer, 250ms poll, 2-poll flicker
+ * debounce, 2s heartbeat). Emits SpeakerData[] over the exposeFunction bridge
+ * exactly like MeetSpeakersObserver, so the downstream speaker-manager /
+ * diarization-tracker is unchanged.
+ *
+ * KNOWN LIMITATION (documented, not a bug): temporal attribution cannot
+ * separate overlapping speakers — whoever Zoom lights up wins the turn. Quality
+ * is below Meet's per-participant network diarization. The in-page getState()
+ * probe is exposed for live selector-forensics when Zoom shifts its DOM.
+ */
+export class ZoomSpeakersObserver {
+  private page: Page
+  private recordingMode: RecordingMode
+  private botName: string
+  private onSpeakersChange: (speakers: SpeakerData[]) => void
+  private isObserving = false
+
+  private readonly POLL_MS = 250
+  private readonly CONFIRM_POLLS = 2
+  private readonly HEARTBEAT_MS = 2000
+
+  constructor(
+    page: Page,
+    recordingMode: RecordingMode,
+    botName: string,
+    onSpeakersChange: (speakers: SpeakerData[]) => void
+  ) {
+    this.page = page
+    this.recordingMode = recordingMode
+    this.botName = botName
+    this.onSpeakersChange = onSpeakersChange
+  }
+
+  public async startObserving(): Promise<void> {
+    if (this.isObserving) {
+      console.warn("[Zoom] Already observing speakers")
+      return
+    }
+    console.log("[Zoom] Starting speaker observation (temporal DOM)...")
+
+    await this.page.exposeFunction("zoomSpeakersChanged", (speakers: SpeakerData[]) => {
+      try {
+        this.onSpeakersChange(speakers)
+      } catch (error) {
+        console.error("[Zoom] Error in speakers callback:", error)
+      }
+    })
+
+    // Forensics come back over the exposeFunction bridge, NOT page console:
+    // page-logger only forwards page console when LOG_LEVEL=debug, so an
+    // in-page console.log here is dropped in normal runs — which is precisely
+    // how the first stale-selector dump went missing.
+    await this.page.exposeFunction("zoomSpeakerForensics", (report: string) => {
+      console.error(`[Zoom-Speakers] FORENSICS (active-speaker selectors matched nothing): ${report}`)
+    })
+
+    await this.page.evaluate(
+      ({ selfName, pollMs, confirmPolls, heartbeatMs }) => {
+        // Active-speaker containers, most-specific first.
+        //
+        // The first two are vexa's; live forensics against Zoom (2026-07) show
+        // BOTH match zero elements — vexa's Zoom speaker module was never wired
+        // into their own bot, so its selectors were never exercised. Kept only
+        // as fallbacks for older/other Zoom builds.
+        //
+        // `.single-main-container__video-frame` is what Zoom actually renders
+        // today: the speaker-view main tile. Zoom itself decides who occupies
+        // it, so the name in its footer IS Zoom's active-speaker pick — which is
+        // precisely the temporal attribution we want.
+        //
+        // Note: the same forensics found NO class matching
+        // /speak|talk|active|audio|voice/ anywhere in the tile DOM, so Zoom
+        // exposes no per-tile "is speaking" flag here. Occupancy of the main
+        // tile is the only speaking signal available to a DOM observer.
+        const ACTIVE_CONTAINER_SELECTORS = [
+          ".speaker-active-container__video-frame",
+          ".speaker-bar-container__video-frame--active",
+          ".single-main-container__video-frame",
+          ".gallery-video-container__video-frame--active"
+        ]
+        const NAME_FOOTER_SELECTOR = ".video-avatar__avatar-footer"
+
+        let active: string | null = null
+        let candidate: string | null = null
+        let candidateCount = 0
+        const heartbeatPolls = Math.max(1, Math.round(heartbeatMs / pollMs))
+        let sinceEmit = 0
+
+        function nameFromContainer(container: Element | null): string | null {
+          if (!container) return null
+          const footer = container.querySelector(NAME_FOOTER_SELECTOR)
+          if (!footer) return null
+          const span = footer.querySelector("span")
+          const raw =
+            (span?.textContent?.trim() || (footer as HTMLElement).innerText?.trim()) || ""
+          const t = raw.replace(/\s+/g, " ").trim()
+          return t || null
+        }
+
+        let reportedSelector: string | null = null
+        function readActiveSpeaker(): string | null {
+          for (const sel of ACTIVE_CONTAINER_SELECTORS) {
+            const name = nameFromContainer(document.querySelector(sel))
+            if (name) {
+              // Report which selector actually won, once — Zoom shifts this DOM
+              // across builds and a silent fallback would hide the drift.
+              if (reportedSelector !== sel) {
+                reportedSelector = sel
+                try {
+                  window.zoomSpeakerForensics?.(`RESOLVED via "${sel}" -> "${name}"`)
+                } catch {
+                  /* bridge unavailable */
+                }
+              }
+              // Never report the bot itself as the remote speaker.
+              if (selfName && name.toLowerCase() === selfName.toLowerCase()) return null
+              return name
+            }
+          }
+          return null
+        }
+
+        // Emit the active-speaker set (0 or 1 name) as SpeakerData[], the shape
+        // speaker-manager consumes. id=0 marks UI/DOM-based detection.
+        //
+        // LIMITATION — isSpeaking is always true when a name is present, and
+        // that is not a shortcut: Zoom's web DOM exposes NO per-tile speaking
+        // flag in this view (live forensics found no class matching
+        // /speak|talk|active|audio|voice/ anywhere in the tile subtree). The
+        // only signal available is WHO Zoom puts in the main tile. So this
+        // reports "who Zoom currently considers the active speaker", not "who is
+        // producing audio right now" — it cannot distinguish speech from
+        // silence, and cannot separate overlapping speakers. Silence is handled
+        // out-of-band by SoundLevelMonitor (ffmpeg PCM levels), which is why the
+        // recording still ends correctly on a silent call.
+        function emit(name: string | null): void {
+          const speakers: SpeakerData[] = name
+            ? [{ name, id: 0, timestamp: Date.now(), isSpeaking: true }]
+            : []
+          try {
+            window.zoomSpeakersChanged?.(speakers)
+          } catch {
+            /* consumer error */
+          }
+        }
+
+        // Selector forensics. The active-speaker selectors above came from vexa,
+        // whose own Zoom speaker module was never wired into their bot — so they
+        // carry no production hours and Zoom shifts this DOM across builds. If we
+        // never resolve a speaker, dump the real participant-tile structure ONCE
+        // so the next run tells us the current selectors instead of silently
+        // producing an unattributed transcript.
+        let probesLeft = 1
+        function dumpDomForensics(): void {
+          if (probesLeft <= 0) return
+          probesLeft--
+          const HINT = /speak|talk|active|audio|volume|voice/i
+          const probe = ACTIVE_CONTAINER_SELECTORS.map((s) => ({
+            selector: s,
+            present: !!document.querySelector(s)
+          }))
+          const footers = document.querySelectorAll(NAME_FOOTER_SELECTOR).length
+          // Sweep name-ish / avatar-ish / video-adjacent nodes carrying short text.
+          const survey: string[] = []
+          const sweep = document.querySelectorAll(
+            '[class*="name"],[class*="avatar"],[class*="participant"],[class*="video"],[class*="tile"],[class*="speaker"]'
+          )
+          for (let i = 0; i < sweep.length && survey.length < 20; i++) {
+            const el = sweep[i] as HTMLElement
+            const cls = String(el.className).slice(0, 70)
+            let own = ""
+            for (const n of Array.from(el.childNodes)) if (n.nodeType === 3) own += n.textContent || ""
+            own = own.trim().slice(0, 30)
+            const hint = HINT.test(cls) ? " [SPEAKING-HINT]" : ""
+            if (cls) survey.push(`${el.tagName.toLowerCase()}.${cls}${own ? ` »${own}` : ""}${hint}`)
+          }
+          try {
+            window.zoomSpeakerForensics?.(
+              `knownSelectors=${JSON.stringify(probe)} nameFooters=${footers} survey=${JSON.stringify(survey)}`
+            )
+          } catch {
+            /* bridge unavailable */
+          }
+        }
+
+        let emptyPolls = 0
+        function tick(): void {
+          let name: string | null = null
+          try {
+            name = readActiveSpeaker()
+          } catch {
+            return
+          }
+          // ~10s of continuous "nobody" while the call is live: either genuinely
+          // silent, or our selectors are stale. Dump once so we can tell which.
+          if (!name && active === null && ++emptyPolls === Math.round(10_000 / pollMs)) {
+            dumpDomForensics()
+          }
+          if (name) emptyPolls = 0
+          if (name !== active) {
+            if (name === candidate) candidateCount++
+            else {
+              candidate = name
+              candidateCount = 1
+            }
+            if (candidateCount >= confirmPolls) {
+              active = candidate
+              candidateCount = 0
+              sinceEmit = 0
+              emit(active)
+            }
+          } else {
+            candidate = active
+            candidateCount = 0
+            if (active && ++sinceEmit >= heartbeatPolls) {
+              sinceEmit = 0
+              emit(active)
+            }
+          }
+        }
+
+        tick()
+        const timer = setInterval(tick, pollMs)
+
+        window.zoomObserverCleanup = () => {
+          clearInterval(timer)
+        }
+      },
+      {
+        selfName: this.botName,
+        pollMs: this.POLL_MS,
+        confirmPolls: this.CONFIRM_POLLS,
+        heartbeatMs: this.HEARTBEAT_MS
+      }
+    )
+
+    this.isObserving = true
+    console.log("[Zoom] ✅ Speaker observer started")
+  }
+
+  public stopObserving(): void {
+    if (!this.isObserving) return
+    this.page
+      ?.evaluate(() => window.zoomObserverCleanup?.())
+      .catch((e) => console.error("[Zoom] Error cleaning up observer:", e))
+    this.isObserving = false
+    console.log("[Zoom] ✅ Speaker observer stopped")
+  }
+}

--- a/src/meeting/zoom/speakersObserver.ts
+++ b/src/meeting/zoom/speakersObserver.ts
@@ -1,5 +1,12 @@
 import type { Page } from "@playwright/test"
 import type { RecordingMode, SpeakerData } from "../../types"
+import { SoundLevelMonitor } from "../../utils/sound-level-monitor"
+
+// Audio level above which we treat the active tile as speaking. Deliberately
+// lower than recording-state's SOUND_LEVEL_ACTIVITY_THRESHOLD (5) so quieter
+// speech still flips isSpeaking; this only affects the observer's label, not the
+// silence/meeting-end logic.
+const SOUND_ACTIVITY_THRESHOLD = 2
 
 declare global {
   interface Window {
@@ -41,6 +48,15 @@ export class ZoomSpeakersObserver {
   private readonly CONFIRM_POLLS = 2
   private readonly HEARTBEAT_MS = 2000
 
+  // Fast audio re-gating: the in-page observer only re-emits ~every HEARTBEAT_MS,
+  // which made isSpeaking lag speech by up to ~2s. We cache the last roster from
+  // the page and re-evaluate isSpeaking against the live audio level on a fast
+  // timer, re-emitting only when the speaking state flips (so the log isn't spammed).
+  private lastSpeakers: SpeakerData[] = []
+  private lastSpeaking = false
+  private soundGateTimer: NodeJS.Timeout | null = null
+  private readonly SOUND_GATE_MS = 250
+
   constructor(
     page: Page,
     recordingMode: RecordingMode,
@@ -62,11 +78,24 @@ export class ZoomSpeakersObserver {
 
     await this.page.exposeFunction("zoomSpeakersChanged", (speakers: SpeakerData[]) => {
       try {
-        this.onSpeakersChange(speakers)
+        this.lastSpeakers = speakers
+        this.emitGated(speakers)
       } catch (error) {
         console.error("[Zoom] Error in speakers callback:", error)
       }
     })
+
+    // Fast audio re-gate: the page emits ~every 2s, so without this isSpeaking
+    // lagged speech by seconds. Poll the live audio level quickly and re-emit the
+    // cached roster the instant speech starts or stops (only on a flip → no spam).
+    this.soundGateTimer = setInterval(() => {
+      if (this.lastSpeakers.length === 0) return
+      const level = SoundLevelMonitor.peekInstance()?.getCurrentSoundLevel() ?? 0
+      const speaking = level > SOUND_ACTIVITY_THRESHOLD
+      if (speaking !== this.lastSpeaking) {
+        this.emitGated(this.lastSpeakers)
+      }
+    }, this.SOUND_GATE_MS)
 
     // Forensics come back over the exposeFunction bridge, NOT page console:
     // page-logger only forwards page console when LOG_LEVEL=debug, so an
@@ -142,23 +171,81 @@ export class ZoomSpeakersObserver {
           return null
         }
 
-        // Emit the active-speaker set (0 or 1 name) as SpeakerData[], the shape
-        // speaker-manager consumes. id=0 marks UI/DOM-based detection.
-        //
-        // LIMITATION — isSpeaking is always true when a name is present, and
-        // that is not a shortcut: Zoom's web DOM exposes NO per-tile speaking
-        // flag in this view (live forensics found no class matching
-        // /speak|talk|active|audio|voice/ anywhere in the tile subtree). The
-        // only signal available is WHO Zoom puts in the main tile. So this
-        // reports "who Zoom currently considers the active speaker", not "who is
-        // producing audio right now" — it cannot distinguish speech from
-        // silence, and cannot separate overlapping speakers. Silence is handled
-        // out-of-band by SoundLevelMonitor (ffmpeg PCM levels), which is why the
-        // recording still ends correctly on a silent call.
+        // Full roster from the participants panel. The panel is opened but forced
+        // OFF-SCREEN and out of flow by the html cleaner (position:fixed;
+        // left:-100000px; opacity:0), so it never appears in the recording and the
+        // video keeps the full frame — while its text stays readable here.
+        const ROSTER_NAME_SELECTORS = [
+          ".participants-item__display-name",
+          '[class*="participants-item"] [class*="display-name"]',
+          '[class*="participants-li"] [class*="display-name"]',
+          '#participants-ul [class*="display-name"]',
+          '[class*="participants-item"] [class*="name"]'
+        ]
+        let rosterReported = false
+
+        function openParticipantsPanel(): void {
+          try {
+            const btn = document.querySelector(
+              'button[aria-label*="open the participants list pane"]'
+            ) as HTMLElement | null
+            if (btn) btn.click()
+          } catch {
+            /* ignore */
+          }
+        }
+
+        function readRoster(): string[] {
+          const names: string[] = []
+          const seen = new Set<string>()
+          for (const sel of ROSTER_NAME_SELECTORS) {
+            const els = document.querySelectorAll(sel)
+            if (els.length === 0) continue
+            els.forEach((el) => {
+              const raw = ((el as HTMLElement).innerText || el.textContent || "")
+                .replace(/\s+/g, " ")
+                .trim()
+              const nm = raw.replace(/\s*\((host|guest|me|co-host)[^)]*\)\s*/gi, "").trim()
+              if (nm && !seen.has(nm.toLowerCase())) {
+                seen.add(nm.toLowerCase())
+                names.push(nm)
+              }
+            })
+            if (names.length > 0) {
+              if (!rosterReported) {
+                rosterReported = true
+                try {
+                  window.zoomSpeakerForensics?.(`ROSTER via "${sel}" -> ${JSON.stringify(names)}`)
+                } catch {
+                  /* bridge unavailable */
+                }
+              }
+              break
+            }
+          }
+          return names
+        }
+
+        // Emit the speaker set. When the roster is readable, emit EVERY participant
+        // (so the log shows Speaker 1, 2, 3), with the one Zoom shows in the main
+        // tile flagged isSpeaking (keeps the audio-capture-failure safety net alive,
+        // since there is always exactly one active tile). If the roster isn't
+        // available, fall back to the single active tile.
         function emit(name: string | null): void {
-          const speakers: SpeakerData[] = name
-            ? [{ name, id: 0, timestamp: Date.now(), isSpeaking: true }]
-            : []
+          const roster = readRoster().filter(
+            (n) => !(selfName && n.toLowerCase() === selfName.toLowerCase())
+          )
+          let speakers: SpeakerData[]
+          if (roster.length > 0) {
+            speakers = roster.map((n, i) => ({
+              name: n,
+              id: i,
+              timestamp: Date.now(),
+              isSpeaking: name ? n.toLowerCase() === name.toLowerCase() : false
+            }))
+          } else {
+            speakers = name ? [{ name, id: 0, timestamp: Date.now(), isSpeaking: true }] : []
+          }
           try {
             window.zoomSpeakersChanged?.(speakers)
           } catch {
@@ -241,11 +328,26 @@ export class ZoomSpeakersObserver {
           }
         }
 
+        // Open the participants panel so readRoster() can see everyone. The panel
+        // is forced off-screen by the html cleaner, so it never shows. Retry a few
+        // seconds; safe to call repeatedly (once open, the "open …" button is gone).
+        openParticipantsPanel()
+        let panelAttempts = 0
+        const panelOpener = setInterval(() => {
+          panelAttempts++
+          if (readRoster().length > 0 || panelAttempts >= 20) {
+            clearInterval(panelOpener)
+            return
+          }
+          openParticipantsPanel()
+        }, 500)
+
         tick()
         const timer = setInterval(tick, pollMs)
 
         window.zoomObserverCleanup = () => {
           clearInterval(timer)
+          clearInterval(panelOpener)
         }
       },
       {
@@ -260,8 +362,31 @@ export class ZoomSpeakersObserver {
     console.log("[Zoom] ✅ Speaker observer started")
   }
 
+  /**
+   * Gate isSpeaking on the REAL audio level and forward to the consumer.
+   *
+   * Zoom's web DOM has no per-tile speaking flag, so the in-page observer marks
+   * the main-tile occupant isSpeaking=true unconditionally. Ungated that is both
+   * misleading in the log and dangerous — recording-state's checkNoSpeaker treats
+   * a recent DOM speaker as "still speaking", so a permanently-true flag keeps the
+   * silence timeout from ever firing. Gating on the audio pipeline makes isSpeaking
+   * reflect actual speech and lets the silence timeout work. No names are logged
+   * here — the speaker-manager table masks them to "Speaker N".
+   */
+  private emitGated(speakers: SpeakerData[]): void {
+    const level = SoundLevelMonitor.peekInstance()?.getCurrentSoundLevel() ?? 0
+    const speaking = level > SOUND_ACTIVITY_THRESHOLD
+    this.lastSpeaking = speaking
+    const gated = speakers.map((s) => ({ ...s, isSpeaking: s.isSpeaking && speaking }))
+    this.onSpeakersChange(gated)
+  }
+
   public stopObserving(): void {
     if (!this.isObserving) return
+    if (this.soundGateTimer) {
+      clearInterval(this.soundGateTimer)
+      this.soundGateTimer = null
+    }
     this.page
       ?.evaluate(() => window.zoomObserverCleanup?.())
       .catch((e) => console.error("[Zoom] Error cleaning up observer:", e))

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -441,6 +441,9 @@ export class ScreenRecorder extends EventEmitter {
       "1", // Mono
       "-ar",
       "24000", // 24kHz is sufficient for sound level analysis
+      "-flush_packets",
+      "1", // Flush each packet to the pipe immediately — keeps the sound level
+      // (and the Zoom observer's isSpeaking) low-latency instead of buffering.
       "-f",
       "f32le", // Raw float32 format
       "pipe:1" // stdout

--- a/src/state-machine/machine.ts
+++ b/src/state-machine/machine.ts
@@ -1,5 +1,6 @@
 import { MeetProvider } from "../meeting/meet"
 import { TeamsProvider } from "../meeting/teams"
+import { ZoomProvider } from "../meeting/zoom"
 import { SimpleDialogObserver } from "../services/dialog-observer/simple-dialog-observer"
 import { GLOBAL } from "../singleton"
 import type { MeetingProviderInterface } from "../types"
@@ -27,8 +28,23 @@ export class MeetingStateMachine {
 
   constructor() {
     this.currentState = MeetingStateType.Initialization
-    this.provider =
-      GLOBAL.get().meeting_platform === "teams" ? new TeamsProvider() : new MeetProvider()
+    // Explicit switch (was a teams?:meet ternary that silently handed "zoom"
+    // bots a MeetProvider — they'd navigate a Zoom URL with Meet selectors and
+    // fail confusingly). Unknown platforms now throw instead of masquerading.
+    const platform = GLOBAL.get().meeting_platform
+    switch (platform) {
+      case "teams":
+        this.provider = new TeamsProvider()
+        break
+      case "zoom":
+        this.provider = new ZoomProvider()
+        break
+      case "meet":
+        this.provider = new MeetProvider()
+        break
+      default:
+        throw new Error(`Unknown meeting_platform: ${platform}`)
+    }
 
     this.context = {
       provider: this.provider,

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -19,14 +19,23 @@ const SOUND_LEVEL_ACTIVITY_THRESHOLD = 5
 // which calls ensurePageLoaded (20s) + button search, while Meet is faster
 const getBotRemovalCheckTimeout = (): number => {
   const provider = GLOBAL.get().meeting_platform
-  return provider === "teams" ? 40000 : 25000 // Teams: 40s, Meet: 25s (sufficient for page.content())
+  // Zoom needs Teams-level headroom: its findEndMeeting embeds a 20s page-freeze
+  // race, so Meet's 25s budget leaves only ~5s for the rest of the check, and
+  // Zoom Web is the heaviest client we run (it's the reason for --in-process-gpu).
+  if (provider === "teams" || provider === "zoom") return 40000
+  return 25000 // Meet: 25s (sufficient for page.content())
 }
 
 // Window for checking recent speaker callbacks when timeout occurs
 // Use a wider window for Teams to avoid false positives when page is slow but still active
 const getSpeakerCallbackCheckWindow = (): number => {
   const provider = GLOBAL.get().meeting_platform
-  return provider === "teams" ? 60000 : 30000 // Teams: 60s, Meet: 30s
+  // Zoom widened alongside Teams: this window is the "page is slow but alive"
+  // rescue signal, and Zoom's observer only emits while someone occupies the
+  // main tile — so a quiet stretch produces no callbacks at all and a slow page
+  // would otherwise be misread as a removal.
+  if (provider === "teams" || provider === "zoom") return 60000
+  return 30000 // Meet: 30s
 }
 
 // How long the bot must be alone (no other attendees + no sound) before leaving
@@ -723,6 +732,23 @@ export class RecordingState extends BaseState {
     now: number,
     currentSoundLevel: number
   ): { shouldEnd: boolean; reason?: MeetingEndReason } {
+    // Zoom cannot participate in this check. attendeesCount comes from the
+    // speaker observer's emitted array (speaker-manager.ts), and Zoom's DOM
+    // observer emits only the ACTIVE SPEAKER (0 or 1 name), never a roster — so
+    // `attendeesCount <= 1` below is permanently true on Zoom. Paired with any
+    // silent stretch (a quiet screen-share, a pause), this check would fire
+    // mid-call and eject the bot from a LIVE meeting as AllParticipantsLeft.
+    //
+    // Silence is still covered: silence_timeout runs off SoundLevelMonitor,
+    // independently of attendee count, so a genuinely empty Zoom call still ends.
+    //
+    // The real fix is a Zoom roster source (participants-panel scrape) so that
+    // attendeesCount means what this check assumes it means. Until then, opt Zoom
+    // out rather than let it act on a number that doesn't mean what it says.
+    if (GLOBAL.get().meeting_platform === "zoom") {
+      return { shouldEnd: false }
+    }
+
     // Never trigger alone-in-meeting during the configured grace period.
     if (this.isInGracePeriod(now)) {
       return { shouldEnd: false }

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -39,6 +39,13 @@ export enum MeetingEndReason {
   // SamlRejected triggers workspace-level auto-disable; Timeout is treated as transient.
   MeetLoginFailedSamlRejected = "meetLoginFailedSamlRejected",
   MeetLoginFailedTimeout = "meetLoginFailedTimeout",
+  // Zoom web-client (browser) specific failures. ZoomRequiresRtms is the
+  // post-Join anti-bot wall ("automated bots aren't allowed … must use Zoom
+  // RTMS") — keyed to the meeting/account, NOT IP reputation, so it is
+  // NON-RETRYABLE: retrying the same meeting always re-hits the wall. The
+  // api-server should route these to the native SDK / RTMS path instead.
+  ZoomRequiresRtms = "zoomRequiresRtms",
+  ZoomPasscodeRequired = "zoomPasscodeRequired",
   Internal = "internalError"
 }
 
@@ -77,6 +84,10 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "Google rejected our SAML assertion (cert mismatch most likely). Workspace auto-disabled."
     case MeetingEndReason.MeetLoginFailedTimeout:
       return "SAML round-trip with Google did not complete in time."
+    case MeetingEndReason.ZoomRequiresRtms:
+      return "Zoom blocks automated browser joins for this meeting and requires Zoom RTMS. Route to the native SDK / RTMS path."
+    case MeetingEndReason.ZoomPasscodeRequired:
+      return "Zoom meeting requires a passcode that was not supplied in the meeting URL (?pwd=)."
     case MeetingEndReason.Internal:
       return "Internal error occurred during recording."
     default:

--- a/src/urlParser/zoomUrlParser.test.ts
+++ b/src/urlParser/zoomUrlParser.test.ts
@@ -1,0 +1,92 @@
+import { buildZoomWebClientUrl, parseZoomMeetingUrl } from "./zoomUrlParser"
+
+// GLOBAL.setError is called on the throw path; stub the singleton so the parser
+// unit tests don't need the full bot runtime.
+jest.mock("../singleton", () => ({
+  GLOBAL: { setError: jest.fn() }
+}))
+
+describe("Zoom URL Parser", () => {
+  describe("parseZoomMeetingUrl — canonical /j/ URLs", () => {
+    test("regional host with pwd", async () => {
+      const r = await parseZoomMeetingUrl("https://us05web.zoom.us/j/84335626851?pwd=aBcD1234")
+      expect(r.meetingId).toBe("84335626851")
+      expect(r.password).toBe("aBcD1234")
+    })
+
+    test("bare zoom.us host, no passcode", async () => {
+      const r = await parseZoomMeetingUrl("https://zoom.us/j/84335626851")
+      expect(r.meetingId).toBe("84335626851")
+      expect(r.password).toBe("")
+    })
+
+    test("schemeless input", async () => {
+      const r = await parseZoomMeetingUrl("zoom.us/j/84335626851?pwd=x")
+      expect(r.meetingId).toBe("84335626851")
+      expect(r.password).toBe("x")
+    })
+
+    test("legacy ?password= param", async () => {
+      const r = await parseZoomMeetingUrl("https://zoom.us/j/84335626851?password=secret")
+      expect(r.password).toBe("secret")
+    })
+  })
+
+  describe("parseZoomMeetingUrl — web-client URLs", () => {
+    test("react /wc/<id>/join", async () => {
+      const r = await parseZoomMeetingUrl("https://app.zoom.us/wc/84335626851/join?pwd=z")
+      expect(r.meetingId).toBe("84335626851")
+      expect(r.password).toBe("z")
+    })
+
+    test("classic /wc/join/<id>", async () => {
+      const r = await parseZoomMeetingUrl("https://us05web.zoom.us/wc/join/84335626851")
+      expect(r.meetingId).toBe("84335626851")
+    })
+  })
+
+  describe("parseZoomMeetingUrl — white-label portals", () => {
+    test("non-canonical host with numeric id falls back to id", async () => {
+      const r = await parseZoomMeetingUrl(
+        "https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284?password=p"
+      )
+      expect(r.meetingId).toBe("96088138284")
+      expect(r.password).toBe("p")
+    })
+
+    test("non-canonical host without id carries the raw URL", async () => {
+      const raw = "https://corp.example.com/portal/landing"
+      const r = await parseZoomMeetingUrl(raw)
+      expect(r.meetingId).toBe(raw)
+    })
+  })
+
+  describe("buildZoomWebClientUrl", () => {
+    test("rewrites canonical /j/ to app.zoom.us/wc/<id>/join and preserves pwd", () => {
+      expect(buildZoomWebClientUrl("https://us05web.zoom.us/j/84335626851?pwd=abc")).toBe(
+        "https://app.zoom.us/wc/84335626851/join?pwd=abc"
+      )
+    })
+
+    test("injects a separately-supplied passcode", () => {
+      expect(buildZoomWebClientUrl("https://zoom.us/j/84335626851", "sep")).toBe(
+        "https://app.zoom.us/wc/84335626851/join?pwd=sep"
+      )
+    })
+
+    test("leaves an existing /wc/ URL untouched", () => {
+      const wc = "https://app.zoom.us/wc/84335626851/join?pwd=abc"
+      expect(buildZoomWebClientUrl(wc)).toBe(wc)
+    })
+
+    test("leaves white-label portals untouched", () => {
+      const portal = "https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284?password=p"
+      expect(buildZoomWebClientUrl(portal)).toBe(portal)
+    })
+
+    test("leaves zoom Events URLs untouched", () => {
+      const ev = "https://events.zoom.us/ejl/AbCd"
+      expect(buildZoomWebClientUrl(ev)).toBe(ev)
+    })
+  })
+})

--- a/src/urlParser/zoomUrlParser.ts
+++ b/src/urlParser/zoomUrlParser.ts
@@ -1,0 +1,96 @@
+import { GLOBAL } from "../singleton"
+import { MeetingEndReason } from "../state-machine/types"
+
+interface ZoomUrlComponents {
+  meetingId: string // numeric Zoom meeting id
+  password: string // decoded ?pwd= value, or "" when absent
+}
+
+/**
+ * Parse a Zoom invite URL into its meeting id and passcode.
+ *
+ * Zoom hands out several URL shapes; we normalise the canonical ones:
+ *   https://us05web.zoom.us/j/84335626851?pwd=abc  → { id: 84335626851, pwd: abc }
+ *   https://zoom.us/j/84335626851                   → { id: 84335626851, pwd: "" }
+ *   https://app.zoom.us/wc/84335626851/join?pwd=abc → { id: 84335626851, pwd: abc }
+ *   https://us05web.zoom.us/wc/join/84335626851     → classic web-client join
+ *
+ * White-label / enterprise portals (zoom-lfx.platform.linuxfoundation.org, corp
+ * portals, AWS Chime …) are NOT canonical Zoom hosts. We can't reliably extract
+ * an id from them and must not rewrite — getMeetingLink returns the original URL
+ * so the bot navigates the portal and a human can VNC in. parseMeetingUrl still
+ * needs an id for logging/pathing, so for a non-canonical host we fall back to
+ * the first long digit run in the URL, or the raw URL as the id.
+ */
+export async function parseZoomMeetingUrl(meeting_url: string): Promise<ZoomUrlComponents> {
+  let cleanUrl = meeting_url.trim().replace(/^"(.*)"$/, "$1")
+  if (cleanUrl.startsWith("zoom.") || cleanUrl.startsWith("app.zoom.")) {
+    cleanUrl = `https://${cleanUrl}`
+  }
+
+  try {
+    const url = new URL(cleanUrl)
+    const isCanonicalZoomHost =
+      url.hostname === "zoom.us" || url.hostname.endsWith(".zoom.us")
+
+    // Passcode: ?pwd= is the standard; some portals use ?password=
+    const pwd = url.searchParams.get("pwd") || url.searchParams.get("password") || ""
+
+    // Meeting id from the path: /j/<id>, /wc/<id>/join, /wc/join/<id>, /s/<id>
+    const pathMatch = url.pathname.match(/\/(?:j|s|wc|wc\/join)\/(\d{8,})/)
+    const meetingId = pathMatch?.[1] ?? url.pathname.match(/(\d{8,})/)?.[1]
+
+    if (isCanonicalZoomHost && meetingId) {
+      return { meetingId, password: pwd }
+    }
+
+    // Non-canonical (white-label) host, or canonical host we couldn't parse:
+    // keep an id if we found one, otherwise carry the original URL so the bot
+    // can still navigate it. Do NOT throw — a human may complete the portal.
+    if (meetingId) {
+      return { meetingId, password: pwd }
+    }
+    return { meetingId: meeting_url, password: pwd }
+  } catch (error) {
+    GLOBAL.setError(MeetingEndReason.InvalidMeetingUrl)
+    throw error
+  }
+}
+
+/**
+ * Build the Zoom Web Client URL the bot actually navigates.
+ * Rewrites ONLY canonical zoom.us hosts to app.zoom.us/wc/<id>/join; everything
+ * else (white-label portals, or an already-built /wc/ URL) is returned as-is.
+ * Ported from vexa buildZoomWebClientUrl (join/zoom/join.ts).
+ */
+export function buildZoomWebClientUrl(meetingUrl: string, password?: string): string {
+  try {
+    const url = new URL(meetingUrl)
+
+    // Zoom Events URLs self-redirect to the web client — leave untouched.
+    if (url.hostname === "events.zoom.us") return meetingUrl
+    // Already a web-client URL — leave untouched (but ensure pwd is present).
+    if (meetingUrl.includes("/wc/")) return meetingUrl
+
+    const isCanonicalZoomHost =
+      url.hostname === "zoom.us" || url.hostname.endsWith(".zoom.us")
+    if (!isCanonicalZoomHost) {
+      // White-label portal — navigate the original; human assists via VNC.
+      return meetingUrl
+    }
+
+    const meetingId = url.pathname.match(/\/(?:j|s)\/(\d+)/)?.[1]
+    if (!meetingId) {
+      throw new Error(`Cannot extract meeting ID from Zoom URL: ${meetingUrl}`)
+    }
+    const pwd = url.searchParams.get("pwd") || password || ""
+    const wcUrl = new URL(`https://app.zoom.us/wc/${meetingId}/join`)
+    if (pwd) wcUrl.searchParams.set("pwd", pwd)
+    return wcUrl.toString()
+  } catch (err) {
+    if (meetingUrl.includes("/wc/")) return meetingUrl
+    throw new Error(
+      `Invalid Zoom meeting URL: ${meetingUrl} — ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+}

--- a/src/utils/sound-level-monitor.ts
+++ b/src/utils/sound-level-monitor.ts
@@ -20,7 +20,11 @@ export class SoundLevelMonitor {
   private lastSoundLogTime = 0
   private readonly SOUND_LOG_INTERVAL_MS: number = 5000
   private audioBuffer: Float32Array[] = []
-  private readonly AUDIO_BUFFER_SIZE: number = 12
+  // Number of ffmpeg stdout chunks to batch before recomputing the level. Kept
+  // small so getCurrentSoundLevel() stays fresh — at 12 the level only refreshed
+  // every ~1s, which made the Zoom speaker observer's isSpeaking lag speech by
+  // seconds. 2 is plenty of audio for a stable RMS while staying responsive.
+  private readonly AUDIO_BUFFER_SIZE: number = 2
   private isActive = false
 
   private constructor() {}


### PR DESCRIPTION
## Summary
Fixes to the browser-based Zoom Web recording bot:
- **Full-frame recording:** force the active-speaker video fullscreen (`object-fit: cover`) and move the participants panel off-screen + hide the name/network overlay, so no black band or on-screen panel appears in the recording.
- **Speaker separation:** read the full participant roster from the (off-screen) participants panel and emit each as a speaker; gate `isSpeaking` on the real audio level (not a constant `true`), with a ~250ms re-check so it tracks speech promptly.
- **Lower audio→level latency:** recompute the sound level every 2 ffmpeg chunks (was 12) and add `-flush_packets 1` to the monitoring pipe.
- **Chat entry message:** focus the Zoom chat editor via JS instead of clicking, so it still sends when the dock is off-screen.

## Testing
- `tsc --noEmit` on the changed Zoom files — passes.
- Live Zoom web meeting: recording fills the frame, panel/name hidden, log shows `Speaker 1/2`, `isSpeaking` toggles with speech, entry message sends.

## Release Notes
- Zoom Web recordings now fill the frame with the active speaker (no black bar, no on-screen participant list), and the live speaker log reflects who is actually talking.