### PR TITLE
fix(retry): reset transformed_meeting_url when requeueing to SQS

### DIFF
--- a/src/utils/retry-handler.ts
+++ b/src/utils/retry-handler.ts
@@ -55,6 +55,10 @@ export function buildRetryMessage(): MeetingParams {
 
   return {
     ...params,
+    // Reset: the waiting-room state overwrites this with the bare meeting ID
+    // (not a URL), which fails schema validation on the retry consumer and
+    // silently kills the retry. The retry run re-derives it from meeting_url.
+    transformed_meeting_url: null,
     // Increment retry count
     retry_count: currentRetryCount + 1
   }


### PR DESCRIPTION
## Problem

Every SQS retry of a failed bot dies before launching a browser. Observed on preprod (2026-07-16, zoom bots `faf13928`, `053ab566`, `e5bcb86e`): each bot logged `✅ Requeued to SQS for retry 1/2`, then the retry pod crashed with:

```
Message validation failed → ZodError: transformed_meeting_url: Invalid URL
```

The consumer deletes the SQS message **before** validating, so the retry is lost permanently.

## Root cause

1. `waiting-room-state.ts:162` stores the bare meeting ID (e.g. `86008871821`) in `transformed_meeting_url` via `GLOBAL.setTransformedMeetingUrl(meetingInfo.meetingId)`.
2. `buildRetryMessage()` spreads the mutated `GLOBAL.get()` into the requeue message.
3. The retry consumer validates against `meeting-params-schema.ts:42` `transformed_meeting_url: url().nullable()` → ZodError → crash.

## Fix

Reset `transformed_meeting_url` to `null` in `buildRetryMessage()` — the retry run re-derives it from `meeting_url` in the waiting-room state, same as a first attempt.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)