### PR TITLE
fix(retry): preserve zoom_engine in parsed params for SQS requeue

### DIFF
--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -41,6 +41,10 @@ export const BotMessageSchema = object({
   meeting_url: url(),
   transformed_meeting_url: url().nullable(),
   meeting_platform: MeetingPlatformSchema,
+  // Must round-trip into the SQS retry message: the consumer routes zoom
+  // messages on this field, and stripping it here made retries fall back to
+  // the native SDK binary, which doesn't exist in the browser-bot image.
+  zoom_engine: zodEnum(["sdk", "web"]).optional(),
   entry_message: string().nullable(),
   recording_mode: RecordingModeSchema.default("speaker_view"),
   streaming_input: url().nullable(),


### PR DESCRIPTION
## Problem

Follow-up to #220. Retry messages now pass validation, but on preprod (2026-07-16) every zoom web-view retry pod crashed:

```
Uncaught Exception: ENOENT spawn /app/app/zoom/target/release/client-zoom
```

## Root cause

`BotMessageSchema` has no `zoom_engine` field, so Zod strips it when parsing the SQS message. `buildRetryMessage()` spreads the parsed params, so the requeued message loses `zoom_engine: "web"`. The consumer defaults the missing field to `"sdk"` and spawns the native Rust binary inside the browser-bot image → ENOENT → retry dead (message already deleted from SQS).

## Fix

Add `zoom_engine` to the schema so it round-trips into the retry message. Paired consumer-side fix (default to web when no `zoom_config`): Meeting-BaaS/meeting-baas-v2#261.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)