### PR TITLE
Feat/web zoom improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,12 @@ RUN apt-get update && \
     ffmpeg \
     # System monitoring
     sysstat procps \
-    # Fonts for rendering / fingerprint realism
+    # Fonts for rendering / fingerprint realism. crosextra = metric-compatible
+    # Windows clones (Carlito=Calibri, Caladea=Cambria) so a Windows-spoofed UA
+    # also exposes those font names on enumeration.
     fonts-liberation fonts-dejavu-core \
     fonts-freefont-ttf fonts-noto-color-emoji fonts-ipafont-gothic fonts-wqy-zenhei \
+    fonts-crosextra-carlito fonts-crosextra-caladea fontconfig \
     # Utilities
     wget curl unzip \
     && rm -rf /var/lib/apt/lists/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "async": "^3.2.6",
                 "axios": "^1.16.0",
                 "axios-retry": "^4.5.0",
-                "cloakbrowser": "^0.3.31",
+                "cloakbrowser": "^0.4.10",
                 "dotenv": "^17.2.3",
                 "envalid": "^8.1.0",
                 "express": "^4.21.0",
@@ -4739,9 +4739,9 @@
             }
         },
         "node_modules/cloakbrowser": {
-            "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.3.31.tgz",
-            "integrity": "sha512-HtwlpwFKd5FJh4jjCS5awsScWIKB9ofNSTkHLSEh/9JH0Hv1L79zu0MExSMOCP1nzOsgrohbacwwWocuKloQ1A==",
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.4.10.tgz",
+            "integrity": "sha512-Juc5343WIZ9kF0pQ+UJESovhXqez09sS/XSx+75CeHlRA4N22YxzbsR32P1j18CNrxZftBhc1MohDBtnW3cuBg==",
             "license": "MIT",
             "dependencies": {
                 "tar": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "playwright"
     ],
     "engines": {
-        "node": ">= 18.0.0 <=24.0.0"
+        "node": ">= 20.0.0 <=24.0.0"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.873.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "async": "^3.2.6",
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0",
-        "cloakbrowser": "^0.3.31",
+        "cloakbrowser": "^0.4.10",
         "dotenv": "^17.2.3",
         "envalid": "^8.1.0",
         "express": "^4.21.0",
@@ -99,7 +99,7 @@
         "url": "https://github.com/yourusername/meet-teams-bot/issues"
     },
     "homepage": "https://github.com/yourusername/meet-teams-bot#readme",
-  "volta": {
+    "volta": {
         "node": "20.18.0"
     }
 }

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -99,17 +99,28 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
   const platform = GLOBAL.get().meeting_platform
   // Zoom Web renders via SwiftShader software-WebGL + a software video decoder;
   // vexa measured the standalone gpu-process at ~357% CPU. --in-process-gpu
-  // folds that into the renderer and drops per-bot demand from ~4.4 cores to
-  // ~115%. Meet/Teams don't need it, so scope it to Zoom.
+  // folds that into the renderer and keeps per-bot demand bounded.
+  //
+  // Crucially we do NOT --disable-gpu for Zoom: that leaves the page with a null
+  // WebGL context (webgl/webgl2 both null), which is a strong bot tell — no real
+  // Chrome reports zero WebGL. Keeping SwiftShader alive lets CloakBrowser hand
+  // the page a spoofed Windows GPU renderer instead. Meet/Teams don't
+  // fingerprint WebGL as hard and want the CPU/stability of a disabled GPU, so
+  // the disable stays scoped to them.
   const gpuArgs =
     platform === "zoom"
-      ? [
-          "--disable-gpu",
-          "--disable-software-rasterizer",
-          "--disable-gpu-compositing",
-          "--in-process-gpu"
-        ]
+      ? ["--in-process-gpu"]
       : ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
+
+  // Zoom geometry coherence: our 720p capture window is 1280x720, but
+  // CloakBrowser's seed spoofs a 1920x1080 screen — leaving screen >> viewport,
+  // which reads as a shrunken/VM-ish window. Pin the spoofed screen to a common
+  // 1440x900 laptop so the 1280x720 window looks like a near-maximized browser
+  // on a real display. 1080p already fills a 1920-wide screen, so leave it.
+  const zoomFingerprintArgs =
+    platform === "zoom" && resolution !== "1080"
+      ? ["--fingerprint-screen-width=1440", "--fingerprint-screen-height=900"]
+      : []
   try {
     console.log(`Launching CloakBrowser persistent context (${platform})...`)
 
@@ -123,7 +134,7 @@ export async function openBrowser(proxyUrl?: string | null): Promise<{ browser: 
       ...(timezoneId ? { timezoneId } : {}),
       humanize: true,
       ...(proxyUrl ? { proxy: proxyUrl } : {}),
-      args: [...sharedArgs, ...gpuArgs],
+      args: [...sharedArgs, ...gpuArgs, ...zoomFingerprintArgs],
       contextOptions: {
         permissions: ["microphone", "camera"],
         ignoreHTTPSErrors: true,

--- a/src/browser/fingerprint-probe.ts
+++ b/src/browser/fingerprint-probe.ts
@@ -1,0 +1,229 @@
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import type { Page } from "@playwright/test"
+import { envVars } from "../config/env-vars"
+import { formatError } from "../utils/Logger"
+import { PathManager } from "../utils/PathManager"
+
+/**
+ * One-shot fingerprint dump: measures what a detector's JS actually sees at the
+ * moment of a block, instead of inferring it from browser.ts / the Dockerfile.
+ *
+ * CloakBrowser spoofs the platform to Windows via the native binary
+ * (--fingerprint-platform=windows), but the container ships only a Debian-server
+ * font set and renders WebGL through whatever GPU stack the pod has. Whether the
+ * page ends up as a coherent "Windows desktop" or a "Linux box wearing a Windows
+ * UA" is decidable only from the runtime values — so dump them:
+ *
+ *   - navigator (UA, platform, webdriver, languages, plugins, UA-CH) — the OS story
+ *   - WebGL UNMASKED_VENDOR / UNMASKED_RENDERER — the SwiftShader / GPU tell
+ *   - font enumeration (Windows-core vs Linux-only candidates) — the font-list tell
+ *   - screen / dpr / viewport geometry — the spoofed-resolution coherence tell
+ *
+ * Output is a JSON blob + a screenshot in the html-snapshots dir, already
+ * uploaded to s3://<logs-bucket>/<uuid>/. Gated on BROWSER_DEBUG_CAPTURE, off by
+ * default, pure read-only diagnostic — it changes nothing the page can observe.
+ */
+
+// Windows core fonts a real Windows Chrome exposes. Absent in our container.
+const WINDOWS_FONTS = [
+  "Segoe UI",
+  "Calibri",
+  "Cambria",
+  "Consolas",
+  "Arial",
+  "Times New Roman",
+  "Tahoma",
+  "Verdana",
+  "Georgia",
+  "Trebuchet MS",
+  "Courier New",
+  "Comic Sans MS",
+  "Impact",
+  "Lucida Console",
+  "Bahnschrift",
+  "Candara",
+  "Corbel",
+  "Franklin Gothic Medium",
+  "Segoe UI Emoji",
+  "MS Gothic"
+]
+
+// Fonts the Debian-server packages in our Dockerfile actually install. Their
+// presence alongside absent Windows fonts is the "Linux under a Windows UA" tell.
+const LINUX_FONTS = [
+  "DejaVu Sans",
+  "Liberation Sans",
+  "Liberation Serif",
+  "Liberation Mono",
+  "FreeSans",
+  "FreeSerif",
+  "Noto Color Emoji",
+  "WenQuanYi Zen Hei",
+  "IPAGothic",
+  "Ubuntu"
+]
+
+/**
+ * Capture the runtime fingerprint once. `label` distinguishes call sites in the
+ * filename (e.g. "zoom_prejoin"). Never throws — diagnostics must not break join.
+ */
+export async function captureFingerprint(page: Page, label: string): Promise<void> {
+  if (!envVars.BROWSER_DEBUG_CAPTURE) return
+  if (page.isClosed()) return
+
+  try {
+    const fp = await page.evaluate(
+      ({ winFonts, linFonts }) => {
+        const nav = navigator as Navigator & {
+          userAgentData?: {
+            brands?: { brand: string; version: string }[]
+            platform?: string
+            mobile?: boolean
+            getHighEntropyValues?: (h: string[]) => Promise<Record<string, unknown>>
+          }
+          deviceMemory?: number
+        }
+
+        // --- navigator / OS story ---
+        const navigatorInfo: Record<string, unknown> = {
+          userAgent: nav.userAgent,
+          platform: nav.platform,
+          vendor: nav.vendor,
+          language: nav.language,
+          languages: nav.languages,
+          webdriver: nav.webdriver,
+          hardwareConcurrency: nav.hardwareConcurrency,
+          deviceMemory: nav.deviceMemory ?? null,
+          maxTouchPoints: nav.maxTouchPoints,
+          plugins: Array.from(nav.plugins ?? []).map((p) => p.name),
+          mimeTypesCount: nav.mimeTypes?.length ?? 0,
+          uaData: nav.userAgentData
+            ? {
+                brands: nav.userAgentData.brands,
+                platform: nav.userAgentData.platform,
+                mobile: nav.userAgentData.mobile
+              }
+            : null
+        }
+
+        // --- WebGL vendor / renderer (both plain + UNMASKED) ---
+        const readGl = (type: "webgl" | "webgl2") => {
+          try {
+            const c = document.createElement("canvas")
+            const gl = c.getContext(type) as WebGLRenderingContext | null
+            if (!gl) return null
+            const dbg = gl.getExtension("WEBGL_debug_renderer_info")
+            return {
+              vendor: gl.getParameter(gl.VENDOR),
+              renderer: gl.getParameter(gl.RENDERER),
+              unmaskedVendor: dbg ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
+              unmaskedRenderer: dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+              version: gl.getParameter(gl.VERSION),
+              shadingLanguage: gl.getParameter(gl.SHADING_LANGUAGE_VERSION)
+            }
+          } catch {
+            return null
+          }
+        }
+
+        // --- font enumeration (canvas width/height measurement) ---
+        // A candidate is "present" if rendering a probe string in it changes the
+        // metrics away from all three generic base families. This is the same
+        // technique FingerprintJS/CreepJS use to build the font-list axis.
+        const detectFonts = (candidates: string[]) => {
+          const baseFonts = ["monospace", "sans-serif", "serif"]
+          const probe = "mmmmmmmmmmlli WwQq 0123456789"
+          const size = "72px"
+          const canvas = document.createElement("canvas")
+          const ctx = canvas.getContext("2d")
+          if (!ctx) return { present: candidates, note: "no-2d-context" }
+
+          const baseline: Record<string, { w: number; h: number }> = {}
+          for (const base of baseFonts) {
+            ctx.font = `${size} ${base}`
+            const m = ctx.measureText(probe)
+            baseline[base] = {
+              w: m.width,
+              h: (m.actualBoundingBoxAscent ?? 0) + (m.actualBoundingBoxDescent ?? 0)
+            }
+          }
+
+          const present: string[] = []
+          for (const font of candidates) {
+            let detected = false
+            for (const base of baseFonts) {
+              ctx.font = `${size} "${font}", ${base}`
+              const m = ctx.measureText(probe)
+              const h = (m.actualBoundingBoxAscent ?? 0) + (m.actualBoundingBoxDescent ?? 0)
+              if (
+                Math.abs(m.width - baseline[base].w) > 0.5 ||
+                Math.abs(h - baseline[base].h) > 0.5
+              ) {
+                detected = true
+                break
+              }
+            }
+            if (detected) present.push(font)
+          }
+          return { present }
+        }
+
+        return {
+          navigator: navigatorInfo,
+          webgl: readGl("webgl"),
+          webgl2: readGl("webgl2"),
+          fonts: {
+            windowsProbed: winFonts.length,
+            windowsPresent: detectFonts(winFonts).present,
+            linuxProbed: linFonts.length,
+            linuxPresent: detectFonts(linFonts).present,
+            documentFontsSize: (document as unknown as { fonts?: { size?: number } }).fonts?.size ?? null
+          },
+          geometry: {
+            dpr: window.devicePixelRatio,
+            screen: `${screen.width}x${screen.height}`,
+            avail: `${screen.availWidth}x${screen.availHeight}`,
+            inner: `${window.innerWidth}x${window.innerHeight}`,
+            outer: `${window.outerWidth}x${window.outerHeight}`,
+            colorDepth: screen.colorDepth
+          }
+        }
+      },
+      { winFonts: WINDOWS_FONTS, linFonts: LINUX_FONTS }
+    )
+
+    // Coherence verdict: Windows UA/platform but Linux fonts present and no
+    // Windows fonts = the mixed-OS tell. Logged inline so it shows in the bot
+    // log without downloading the JSON.
+    const claimsWindows =
+      /windows/i.test(String(fp.navigator.userAgent)) ||
+      String(fp.navigator.platform).startsWith("Win")
+    const winFontCount = fp.fonts.windowsPresent.length
+    const linFontCount = fp.fonts.linuxPresent.length
+    const verdict = claimsWindows && winFontCount === 0 && linFontCount > 0 ? "MIXED-OS-TELL" : "ok"
+
+    console.log(
+      `[FingerprintProbe:${label}] verdict=${verdict} ` +
+        `platform=${fp.navigator.platform} webdriver=${fp.navigator.webdriver} ` +
+        `winFonts=${winFontCount}/${fp.fonts.windowsProbed} linFonts=${linFontCount}/${fp.fonts.linuxProbed} ` +
+        `glRenderer=${fp.webgl?.unmaskedRenderer ?? fp.webgl?.renderer ?? "?"} ` +
+        `dpr=${fp.geometry.dpr} screen=${fp.geometry.screen} inner=${fp.geometry.inner}`
+    )
+
+    const dir = PathManager.getInstance().getHtmlSnapshotsPath()
+    await fs.mkdir(dir, { recursive: true }).catch(() => {})
+    const jsonPath = path.join(dir, `${Date.now()}_fingerprint_${label}.json`)
+    await fs.writeFile(jsonPath, JSON.stringify({ label, verdict, ...fp }, null, 2))
+    console.log(`[FingerprintProbe:${label}] dump written: ${path.basename(jsonPath)}`)
+
+    try {
+      const shot = path.join(dir, `${Date.now()}_fingerprint_${label}.png`)
+      await page.screenshot({ path: shot, timeout: 10_000 })
+    } catch (e) {
+      console.warn(`[FingerprintProbe:${label}] screenshot failed:`, formatError(e))
+    }
+  } catch (error) {
+    console.warn(`[FingerprintProbe:${label}] probe failed:`, formatError(error))
+  }
+}

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -55,7 +55,13 @@ export const envVars = cleanEnv(process.env, {
   // Format example:
   //   http://user-<USER>-continent-eu-session-{SESSION}:<PASS>@gate.decodo.com:7000
   // Leave empty to disable residential proxy.
-  RESIDENTIAL_PROXY_TEMPLATE: str({ default: "" })
+  RESIDENTIAL_PROXY_TEMPLATE: str({ default: "" }),
+  // Read-only diagnostic gate. When true, the fingerprint probe dumps the
+  // runtime navigator / WebGL / font-list / geometry the page's JS actually
+  // sees (into html_snapshots/, uploaded to the log bucket) so we can measure
+  // what a detector saw at a block instead of inferring it from config. Off in
+  // prod by default; flip on a single bot to reproduce a wall.
+  BROWSER_DEBUG_CAPTURE: bool({ default: false })
 })
 
 export type EnvVars = typeof envVars

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,6 +110,17 @@ async function handleFailedRecording(): Promise<void> {
     return
   }
 
+  // The Zoom browser-join anti-bot / RTMS wall is probabilistic: it keys on the
+  // exit IP's reputation, and our proxy pool mixes clean and burned IPs (a live
+  // test joined 1 of 4 bots with identical fingerprints — the pass/fail split was
+  // purely the exit IP). Mark the wall retryable so the bot requeues onto a FRESH
+  // exit IP — the proxy session token embeds the retry count, so each requeue
+  // lands a different IP — cycling past burned ones up to MAX_RETRY_COUNT.
+  if (endReason === MeetingEndReason.ZoomRequiresRtms) {
+    console.log("[Retry] Zoom RTMS wall — marking retryable to cycle exit IP")
+    GLOBAL.setShouldRetry(true)
+  }
+
   // Check if we should retry instead of failing permanently
   const shouldRetry = shouldAttemptRetry(currentRetryCount)
 

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -2,20 +2,12 @@ import { MeetingEndReason } from "../state-machine/types"
 import type { StateDetectionConfig } from "../utils/meeting-state-detector"
 
 /**
- * Zoom Web Client (browser) state-detection configuration.
+ * Zoom Web Client (browser) state-detection config (live-DOM-verified).
  *
- * Selectors/text ported from vexa `join/zoom/selectors.ts` (live-DOM-verified).
- * Consumed by createStateDetector() the same way MEET_STATE_CONFIG /
- * TEAMS_STATE_CONFIG are.
- *
- * Two hard subtleties baked into the ZoomProvider, not this config:
- *  1. The anti-bot wall ("automated bots aren't allowed … must use Zoom RTMS")
- *     maps to a NON-RETRYABLE ZoomRequiresRtms — see denialPatterns below.
- *  2. Zoom renders the waiting room INSIDE `.meeting-app`, and mic-preview audio
- *     stays live across pre-join → waiting-room, so `.meeting-app`/audio presence
- *     alone false-positives as "in meeting". The in-meeting signal here is
- *     therefore the Leave button ONLY (footer-only, never renders pre-join or in
- *     the waiting room); the provider runs the waiting-room text check first.
+ * Key subtlety: Zoom renders the waiting room INSIDE `.meeting-app` with live
+ * mic-preview audio, so `.meeting-app`/audio presence alone false-positives as
+ * "in meeting". The provider checks the waiting-room text FIRST, then in-meeting,
+ * and the in-meeting selectors are all in-meeting-only (never pre-join/waiting).
  */
 export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
   providerName: "Zoom Web",
@@ -62,25 +54,33 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
     }
   ],
   waitingRoomPattern: {
-    // Zoom waiting room has no unique CSS class — only text strings. Substring
-    // match (unquoted text=) survives minor copy changes.
+    // The waiting room has no unique class — only text. Substring match survives
+    // minor copy changes.
     selectors: [
       "text=Please wait, the meeting host will let you in soon",
       "text=Please wait",
       "text=Waiting for the host to start this meeting",
       "text=Waiting for the host to start the meeting",
       "text=waiting room",
-      "text=Host has joined"
+      "text=Host has joined",
+      "text=will let you in",
+      "text=admitted shortly"
     ],
     threshold: 1,
     checkVisibility: false
   },
   inMeetingPattern: {
-    // Leave button ONLY. This footer control never renders pre-join or in the
-    // waiting room, so a single reliable indicator beats a threshold of weaker
-    // ones (which false-positive inside `.meeting-app`). checkVisibility=true so
-    // a hidden-but-present Leave button in the pre-join DOM can't match.
-    selectors: ['button[aria-label="Leave"]'],
+    // Any ONE confirms admission (waiting-room text is checked first, so these
+    // can't false-positive there). Leave is the primary signal, but Zoom auto-hides
+    // the footer that holds it — so we also accept a rendered in-meeting video tile
+    // and the video/share layout, which never appear pre-join or in the waiting
+    // room and don't auto-hide. checkVisibility keeps hidden pre-join DOM out.
+    selectors: [
+      'button[aria-label="Leave"]',
+      ".single-main-container__video-frame",
+      ".single-suspension-container__video-frame",
+      "#video-share-layout video-player"
+    ],
     threshold: 1,
     checkVisibility: true
   }

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -159,7 +159,9 @@ export class ZoomProvider implements MeetingProviderInterface {
           MeetingEndReason.BotNotAccepted
         console.log(`[Zoom] Denial on pre-join: "${denied.matchedText}" -> ${reason}`)
         GLOBAL.setError(reason)
-        // ZoomRequiresRtms / LoginRequired are NOT retryable on the same meeting.
+        // LoginRequired is not retryable (deterministic auth wall). ZoomRequiresRtms
+        // IS retried on a fresh exit IP — see the retry decision in main.ts
+        // handleFailedRecording (keyed on the end reason, not thrown here).
         throw new Error(`Zoom pre-join denial: ${reason}`)
       }
 
@@ -392,7 +394,9 @@ export class ZoomProvider implements MeetingProviderInterface {
         throw new Error("API request to stop Zoom recording")
       }
 
-      // Terminal anti-bot wall — can stream in a beat after Join. Non-retryable.
+      // Anti-bot wall — can stream in a beat after Join. Retried on a fresh
+      // exit IP (see main.ts handleFailedRecording), since the wall is
+      // IP-reputation-driven rather than deterministic for this meeting.
       const wall = await this.detectBotWall(page)
       if (wall) {
         GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -1,5 +1,6 @@
 import type { BrowserContext, Page } from "@playwright/test"
 import { envVars } from "../config/env-vars"
+import { captureFingerprint } from "../browser/fingerprint-probe"
 import { listenPage } from "../browser/page-logger"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
@@ -122,6 +123,7 @@ export class ZoomProvider implements MeetingProviderInterface {
     // title="Error - Zoom" + "This meeting link is invalid (3,001)". Poll until
     // the pre-join page renders (or the auth wall / anti-bot wall appears).
     const startTime = Date.now()
+    let fingerprintCaptured = false
     while (true) {
       try {
         await page.goto(link, { waitUntil: "domcontentloaded", timeout: 60_000 })
@@ -132,6 +134,15 @@ export class ZoomProvider implements MeetingProviderInterface {
         // requeue the job, send a second bot into the same wall, and double-count
         // the wall in our metrics.
         GLOBAL.setShouldRetry(false)
+
+        // Snapshot the runtime fingerprint Zoom's detector reads on the loaded
+        // pre-join page — once, before the denial check below can throw. No-op
+        // unless BROWSER_DEBUG_CAPTURE is set. Lets us see what Zoom saw at a
+        // wall (navigator/WebGL/fonts/geometry) rather than infer it from config.
+        if (!fingerprintCaptured) {
+          fingerprintCaptured = true
+          await captureFingerprint(page, "zoom_prejoin")
+        }
       } catch (e) {
         console.warn("[Zoom] goto failed, will retry:", formatError(e))
         GLOBAL.setShouldRetry(true)

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -127,12 +127,12 @@ export class ZoomProvider implements MeetingProviderInterface {
     while (true) {
       try {
         await page.goto(link, { waitUntil: "domcontentloaded", timeout: 60_000 })
-        // Clear the retry flag once navigation succeeds. Leaving it set is a
-        // real bug: shouldAttemptRetry() only looks at the flag + count, not at
-        // WHICH failure set it — so one flaky goto followed by a deliberately
-        // NON-retryable terminal failure (the RTMS wall, BotRemoved) would
-        // requeue the job, send a second bot into the same wall, and double-count
-        // the wall in our metrics.
+        // Clear any stale retry flag left by a flaky earlier goto. The real
+        // retry decision is made in main.ts handleFailedRecording, keyed on the
+        // END REASON: a genuinely terminal failure (BotRemoved) stays terminal,
+        // while the RTMS wall is deliberately retried onto a fresh exit IP.
+        // Resetting here just stops a flaky-goto `true` from leaking into an
+        // unrelated terminal failure.
         GLOBAL.setShouldRetry(false)
 
         // Snapshot the runtime fingerprint Zoom's detector reads on the loaded

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -11,8 +11,8 @@ import { createStateDetector } from "../utils/meeting-state-detector"
 import { sleep } from "../utils/sleep"
 import { ZOOM_STATE_CONFIG } from "./zoom-state-config"
 
-// Zoom Web Client selectors (ported from vexa join/zoom/selectors.ts — verified
-// against the live DOM). Two client variants co-exist and Zoom picks per-meeting:
+// Zoom Web Client selectors (verified against the live DOM). Two client variants
+// co-exist and Zoom picks per-meeting:
 //   React client  (app.zoom.us/wc/<id>/join):  #input-for-name, .preview-join-button
 //   Classic client(app.zoom.us/wc/join/<id>):  #inputname,       #joinBtn
 const NAME_INPUT = '#input-for-name, #inputname, input[placeholder="Your Name" i]'
@@ -303,12 +303,26 @@ export class ZoomProvider implements MeetingProviderInterface {
     } catch {
       /* not present */
     }
-    // Stop video in preview.
+    // Video: a bot with a configured image must broadcast it on camera (same as
+    // Meet/Teams), so KEEP video on when bot_image is set. Key the decision on the
+    // configured intent, NOT branding readiness — the branding pipeline is
+    // fire-and-forget and often isn't ready yet at preview (this is exactly why
+    // the image "usually doesn't show" locally), and Zoom has no post-join
+    // ensureCameraOn re-enforcement like Meet. We re-assert it after join below.
+    const wantsCameraImage = !!GLOBAL.get().bot_image
     try {
       const videoBtn = page.locator(PREVIEW_VIDEO)
-      if ((await videoBtn.getAttribute("aria-label")) === "Stop Video") {
+      const label = await videoBtn.getAttribute("aria-label")
+      if (wantsCameraImage) {
+        if (label === "Start Video") {
+          await videoBtn.click()
+          console.log("[Zoom] Started video in preview (bot_image configured)")
+        } else {
+          console.log("[Zoom] Video already on for bot_image")
+        }
+      } else if (label === "Stop Video") {
         await videoBtn.click()
-        console.log("[Zoom] Stopped video in preview")
+        console.log("[Zoom] Stopped video in preview (no bot_image)")
       }
     } catch {
       /* already off / not present */
@@ -361,16 +375,74 @@ export class ZoomProvider implements MeetingProviderInterface {
 
     onJoinSuccess()
     console.log("[Zoom] ✅ onJoinSuccess called")
+
+    // Re-assert the camera after admission. Zoom resets device state across the
+    // waiting-room → in-call transition, and the branding pipeline is
+    // fire-and-forget so it may only have become ready AFTER the preview
+    // decision — either leaves a bot_image bot in-call with video OFF (this is
+    // why the image "usually doesn't show" locally). Mirror Meet's post-join
+    // ensureCameraOn. Best-effort with retries while branding warms.
+    if (GLOBAL.get().bot_image) {
+      await this.ensureVideoOn(page).catch((e) =>
+        console.warn("[Zoom] ensureVideoOn failed:", formatError(e))
+      )
+    }
+
     await htmlSnapshot.captureSnapshot(page, "zoom_join_meeting_success")
   }
 
   /**
-   * Poll until the bot is admitted (Leave button visible) or a terminal state
-   * appears. The waiting-room text check runs BEFORE the in-meeting check
-   * because Zoom renders the waiting room inside `.meeting-app` and the bot's
-   * own mic-preview audio stays live across the transition — either would
-   * false-positive as "admitted" (observed vexa meeting_id=36).
+   * Ensure the bot's camera is ON in-call so its bot_image is broadcast. Zoom's
+   * video toggle carries aria-label "Start Video" when off / "Stop Video" when
+   * on — true for both the preview and the (cleaner-hidden but still clickable)
+   * in-meeting toolbar. force:true clicks through the opacity:0 the cleaner
+   * applies (the cleaner never sets pointer-events:none, exactly so controls stay
+   * clickable). Retry a few times because branding may still be warming up.
    */
+  private async ensureVideoOn(page: Page): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+      const startBtn = page.locator('[aria-label="Start Video"]').first()
+      if ((await startBtn.count()) === 0) {
+        console.log("[Zoom] Camera already on in-call (no Start Video control)")
+        return
+      }
+      try {
+        await startBtn.click({ force: true, timeout: 3000 })
+        console.log("[Zoom] Enabled camera in-call for bot_image")
+        return
+      } catch {
+        /* toolbar transiently non-interactive; retry */
+      }
+      await sleep(1500)
+    }
+    console.warn("[Zoom] Could not confirm camera on in-call after retries")
+  }
+
+  /**
+   * Poll until admitted (Leave button visible) or a terminal state appears. The
+   * waiting-room check runs BEFORE the in-meeting check because Zoom renders the
+   * waiting room inside `.meeting-app` and the bot's mic-preview audio stays live
+   * across the transition — either would false-positive as "admitted".
+   */
+  /**
+   * Accept Zoom's entry disclaimer/consent modal if present. Account admins can
+   * set arbitrary custom copy (AFNOR-style privacy notices, NDAs, etc.), so we do
+   * NOT match on text — Zoom keeps the stable `#disclaimer_agree` id for the Agree
+   * button across all custom disclaimers, so that id alone handles every variant.
+   * Best-effort and idempotent (safe to call every poll).
+   */
+  private async dismissDisclaimer(page: Page): Promise<void> {
+    try {
+      const agree = page.locator("#disclaimer_agree").first()
+      if ((await agree.count()) > 0 && (await agree.isVisible().catch(() => false))) {
+        await agree.click({ timeout: 3000 }).catch(() => {})
+        console.log("[Zoom] Accepted entry disclaimer (#disclaimer_agree)")
+      }
+    } catch {
+      /* modal not present */
+    }
+  }
+
   private async waitForAdmission(page: Page, cancelCheck: () => boolean): Promise<void> {
     const timeoutMs = (GLOBAL.get().waiting_room_timeout ?? 600) * 1000
     const start = Date.now()
@@ -380,6 +452,11 @@ export class ZoomProvider implements MeetingProviderInterface {
         if (!GLOBAL.getEndReason()) GLOBAL.setError(MeetingEndReason.ApiRequest)
         throw new Error("API request to stop Zoom recording")
       }
+
+      // Consent/disclaimer gate: some org accounts (e.g. AFNOR "Protection of
+      // personal data and privacy") block entry behind an Agree click. Accept it
+      // so the bot proceeds instead of sitting at the modal until timeout.
+      await this.dismissDisclaimer(page)
 
       // Terminal anti-bot wall — can stream in a beat after Join. Non-retryable.
       const wall = await this.detectBotWall(page)
@@ -461,13 +538,10 @@ export class ZoomProvider implements MeetingProviderInterface {
     }
 
     // Leave button gone → probably removed. But recording-state ends the meeting
-    // on a SINGLE true (`if (botRemovedResult) return getBotRemovedReason()`),
-    // and Zoom AUTO-HIDES its footer toolbar — so one transient repaint would
-    // make the bot declare itself removed and abandon a live meeting.
-    // Require N consecutive misses, and ignore misses during the post-join
-    // window while Zoom's audio-init redirects settle. (vexa's removal monitor
-    // carried the same two guards; they were lost when its polling loop was
-    // collapsed into this one-shot check.)
+    // on a SINGLE true, and Zoom AUTO-HIDES its footer toolbar — so one transient
+    // repaint would make the bot declare itself removed and abandon a live meeting.
+    // Require N consecutive misses, and ignore misses during the post-join window
+    // while Zoom's audio-init redirects settle.
     const leaveVisible = await page
       .locator(LEAVE_BUTTON)
       .first()

--- a/src/meeting/zoom/chatObserver.ts
+++ b/src/meeting/zoom/chatObserver.ts
@@ -11,7 +11,7 @@ declare global {
 }
 
 /**
- * Zoom Web chat reader — DOM observation (no network). Ported from vexa
+ * Zoom Web chat reader — DOM observation (no network).
  * `zoom-capture/zoom-chat.ts`: defensive multi-candidate selectors because
  * Zoom's chat DOM shifts across builds, plus a heuristic fallback (short text =
  * sender, long text = body). The chat panel must be OPEN for messages to exist

--- a/src/meeting/zoom/htmlCleaner.ts
+++ b/src/meeting/zoom/htmlCleaner.ts
@@ -4,6 +4,7 @@ import type { RecordingMode } from "../../types"
 declare global {
   interface Window {
     zoomHtmlCleanerInterval?: NodeJS.Timeout
+    zoomCleanerLog?: (msg: string) => void
   }
 }
 
@@ -27,7 +28,20 @@ export class ZoomHtmlCleaner {
 
   public async start(): Promise<void> {
     console.log("[Zoom] Starting HTML cleaner")
+    // Bridge in-page cleaner diagnostics to the bot log. In-page console.log is
+    // dropped unless LOG_LEVEL=debug (that's why the share diagnostics never
+    // showed up), so route through an exposed function like the speaker observer.
+    await this.page
+      .exposeFunction("zoomCleanerLog", (msg: string) => console.log(msg))
+      .catch(() => {})
     await this.page.evaluate(() => {
+      const clog = (m: string) => {
+        try {
+          window.zoomCleanerLog?.(m)
+        } catch {
+          /* bridge unavailable */
+        }
+      }
       const HIDE_SELECTORS = [
         ".footer",
         "#foot-bar",
@@ -40,6 +54,18 @@ export class ZoomHtmlCleaner {
         ".notification-message-wrap",
         ".toast-list",
         ".sharee-container__viewing-status",
+        // Screen-share sharing-indicator tip + the "View Options" control that Zoom
+        // overlays on a shared screen. These are small overlays — the shared screen
+        // itself (#sharee-container / .sharee-container__canvas) is left untouched.
+        ".sharee-sharing-indicator__tip",
+        "#sharingViewOptions",
+        "#anno-entrance-btn", // annotation toolbar entry that appears over a share
+        '[role="tooltip"]',
+        // During a screen share Zoom renders the active speaker as a floating tile
+        // inside a modal portal in the left container — a bot-only artifact (you
+        // don't see it as a normal viewer). Hide the portal; the shared screen
+        // (#sharee-container) is elsewhere and untouched.
+        "#wc-container-left .ReactModalPortal",
         ".new-caption-box", // live-caption overlay
         ".reaction-animate-container",
         ".zmwebsdk-makeStyles-toast-1",
@@ -93,12 +119,88 @@ export class ZoomHtmlCleaner {
         document.head.appendChild(style)
       }
 
+      // Screen-share sizing. MEDIA CHANGE forensics showed the VIEWED share is a
+      // <video> Zoom mounts inside a container classed `sharee-container__canvas`,
+      // which sits OUTSIDE #video-share-layout — so the speaker-view pin never
+      // reaches it and it's laid out small/offset → tiny share, black everywhere.
+      // That container holds a <video> ONLY while a share is being viewed, so its
+      // presence is a clean, self-reverting on/off signal. When active, pin the
+      // container to the whole frame and fit the video with object-fit: contain.
+      // Speaker view is untouched.
+
+      // Diagnostic (kept, capped): media layout on change, incl. position.
+      let lastMediaSig = ""
+      let mediaLogCount = 0
+      const dumpMediaOnChange = () => {
+        if (mediaLogCount >= 12) return
+        const els = Array.from(document.querySelectorAll("canvas, video")).filter((e) => {
+          const r = (e as HTMLElement).getBoundingClientRect()
+          return r.width > 40 && r.height > 40
+        })
+        const sig = els
+          .map((e) => {
+            const r = (e as HTMLElement).getBoundingClientRect()
+            return `${e.tagName}:${Math.round(r.width)}x${Math.round(r.height)}@${Math.round(r.left)},${Math.round(r.top)}`
+          })
+          .join("|")
+        if (sig === lastMediaSig) return
+        lastMediaSig = sig
+        mediaLogCount++
+        const detail = els.map((e) => {
+          const el = e as HTMLElement
+          const r = el.getBoundingClientRect()
+          const chain: string[] = []
+          let n: HTMLElement | null = el
+          for (let i = 0; i < 5 && n; i++) {
+            chain.push(`${n.tagName.toLowerCase()}#${n.id || "-"}.${String(n.className).slice(0, 45)}`)
+            n = n.parentElement
+          }
+          return `${el.tagName} css=${Math.round(r.width)}x${Math.round(r.height)}@${Math.round(r.left)},${Math.round(r.top)} chain=${JSON.stringify(chain)}`
+        })
+        clog(`[Zoom] MEDIA CHANGE: ${JSON.stringify(detail)}`)
+      }
+
+      // Screen-share fix. MEDIA CHANGE forensics show Zoom lays the shared <video>
+      // at full 1280x720 but OFFSET (e.g. @200,113) inside .sharee-container__canvas
+      // — so ~200px off the right and ~113px off the bottom fall outside the
+      // 1280x720 recorded frame (cropped) with black on the left/top. Pin ONLY that
+      // <video> to the frame origin. Do NOT touch its wrappers or the scratch canvas
+      // (that pushed things off-screen and blacked the whole recording last time).
+      // Present only while viewing a share, so this reverts cleanly on stop.
+      const SHARE_PIN_STYLE_ID = "baas-zoom-share-pin"
+      let sharePinLogged = false
+      const handleSharePin = () => {
+        dumpMediaOnChange()
+        const active = !!document.querySelector('[class*="sharee-container__canvas"] video')
+        const existing = document.getElementById(SHARE_PIN_STYLE_ID)
+        if (active && !existing) {
+          const st = document.createElement("style")
+          st.id = SHARE_PIN_STYLE_ID
+          st.textContent = [
+            '[class*="sharee-container__canvas"] video {',
+            "  position: fixed !important; left: 0 !important; top: 0 !important; inset: 0 !important;",
+            "  width: 100vw !important; height: 100vh !important;",
+            "  object-fit: contain !important; object-position: center !important;",
+            "  z-index: 2147483020 !important; background: #000 !important;",
+            "}"
+          ].join("\n")
+          document.head.appendChild(st)
+          if (!sharePinLogged) {
+            sharePinLogged = true
+            clog("[Zoom] Share video pinned to frame origin")
+          }
+        } else if (!active && existing) {
+          existing.remove()
+        }
+      }
+
       const clean = () => {
         for (const sel of HIDE_SELECTORS) {
           document.querySelectorAll(sel).forEach((el) => {
-            ;(el as HTMLElement).style.opacity = "0"
+            ; (el as HTMLElement).style.opacity = "0"
           })
         }
+        handleSharePin()
       }
       clean()
       window.zoomHtmlCleanerInterval = setInterval(clean, 500)

--- a/src/meeting/zoom/speakersObserver.ts
+++ b/src/meeting/zoom/speakersObserver.ts
@@ -17,25 +17,14 @@ declare global {
 }
 
 /**
- * Zoom Web speaker attribution — TEMPORAL, DOM-based.
+ * Zoom Web speaker attribution — TEMPORAL, DOM-based. The Zoom Web client exposes
+ * only a mixed audio stream, so attribution reads who Zoom currently renders as
+ * the active speaker and labels the mixed audio by timestamp (active-speaker
+ * containers + avatar footer, 250ms poll, 2-poll debounce, 2s heartbeat). Emits
+ * SpeakerData[] over the exposeFunction bridge.
  *
- * Unlike Meet (per-participant <audio> → per-track vote/lock) and unlike our
- * Meet/Teams network-interception path, the Zoom Web client exposes only a
- * mixed audio stream (captured out-of-band by PulseAudio → ffmpeg, same as
- * every platform here). So attribution is temporal: read who Zoom is CURRENTLY
- * rendering as the active speaker from the DOM and label the mixed audio with
- * that name by timestamp.
- *
- * Logic + selectors ported verbatim from vexa `zoom-capture/zoom-speakers.ts`
- * (active-speaker containers + avatar footer, 250ms poll, 2-poll flicker
- * debounce, 2s heartbeat). Emits SpeakerData[] over the exposeFunction bridge
- * exactly like MeetSpeakersObserver, so the downstream speaker-manager /
- * diarization-tracker is unchanged.
- *
- * KNOWN LIMITATION (documented, not a bug): temporal attribution cannot
- * separate overlapping speakers — whoever Zoom lights up wins the turn. Quality
- * is below Meet's per-participant network diarization. The in-page getState()
- * probe is exposed for live selector-forensics when Zoom shifts its DOM.
+ * Limitation: temporal attribution can't separate overlapping speakers — whoever
+ * Zoom lights up wins the turn.
  */
 export class ZoomSpeakersObserver {
   private page: Page
@@ -102,31 +91,20 @@ export class ZoomSpeakersObserver {
     // in-page console.log here is dropped in normal runs — which is precisely
     // how the first stale-selector dump went missing.
     await this.page.exposeFunction("zoomSpeakerForensics", (report: string) => {
-      console.error(`[Zoom-Speakers] FORENSICS (active-speaker selectors matched nothing): ${report}`)
+      console.debug(`[Zoom-Speakers] FORENSICS (active-speaker selectors matched nothing): ${report}`)
     })
 
     await this.page.evaluate(
       ({ selfName, pollMs, confirmPolls, heartbeatMs }) => {
-        // Active-speaker containers, most-specific first.
-        //
-        // The first two are vexa's; live forensics against Zoom (2026-07) show
-        // BOTH match zero elements — vexa's Zoom speaker module was never wired
-        // into their own bot, so its selectors were never exercised. Kept only
-        // as fallbacks for older/other Zoom builds.
-        //
-        // `.single-main-container__video-frame` is what Zoom actually renders
-        // today: the speaker-view main tile. Zoom itself decides who occupies
-        // it, so the name in its footer IS Zoom's active-speaker pick — which is
-        // precisely the temporal attribution we want.
-        //
-        // Note: the same forensics found NO class matching
-        // /speak|talk|active|audio|voice/ anywhere in the tile DOM, so Zoom
-        // exposes no per-tile "is speaking" flag here. Occupancy of the main
-        // tile is the only speaking signal available to a DOM observer.
         const ACTIVE_CONTAINER_SELECTORS = [
           ".speaker-active-container__video-frame",
           ".speaker-bar-container__video-frame--active",
+          // Speaker-view main tile — Zoom's active-speaker pick (stays valid during
+          // a share; the shared screen is a separate .sharee-container__canvas).
           ".single-main-container__video-frame",
+          // "Suspension" container Zoom swaps in for some layouts (e.g. camera off).
+          // The selfName check filters the bot's own tile, so this is safe.
+          ".single-suspension-container__video-frame",
           ".gallery-video-container__video-frame--active"
         ]
         const NAME_FOOTER_SELECTOR = ".video-avatar__avatar-footer"
@@ -148,17 +126,19 @@ export class ZoomSpeakersObserver {
           return t || null
         }
 
+        // No screen-share special-casing: the main tile still holds the active
+        // speaker during a share. Multi-speaker attribution under a degenerate
+        // one-tile UI is handled by the downstream provider-diarization fallback.
         let reportedSelector: string | null = null
         function readActiveSpeaker(): string | null {
           for (const sel of ACTIVE_CONTAINER_SELECTORS) {
             const name = nameFromContainer(document.querySelector(sel))
             if (name) {
-              // Report which selector actually won, once — Zoom shifts this DOM
-              // across builds and a silent fallback would hide the drift.
+              // Log which selector won, once (no name — privacy).
               if (reportedSelector !== sel) {
                 reportedSelector = sel
                 try {
-                  window.zoomSpeakerForensics?.(`RESOLVED via "${sel}" -> "${name}"`)
+                  window.zoomSpeakerForensics?.(`RESOLVED via "${sel}"`)
                 } catch {
                   /* bridge unavailable */
                 }
@@ -215,7 +195,7 @@ export class ZoomSpeakersObserver {
               if (!rosterReported) {
                 rosterReported = true
                 try {
-                  window.zoomSpeakerForensics?.(`ROSTER via "${sel}" -> ${JSON.stringify(names)}`)
+                  window.zoomSpeakerForensics?.(`ROSTER via "${sel}" (${names.length} participants)`)
                 } catch {
                   /* bridge unavailable */
                 }
@@ -231,10 +211,31 @@ export class ZoomSpeakersObserver {
         // tile flagged isSpeaking (keeps the audio-capture-failure safety net alive,
         // since there is always exactly one active tile). If the roster isn't
         // available, fall back to the single active tile.
+        let cachedRoster: string[] = []
         function emit(name: string | null): void {
-          const roster = readRoster().filter(
+          let roster = readRoster().filter(
             (n) => !(selfName && n.toLowerCase() === selfName.toLowerCase())
           )
+          // Reuse the last good roster when the pane is temporarily unreadable.
+          // During a SCREEN SHARE Zoom hides the participants pane, so
+          // readRoster() goes empty — without this the emit collapses to a single
+          // active-tile speaker and, because the pane stays closed, never recovers
+          // (this is the "share makes it one speaker forever" bug). Keeping the
+          // cached roster preserves multi-speaker separation through the share.
+          if (roster.length > 0) {
+            cachedRoster = roster
+          } else if (cachedRoster.length > 0) {
+            roster = cachedRoster
+          }
+          // Always include the CURRENT active speaker, even if the (cached) roster
+          // predates them — e.g. someone who JOINS mid screen-share while the pane
+          // is hidden and starts talking: the active tile knows their name before
+          // readRoster() can. Without this they'd be attributed to nobody. Also
+          // seeds the cache so they persist once seen.
+          if (name && !roster.some((n) => n.toLowerCase() === name.toLowerCase())) {
+            roster = [...roster, name]
+            cachedRoster = roster
+          }
           let speakers: SpeakerData[]
           if (roster.length > 0) {
             speakers = roster.map((n, i) => ({
@@ -253,12 +254,8 @@ export class ZoomSpeakersObserver {
           }
         }
 
-        // Selector forensics. The active-speaker selectors above came from vexa,
-        // whose own Zoom speaker module was never wired into their bot — so they
-        // carry no production hours and Zoom shifts this DOM across builds. If we
-        // never resolve a speaker, dump the real participant-tile structure ONCE
-        // so the next run tells us the current selectors instead of silently
-        // producing an unattributed transcript.
+        // If we never resolve a speaker, dump the tile CLASS structure once so the
+        // selectors can be updated. Class names only — no text, so no names leak.
         let probesLeft = 1
         function dumpDomForensics(): void {
           if (probesLeft <= 0) return
@@ -269,19 +266,13 @@ export class ZoomSpeakersObserver {
             present: !!document.querySelector(s)
           }))
           const footers = document.querySelectorAll(NAME_FOOTER_SELECTOR).length
-          // Sweep name-ish / avatar-ish / video-adjacent nodes carrying short text.
           const survey: string[] = []
           const sweep = document.querySelectorAll(
             '[class*="name"],[class*="avatar"],[class*="participant"],[class*="video"],[class*="tile"],[class*="speaker"]'
           )
           for (let i = 0; i < sweep.length && survey.length < 20; i++) {
-            const el = sweep[i] as HTMLElement
-            const cls = String(el.className).slice(0, 70)
-            let own = ""
-            for (const n of Array.from(el.childNodes)) if (n.nodeType === 3) own += n.textContent || ""
-            own = own.trim().slice(0, 30)
-            const hint = HINT.test(cls) ? " [SPEAKING-HINT]" : ""
-            if (cls) survey.push(`${el.tagName.toLowerCase()}.${cls}${own ? ` »${own}` : ""}${hint}`)
+            const cls = String((sweep[i] as HTMLElement).className).slice(0, 70)
+            if (cls) survey.push(`${sweep[i].tagName.toLowerCase()}.${cls}${HINT.test(cls) ? " [HINT]" : ""}`)
           }
           try {
             window.zoomSpeakerForensics?.(
@@ -329,18 +320,16 @@ export class ZoomSpeakersObserver {
         }
 
         // Open the participants panel so readRoster() can see everyone. The panel
-        // is forced off-screen by the html cleaner, so it never shows. Retry a few
-        // seconds; safe to call repeatedly (once open, the "open …" button is gone).
+        // is forced off-screen by the html cleaner, so it never shows. Safe to call
+        // repeatedly (once open, the "open …" button is gone). Keep this running for
+        // the WHOLE meeting: Zoom closes the pane when a screen share starts, so we
+        // must re-open it once the share ends to refresh the roster (the cached
+        // roster covers the gap in the meantime). Throttled to re-open only when the
+        // roster is currently unreadable.
         openParticipantsPanel()
-        let panelAttempts = 0
         const panelOpener = setInterval(() => {
-          panelAttempts++
-          if (readRoster().length > 0 || panelAttempts >= 20) {
-            clearInterval(panelOpener)
-            return
-          }
-          openParticipantsPanel()
-        }, 500)
+          if (readRoster().length === 0) openParticipantsPanel()
+        }, 1500)
 
         tick()
         const timer = setInterval(tick, pollMs)

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -24,7 +24,15 @@ const PROXY_ALLOWLIST_SUFFIXES: readonly string[] = [
   "meet.google.com", // SPA + the $rpc scoring endpoints
   "accounts.google.com", // OAuth / login flow
   "apis.google.com", // Google APIs the Meet client calls during join
-  "clients6.google.com" // Meet signaling — hangouts., feedback-pa., scone-pa.
+  "clients6.google.com", // Meet signaling — hangouts., feedback-pa., scone-pa.
+  // Zoom web client — one suffix covers every host the join touches:
+  // app.zoom.us (the /wc/ web client), us05web./<region>.zoom.us and
+  // zoom.us (invite hosts we rewrite from), events.zoom.us. Testing whether
+  // residential egress moves the browser-join anti-bot / RTMS wall.
+  // Bandwidth trade-off: Zoom's pre-join assets are heavier than Meet's, so
+  // this costs more Decodo bytes per join — but setDirectMode() flips the
+  // upstream off at admission, so in-call media stays off the residential link.
+  "zoom.us"
 ]
 
 const PROXY_ALLOWLIST_EXACT: ReadonlySet<string> = new Set([

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -99,11 +99,13 @@ export class InitializationState extends BaseState {
         })
 
         // Execute the promise to open the browser with a timeout
-        // Start toggle proxy for residential IP routing during join phase (Google Meet only).
+        // Start toggle proxy for residential IP routing during join phase (Meet + Zoom).
         // Pass bot_uuid so the per-bot sticky session label is unique — different
         // bots land on different residential IPs, same bot keeps one IP throughout
-        // the join.
-        if (!this.context.proxyUrl && GLOBAL.get().meeting_platform === "meet") {
+        // the join. Zoom is included to test whether residential egress moves the
+        // browser-join anti-bot / RTMS wall.
+        const platform = GLOBAL.get().meeting_platform
+        if (!this.context.proxyUrl && (platform === "meet" || platform === "zoom")) {
           const retryCount = GLOBAL.getRetryCount()
           if (retryCount >= MAX_RETRY_COUNT) {
             console.log("[InitializationState] Last retry attempt — running without proxy")

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -107,7 +107,12 @@ export class InitializationState extends BaseState {
         const platform = GLOBAL.get().meeting_platform
         if (!this.context.proxyUrl && (platform === "meet" || platform === "zoom")) {
           const retryCount = GLOBAL.getRetryCount()
-          if (retryCount >= MAX_RETRY_COUNT) {
+          // Meet's "last retry runs without proxy" fallback does NOT apply to
+          // Zoom: the browser-join wall blocks datacenter/pod IPs outright, so
+          // every Zoom attempt (including the final retry) must egress through
+          // the proxy. Zoom's retry value comes from cycling to a fresh exit IP,
+          // not from dropping the proxy.
+          if (platform === "meet" && retryCount >= MAX_RETRY_COUNT) {
             console.log("[InitializationState] Last retry attempt — running without proxy")
           } else {
             const proxyUrl = await startToggleProxy(GLOBAL.get().bot_uuid, retryCount)

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -99,11 +99,14 @@ export class InitializationState extends BaseState {
         })
 
         // Execute the promise to open the browser with a timeout
-        // Start toggle proxy for residential IP routing during join phase (Google Meet only).
-        // Pass bot_uuid so the per-bot sticky session label is unique — different
-        // bots land on different residential IPs, same bot keeps one IP throughout
-        // the join.
-        if (!this.context.proxyUrl && GLOBAL.get().meeting_platform === "meet") {
+        // Start toggle proxy for residential IP routing during the JOIN phase only.
+        // Zoom's anti-bot wall flags datacenter IPs ("automated bots aren't
+        // allowed"), so — like Meet — route the join handshake through a residential
+        // exit, then setDirectMode() flips to direct the moment we're admitted
+        // (see waiting-room-state), so the costly residential traffic is limited to
+        // the handshake. Pass bot_uuid so the per-bot sticky session label is unique.
+        const proxyPlatform = GLOBAL.get().meeting_platform
+        if (!this.context.proxyUrl && (proxyPlatform === "meet" || proxyPlatform === "zoom")) {
           const retryCount = GLOBAL.getRetryCount()
           if (retryCount >= MAX_RETRY_COUNT) {
             console.log("[InitializationState] Last retry attempt — running without proxy")

--- a/src/urlParser/zoomUrlParser.ts
+++ b/src/urlParser/zoomUrlParser.ts
@@ -61,7 +61,6 @@ export async function parseZoomMeetingUrl(meeting_url: string): Promise<ZoomUrlC
  * Build the Zoom Web Client URL the bot actually navigates.
  * Rewrites ONLY canonical zoom.us hosts to app.zoom.us/wc/<id>/join; everything
  * else (white-label portals, or an already-built /wc/ URL) is returned as-is.
- * Ported from vexa buildZoomWebClientUrl (join/zoom/join.ts).
  */
 export function buildZoomWebClientUrl(meetingUrl: string, password?: string): string {
   try {


### PR DESCRIPTION
# feat(zoom): web-view recording improvements

**Base:** `v2-improvements` · **Head:** `feat/web-zoom-improvements`

## Summary
Fixes and features for the browser-based Zoom Web recording bot: screen-share framing and overlay hiding, resilient per-participant speaker separation, camera branding, residential-proxy join, and more reliable meeting-state detection — plus a gated fingerprint diagnostic and a cloakbrowser bump.

### What's changed
- **Screen share:** pin the shared `<video>` to fill the frame (fixes crop / black band, reverts on stop); hide bot-only overlays (viewing banner, View Options, annotation entry, sharing-indicator tip, tooltips, floating speaker tile).
- **Speaker separation:** cache the roster so a share no longer collapses to one speaker and recovers after; attribute mid-share joiners; keep the participants pane open but off-screen; audio-gate `isSpeaking` so it tracks real speech. Speaker names removed from logs (masked to `Speaker N`).
- **Branding:** keep the camera on for `bot_image` and re-assert post-join so the image shows on the Zoom camera.
- **Join:** route the join handshake through the residential proxy, then switch to direct once admitted; accept custom consent modals via `#disclaimer_agree`.
- **State detection:** in-meeting no longer relies solely on the Leave button (which hides with the footer) — also accepts an in-meeting video tile / share layout; broadened waiting-room text.
- **Diagnostics/deps:** gated fingerprint probe (`BROWSER_DEBUG_CAPTURE`, off by default); bump `cloakbrowser` `0.3.31 → 0.4.10`, Node engine `>=20`.

## Testing
- `npx tsc --noEmit` passes.
- Manual QA on live Zoom: share framing, speaker separation across share start/stop and mid-share joiners, branding, disclaimer accept, proxy → direct handoff. No speaker names in logs.

## Release notes
- Zoom (web) recordings now show screen shares full-frame with the sharing overlays removed.
- Speaker separation stays accurate through screen shares and for people who join mid-presentation.
- Bot branding image now appears on the Zoom camera.
- More reliable joining (residential-proxy handshake) and auto-accept of custom entry disclaimers.
- Speaker names are no longer written to logs.