### PR TITLE
chore(deps): bump cloakbrowser ^0.3.31 -> ^0.4.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "async": "^3.2.6",
                 "axios": "^1.16.0",
                 "axios-retry": "^4.5.0",
-                "cloakbrowser": "^0.3.31",
+                "cloakbrowser": "^0.4.10",
                 "dotenv": "^17.2.3",
                 "envalid": "^8.1.0",
                 "express": "^4.21.0",
@@ -4739,9 +4739,9 @@
             }
         },
         "node_modules/cloakbrowser": {
-            "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.3.31.tgz",
-            "integrity": "sha512-HtwlpwFKd5FJh4jjCS5awsScWIKB9ofNSTkHLSEh/9JH0Hv1L79zu0MExSMOCP1nzOsgrohbacwwWocuKloQ1A==",
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.4.10.tgz",
+            "integrity": "sha512-Juc5343WIZ9kF0pQ+UJESovhXqez09sS/XSx+75CeHlRA4N22YxzbsR32P1j18CNrxZftBhc1MohDBtnW3cuBg==",
             "license": "MIT",
             "dependencies": {
                 "tar": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "playwright"
     ],
     "engines": {
-        "node": ">= 18.0.0 <=24.0.0"
+        "node": ">= 20.0.0 <=24.0.0"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.873.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "async": "^3.2.6",
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0",
-        "cloakbrowser": "^0.3.31",
+        "cloakbrowser": "^0.4.10",
         "dotenv": "^17.2.3",
         "envalid": "^8.1.0",
         "express": "^4.21.0",
@@ -99,7 +99,7 @@
         "url": "https://github.com/yourusername/meet-teams-bot/issues"
     },
     "homepage": "https://github.com/yourusername/meet-teams-bot#readme",
-  "volta": {
+    "volta": {
         "node": "20.18.0"
     }
 }

--- a/src/browser/fingerprint-probe.ts
+++ b/src/browser/fingerprint-probe.ts
@@ -1,0 +1,229 @@
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import type { Page } from "@playwright/test"
+import { envVars } from "../config/env-vars"
+import { formatError } from "../utils/Logger"
+import { PathManager } from "../utils/PathManager"
+
+/**
+ * One-shot fingerprint dump: measures what a detector's JS actually sees at the
+ * moment of a block, instead of inferring it from browser.ts / the Dockerfile.
+ *
+ * CloakBrowser spoofs the platform to Windows via the native binary
+ * (--fingerprint-platform=windows), but the container ships only a Debian-server
+ * font set and renders WebGL through whatever GPU stack the pod has. Whether the
+ * page ends up as a coherent "Windows desktop" or a "Linux box wearing a Windows
+ * UA" is decidable only from the runtime values — so dump them:
+ *
+ *   - navigator (UA, platform, webdriver, languages, plugins, UA-CH) — the OS story
+ *   - WebGL UNMASKED_VENDOR / UNMASKED_RENDERER — the SwiftShader / GPU tell
+ *   - font enumeration (Windows-core vs Linux-only candidates) — the font-list tell
+ *   - screen / dpr / viewport geometry — the spoofed-resolution coherence tell
+ *
+ * Output is a JSON blob + a screenshot in the html-snapshots dir, already
+ * uploaded to s3://<logs-bucket>/<uuid>/. Gated on BROWSER_DEBUG_CAPTURE, off by
+ * default, pure read-only diagnostic — it changes nothing the page can observe.
+ */
+
+// Windows core fonts a real Windows Chrome exposes. Absent in our container.
+const WINDOWS_FONTS = [
+  "Segoe UI",
+  "Calibri",
+  "Cambria",
+  "Consolas",
+  "Arial",
+  "Times New Roman",
+  "Tahoma",
+  "Verdana",
+  "Georgia",
+  "Trebuchet MS",
+  "Courier New",
+  "Comic Sans MS",
+  "Impact",
+  "Lucida Console",
+  "Bahnschrift",
+  "Candara",
+  "Corbel",
+  "Franklin Gothic Medium",
+  "Segoe UI Emoji",
+  "MS Gothic"
+]
+
+// Fonts the Debian-server packages in our Dockerfile actually install. Their
+// presence alongside absent Windows fonts is the "Linux under a Windows UA" tell.
+const LINUX_FONTS = [
+  "DejaVu Sans",
+  "Liberation Sans",
+  "Liberation Serif",
+  "Liberation Mono",
+  "FreeSans",
+  "FreeSerif",
+  "Noto Color Emoji",
+  "WenQuanYi Zen Hei",
+  "IPAGothic",
+  "Ubuntu"
+]
+
+/**
+ * Capture the runtime fingerprint once. `label` distinguishes call sites in the
+ * filename (e.g. "zoom_prejoin"). Never throws — diagnostics must not break join.
+ */
+export async function captureFingerprint(page: Page, label: string): Promise<void> {
+  if (!envVars.BROWSER_DEBUG_CAPTURE) return
+  if (page.isClosed()) return
+
+  try {
+    const fp = await page.evaluate(
+      ({ winFonts, linFonts }) => {
+        const nav = navigator as Navigator & {
+          userAgentData?: {
+            brands?: { brand: string; version: string }[]
+            platform?: string
+            mobile?: boolean
+            getHighEntropyValues?: (h: string[]) => Promise<Record<string, unknown>>
+          }
+          deviceMemory?: number
+        }
+
+        // --- navigator / OS story ---
+        const navigatorInfo: Record<string, unknown> = {
+          userAgent: nav.userAgent,
+          platform: nav.platform,
+          vendor: nav.vendor,
+          language: nav.language,
+          languages: nav.languages,
+          webdriver: nav.webdriver,
+          hardwareConcurrency: nav.hardwareConcurrency,
+          deviceMemory: nav.deviceMemory ?? null,
+          maxTouchPoints: nav.maxTouchPoints,
+          plugins: Array.from(nav.plugins ?? []).map((p) => p.name),
+          mimeTypesCount: nav.mimeTypes?.length ?? 0,
+          uaData: nav.userAgentData
+            ? {
+                brands: nav.userAgentData.brands,
+                platform: nav.userAgentData.platform,
+                mobile: nav.userAgentData.mobile
+              }
+            : null
+        }
+
+        // --- WebGL vendor / renderer (both plain + UNMASKED) ---
+        const readGl = (type: "webgl" | "webgl2") => {
+          try {
+            const c = document.createElement("canvas")
+            const gl = c.getContext(type) as WebGLRenderingContext | null
+            if (!gl) return null
+            const dbg = gl.getExtension("WEBGL_debug_renderer_info")
+            return {
+              vendor: gl.getParameter(gl.VENDOR),
+              renderer: gl.getParameter(gl.RENDERER),
+              unmaskedVendor: dbg ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
+              unmaskedRenderer: dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+              version: gl.getParameter(gl.VERSION),
+              shadingLanguage: gl.getParameter(gl.SHADING_LANGUAGE_VERSION)
+            }
+          } catch {
+            return null
+          }
+        }
+
+        // --- font enumeration (canvas width/height measurement) ---
+        // A candidate is "present" if rendering a probe string in it changes the
+        // metrics away from all three generic base families. This is the same
+        // technique FingerprintJS/CreepJS use to build the font-list axis.
+        const detectFonts = (candidates: string[]) => {
+          const baseFonts = ["monospace", "sans-serif", "serif"]
+          const probe = "mmmmmmmmmmlli WwQq 0123456789"
+          const size = "72px"
+          const canvas = document.createElement("canvas")
+          const ctx = canvas.getContext("2d")
+          if (!ctx) return { present: candidates, note: "no-2d-context" }
+
+          const baseline: Record<string, { w: number; h: number }> = {}
+          for (const base of baseFonts) {
+            ctx.font = `${size} ${base}`
+            const m = ctx.measureText(probe)
+            baseline[base] = {
+              w: m.width,
+              h: (m.actualBoundingBoxAscent ?? 0) + (m.actualBoundingBoxDescent ?? 0)
+            }
+          }
+
+          const present: string[] = []
+          for (const font of candidates) {
+            let detected = false
+            for (const base of baseFonts) {
+              ctx.font = `${size} "${font}", ${base}`
+              const m = ctx.measureText(probe)
+              const h = (m.actualBoundingBoxAscent ?? 0) + (m.actualBoundingBoxDescent ?? 0)
+              if (
+                Math.abs(m.width - baseline[base].w) > 0.5 ||
+                Math.abs(h - baseline[base].h) > 0.5
+              ) {
+                detected = true
+                break
+              }
+            }
+            if (detected) present.push(font)
+          }
+          return { present }
+        }
+
+        return {
+          navigator: navigatorInfo,
+          webgl: readGl("webgl"),
+          webgl2: readGl("webgl2"),
+          fonts: {
+            windowsProbed: winFonts.length,
+            windowsPresent: detectFonts(winFonts).present,
+            linuxProbed: linFonts.length,
+            linuxPresent: detectFonts(linFonts).present,
+            documentFontsSize: (document as unknown as { fonts?: { size?: number } }).fonts?.size ?? null
+          },
+          geometry: {
+            dpr: window.devicePixelRatio,
+            screen: `${screen.width}x${screen.height}`,
+            avail: `${screen.availWidth}x${screen.availHeight}`,
+            inner: `${window.innerWidth}x${window.innerHeight}`,
+            outer: `${window.outerWidth}x${window.outerHeight}`,
+            colorDepth: screen.colorDepth
+          }
+        }
+      },
+      { winFonts: WINDOWS_FONTS, linFonts: LINUX_FONTS }
+    )
+
+    // Coherence verdict: Windows UA/platform but Linux fonts present and no
+    // Windows fonts = the mixed-OS tell. Logged inline so it shows in the bot
+    // log without downloading the JSON.
+    const claimsWindows =
+      /windows/i.test(String(fp.navigator.userAgent)) ||
+      String(fp.navigator.platform).startsWith("Win")
+    const winFontCount = fp.fonts.windowsPresent.length
+    const linFontCount = fp.fonts.linuxPresent.length
+    const verdict = claimsWindows && winFontCount === 0 && linFontCount > 0 ? "MIXED-OS-TELL" : "ok"
+
+    console.log(
+      `[FingerprintProbe:${label}] verdict=${verdict} ` +
+        `platform=${fp.navigator.platform} webdriver=${fp.navigator.webdriver} ` +
+        `winFonts=${winFontCount}/${fp.fonts.windowsProbed} linFonts=${linFontCount}/${fp.fonts.linuxProbed} ` +
+        `glRenderer=${fp.webgl?.unmaskedRenderer ?? fp.webgl?.renderer ?? "?"} ` +
+        `dpr=${fp.geometry.dpr} screen=${fp.geometry.screen} inner=${fp.geometry.inner}`
+    )
+
+    const dir = PathManager.getInstance().getHtmlSnapshotsPath()
+    await fs.mkdir(dir, { recursive: true }).catch(() => {})
+    const jsonPath = path.join(dir, `${Date.now()}_fingerprint_${label}.json`)
+    await fs.writeFile(jsonPath, JSON.stringify({ label, verdict, ...fp }, null, 2))
+    console.log(`[FingerprintProbe:${label}] dump written: ${path.basename(jsonPath)}`)
+
+    try {
+      const shot = path.join(dir, `${Date.now()}_fingerprint_${label}.png`)
+      await page.screenshot({ path: shot, timeout: 10_000 })
+    } catch (e) {
+      console.warn(`[FingerprintProbe:${label}] screenshot failed:`, formatError(e))
+    }
+  } catch (error) {
+    console.warn(`[FingerprintProbe:${label}] probe failed:`, formatError(error))
+  }
+}

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -55,7 +55,13 @@ export const envVars = cleanEnv(process.env, {
   // Format example:
   //   http://user-<USER>-continent-eu-session-{SESSION}:<PASS>@gate.decodo.com:7000
   // Leave empty to disable residential proxy.
-  RESIDENTIAL_PROXY_TEMPLATE: str({ default: "" })
+  RESIDENTIAL_PROXY_TEMPLATE: str({ default: "" }),
+  // Read-only diagnostic gate. When true, the fingerprint probe dumps the
+  // runtime navigator / WebGL / font-list / geometry the page's JS actually
+  // sees (into html_snapshots/, uploaded to the log bucket) so we can measure
+  // what a detector saw at a block instead of inferring it from config. Off in
+  // prod by default; flip on a single bot to reproduce a wall.
+  BROWSER_DEBUG_CAPTURE: bool({ default: false })
 })
 
 export type EnvVars = typeof envVars

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -1,5 +1,6 @@
 import type { BrowserContext, Page } from "@playwright/test"
 import { envVars } from "../config/env-vars"
+import { captureFingerprint } from "../browser/fingerprint-probe"
 import { listenPage } from "../browser/page-logger"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
@@ -122,6 +123,7 @@ export class ZoomProvider implements MeetingProviderInterface {
     // title="Error - Zoom" + "This meeting link is invalid (3,001)". Poll until
     // the pre-join page renders (or the auth wall / anti-bot wall appears).
     const startTime = Date.now()
+    let fingerprintCaptured = false
     while (true) {
       try {
         await page.goto(link, { waitUntil: "domcontentloaded", timeout: 60_000 })
@@ -132,6 +134,15 @@ export class ZoomProvider implements MeetingProviderInterface {
         // requeue the job, send a second bot into the same wall, and double-count
         // the wall in our metrics.
         GLOBAL.setShouldRetry(false)
+
+        // Snapshot the runtime fingerprint Zoom's detector reads on the loaded
+        // pre-join page — once, before the denial check below can throw. No-op
+        // unless BROWSER_DEBUG_CAPTURE is set. Lets us see what Zoom saw at a
+        // wall (navigator/WebGL/fonts/geometry) rather than infer it from config.
+        if (!fingerprintCaptured) {
+          fingerprintCaptured = true
+          await captureFingerprint(page, "zoom_prejoin")
+        }
       } catch (e) {
         console.warn("[Zoom] goto failed, will retry:", formatError(e))
         GLOBAL.setShouldRetry(true)


### PR DESCRIPTION
## What
Two changes on this branch:

### 1. Bump `cloakbrowser` `^0.3.31` → `^0.4.10` + Node engine floor
- `0.4.10` is the latest **free-tier** wrapper (MIT). Still resolves the **free Chromium 146** stealth binary (58 C++ patches); 148/66-patch binary stays **Pro-gated**.
- Wrapper 0.4.x adds: HTTP-proxy inline credentials, native SOCKS5 fixes, `extensionPaths`, per-call humanize config. No change to the Meet/Teams/Zoom launch path.
- `engines.node` raised `>=18` → `>=20` (cloakbrowser already required Node ≥20 at 0.3.31; Docker installs 20.x, volta pins 20.18.0). Addresses CodeRabbit.

### 2. Gated fingerprint probe for Zoom-wall diagnosis (`BROWSER_DEBUG_CAPTURE`)
New read-only, one-shot diagnostic (`src/browser/fingerprint-probe.ts`), off by default. On a flagged bot it dumps what a detector's JS actually sees on the loaded Zoom pre-join page — so we diagnose blocks from measured runtime values instead of inferring from `browser.ts` / the Dockerfile:
- **navigator**: UA, platform, webdriver, languages, plugins, UA-CH
- **WebGL**: plain + UNMASKED vendor/renderer (SwiftShader / GPU tell)
- **fonts**: Windows-core vs Linux-only enumeration (font-list tell)
- **geometry**: dpr / screen / avail / inner / outer (resolution coherence)

Emits a one-line verdict (flags the "Windows UA + Linux fonts" mixed-OS tell) + full JSON blob + screenshot into `html_snapshots/`, already uploaded to `s3://<logs-bucket>/<uuid>/`. Wired into `zoom.ts` `openMeetingPage` right after the first successful navigation, before the denial check — captures the environment Zoom scored at the wall.

**To use:** set `BROWSER_DEBUG_CAPTURE=true` on one bot that hits the Zoom wall; retrieve `*_fingerprint_zoom_prejoin.json` from the bot's S3 log dir.

## Scope / risk
- cloakbrowser lockfile diff = its entry only. No binary/launch-path change.
- Probe is inert unless `BROWSER_DEBUG_CAPTURE=true`; wrapped so it never throws into the join path; changes nothing the page can observe.
- Targets `v2-improvements` (de-facto preprod).

## Follow-ups (not here)
- **Font-enumeration fix**: real Windows fonts + `--fingerprint-fonts-dir` (works on free 146) — the probe confirms whether it's needed.
- **`--fingerprint-windows-font-metrics`**: 148+ binary only → requires Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)