### PR TITLE
Feat/zoom error handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,10 +20,57 @@ import { PathManager } from "./utils/PathManager"
 import {
   buildRetryMessage,
   formatRetryErrorMessage,
-  MAX_RETRY_COUNT,
+  getMaxRetryCount,
   requeueToSQS,
   shouldAttemptRetry
 } from "./utils/retry-handler"
+
+// Display names Zoom hosts commonly auto-reject as "obviously a bot". Surfaced as
+// a LOG hint (never the user-facing error) when a join is rejected.
+const BOT_LIKE_NAME_RE =
+  /note ?taker|recorder|recording|transcri|\bbots?\b|\bai\b|assistant|\bnotes?\b|meeting ?baas|fireflies|otter|read ?ai/i
+
+// Set once the run has finished (success or a handled failure) so a SIGTERM
+// during normal shutdown never double-requeues.
+let settled = false
+
+// k8s evicts / scales down bot pods with SIGTERM. If it arrives BEFORE the run
+// has settled, the meeting would otherwise be lost — so requeue it to a fresh pod
+// (bounded by the retry cap), upload logs, and exit cleanly instead of being
+// force-killed. Best-effort and guarded (GLOBAL may be unset on a very early kill).
+process.on("SIGTERM", async () => {
+  if (settled) {
+    exit(0)
+    return
+  }
+  settled = true
+  console.error("[SIGTERM] Pod termination received — requeuing so the meeting isn't lost")
+  try {
+    if (!GLOBAL.isServerless()) await uploadLogsToS3()
+  } catch (e) {
+    console.error("[SIGTERM] log upload failed:", formatError(e))
+  }
+  try {
+    if (GLOBAL.hasRecordingFinalized()) {
+      // Eviction during upload: the merged recording exists — preserve it for the
+      // S3/EFS salvage path rather than requeuing (which would re-record).
+      console.log(
+        "[SIGTERM] Recording finalized/uploading — preserving artifacts for salvage (not requeuing)"
+      )
+    } else if (!GLOBAL.isServerless()) {
+      // Join or mid-recording: the only copy is ephemeral /tmp, lost with the pod —
+      // requeue to re-record on a fresh pod.
+      GLOBAL.setShouldRetry(true)
+      if (shouldAttemptRetry(GLOBAL.getRetryCount())) {
+        await requeueToSQS(buildRetryMessage())
+        console.log("[SIGTERM] Requeued to SQS to re-record")
+      }
+    }
+  } catch (e) {
+    console.error("[SIGTERM] requeue failed:", formatError(e))
+  }
+  exit(0)
+})
 
 // Setup console logger first to ensure proper formatting
 setupConsoleLogger()
@@ -102,7 +149,21 @@ async function handleFailedRecording(): Promise<void> {
   console.log(`Recording failed with reason: ${endReason || "Unknown"}`)
   console.log(`Error message: ${originalErrorMessage || "None"}`)
   console.log(`Should retry: ${GLOBAL.getShouldRetry()}`)
-  console.log(`Current retry count: ${currentRetryCount}/${MAX_RETRY_COUNT}`)
+  console.log(`Current retry count: ${currentRetryCount}/${getMaxRetryCount()}`)
+
+  // Zoom hosts frequently auto-reject bot-sounding display names ("Notetaker",
+  // "…Bot", "AI …"). When a Zoom join is rejected, hint at it in the logs — a more
+  // human name often clears the wall. Log-only; not exposed to the user.
+  const botName = GLOBAL.get().bot_name ?? ""
+  if (
+    (endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed ||
+      endReason === MeetingEndReason.BotNotAccepted) &&
+    BOT_LIKE_NAME_RE.test(botName)
+  ) {
+    console.warn(
+      `[Hint] Bot display name "${botName}" contains a bot-indicating keyword; some Zoom hosts auto-reject such names — a more human name may get admitted.`
+    )
+  }
 
   // Early return for serverless mode - no SQS retry available
   if (GLOBAL.isServerless()) {
@@ -116,7 +177,7 @@ async function handleFailedRecording(): Promise<void> {
   // purely the exit IP). Mark the wall retryable so the bot requeues onto a FRESH
   // exit IP — the proxy session token embeds the retry count, so each requeue
   // lands a different IP — cycling past burned ones up to MAX_RETRY_COUNT.
-  if (endReason === MeetingEndReason.ZoomRequiresRtms) {
+  if (endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) {
     console.log("[Retry] Zoom RTMS wall — marking retryable to cycle exit IP")
     GLOBAL.setShouldRetry(true)
   }
@@ -126,7 +187,7 @@ async function handleFailedRecording(): Promise<void> {
 
   if (shouldRetry) {
     console.log(
-      `🔄 Error marked as retryable - attempting retry ${currentRetryCount + 1}/${MAX_RETRY_COUNT}`
+      `🔄 Error marked as retryable - attempting retry ${currentRetryCount + 1}/${getMaxRetryCount()}`
     )
 
     try {
@@ -152,7 +213,7 @@ async function handleFailedRecording(): Promise<void> {
   } else {
     if (GLOBAL.getShouldRetry()) {
       console.log(
-        `🚫 Maximum retry attempts reached (${currentRetryCount}/${MAX_RETRY_COUNT}) - reporting failure`
+        `🚫 Maximum retry attempts reached (${currentRetryCount}/${getMaxRetryCount()}) - reporting failure`
       )
     } else {
       console.log("🚫 Error not retryable - reporting failure immediately")
@@ -243,6 +304,8 @@ async function handleFailedRecording(): Promise<void> {
     // Delegate to handleFailedRecording which includes retry logic
     await handleFailedRecording()
   } finally {
+    // Mark settled so a SIGTERM during shutdown doesn't requeue an already-handled run.
+    settled = true
     if (!GLOBAL.isServerless()) {
       try {
         await uploadLogsToS3()

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -21,10 +21,10 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
         "must use Zoom RTMS",
         "detected you may be a bot"
       ],
-      reason: MeetingEndReason.ZoomRequiresRtms,
-      logPrefix: "XXXXXXXXXXXXXXXXXX Zoom anti-bot wall (RTMS required)",
+      reason: MeetingEndReason.ZoomAnonymousJoinNotAllowed,
+      logPrefix: "XXXXXXXXXXXXXXXXXX Zoom anonymous-join wall (anonymous/automated join not allowed)",
       errorMessage:
-        "Zoom blocks automated browser joins for this meeting and requires RTMS"
+        "Zoom rejected the anonymous recording bot for this meeting — recommend recording via Zoom RTMS / the native SDK"
     },
     {
       // Host-restricted entry: only authenticated Zoom users may join. The

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -34,7 +34,7 @@ const PASSCODE_INPUT =
 //
 // Deliberately does NOT include "sign in to join". That phrase appears both on
 // the anti-bot wall AND on an ordinary auth-required meeting, and matching it
-// here would report every login-gated meeting as ZoomRequiresRtms. That metric
+// here would report every login-gated meeting as ZoomAnonymousJoinNotAllowed. That metric
 // is exactly what decides whether browser Zoom is viable at all, so polluting it
 // would corrupt the decision. Auth-required is already classified correctly as
 // LoginRequired by ZOOM_STATE_CONFIG.denialPatterns.
@@ -172,7 +172,7 @@ export class ZoomProvider implements MeetingProviderInterface {
           MeetingEndReason.BotNotAccepted
         console.log(`[Zoom] Denial on pre-join: "${denied.matchedText}" -> ${reason}`)
         GLOBAL.setError(reason)
-        // LoginRequired is not retryable (deterministic auth wall). ZoomRequiresRtms
+        // LoginRequired is not retryable (deterministic auth wall). ZoomAnonymousJoinNotAllowed
         // IS retried on a fresh exit IP — see the retry decision in main.ts
         // handleFailedRecording (keyed on the end reason, not thrown here).
         throw new Error(`Zoom pre-join denial: ${reason}`)
@@ -220,6 +220,11 @@ export class ZoomProvider implements MeetingProviderInterface {
       }
     }
 
+    // A separate in-page consent/disclaimer can sit alongside the cookie banner on
+    // the pre-join page — accept it too (the cookie accept above only clears
+    // cookies). Also re-checked every poll during admission (see dismissDisclaimer).
+    await this.dismissDisclaimer(page)
+
     // Media-permission dialog(s): Zoom shows "Allow" up to twice (camera+mic,
     // then mic-only). The bot MUST click Allow to join the audio channel — else
     // Zoom never creates <audio> elements for participants and PulseAudio
@@ -258,8 +263,8 @@ export class ZoomProvider implements MeetingProviderInterface {
       // The wall can render here instead of a name field — check before failing.
       const wall = await this.detectBotWall(page)
       if (wall) {
-        GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)
-        throw new Error(`[Zoom] zoom_requires_rtms: ${wall}`)
+        GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+        throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
       }
       GLOBAL.setError(MeetingEndReason.CannotJoinMeeting)
       throw new Error("[Zoom] Pre-join name input never appeared")
@@ -295,8 +300,8 @@ export class ZoomProvider implements MeetingProviderInterface {
     // by automation — fail fast rather than holding the browser.
     const wall = await this.detectBotWall(page)
     if (wall) {
-      GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)
-      throw new Error(`[Zoom] zoom_requires_rtms: ${wall}`)
+      GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+      throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
     }
 
     // Wait for Join to enable (React enables within ~1-2s of valid name).
@@ -507,27 +512,65 @@ export class ZoomProvider implements MeetingProviderInterface {
    * across the transition — either would false-positive as "admitted".
    */
   /**
-   * Accept Zoom's entry disclaimer/consent modal if present. Account admins can
-   * set arbitrary custom copy (AFNOR-style privacy notices, NDAs, etc.), so we do
-   * NOT match on text — Zoom keeps the stable `#disclaimer_agree` id for the Agree
-   * button across all custom disclaimers, so that id alone handles every variant.
+   * Accept Zoom's entry disclaimer / in-page consent if present. Two distinct
+   * gates exist and BOTH must be handled:
+   *   1) Zoom's stable `#disclaimer_agree` Agree button (custom admin disclaimers).
+   *   2) A separate in-page consent/disclaimer whose Accept/Agree button is NOT
+   *      `#disclaimer_agree` — the old code missed this, so the bot only ever
+   *      dismissed the (separately-handled) OneTrust COOKIE banner and sat behind
+   *      the real consent.
+   * The text match is anchored and excludes the cookie banner, so it never clicks
+   * "Accept All Cookies", "Continue without microphone…", or a Decline/Reject.
    * Best-effort and idempotent (safe to call every poll).
    */
   private async dismissDisclaimer(page: Page): Promise<void> {
+    // 1) Zoom's stable entry-disclaimer Agree button.
     try {
       const agree = page.locator("#disclaimer_agree").first()
       if ((await agree.count()) > 0 && (await agree.isVisible().catch(() => false))) {
         await agree.click({ timeout: 3000 }).catch(() => { })
         console.log("[Zoom] Accepted entry disclaimer (#disclaimer_agree)")
+        return
       }
     } catch {
-      /* modal not present */
+      /* not present */
+    }
+
+    // 2) A separate in-page consent/disclaimer accept (NOT the cookie banner).
+    // Anchored names so "Accept All Cookies" / "Continue without microphone…" /
+    // Decline never match; skip anything inside the OneTrust cookie container.
+    try {
+      const ACCEPT_RE = /^\s*(i\s+)?(agree|accept|continue|got it|i understand)\s*$/i
+      const candidates = page.getByRole("button", { name: ACCEPT_RE })
+      const count = await candidates.count()
+      for (let i = 0; i < count; i++) {
+        const btn = candidates.nth(i)
+        const inCookieBanner = await btn
+          .evaluate(
+            (el) => !!el.closest('#onetrust-banner-sdk, #onetrust-consent-sdk, [id*="onetrust"]')
+          )
+          .catch(() => false)
+        if (inCookieBanner) continue
+        if (await btn.isVisible().catch(() => false)) {
+          const label = (await btn.textContent().catch(() => ""))?.trim().slice(0, 40)
+          await btn.click({ timeout: 3000 }).catch(() => { })
+          console.log(`[Zoom] Accepted in-page consent/disclaimer ("${label}")`)
+          return
+        }
+      }
+    } catch {
+      /* no in-page consent */
     }
   }
 
   private async waitForAdmission(page: Page, cancelCheck: () => boolean): Promise<void> {
     const timeoutMs = (GLOBAL.get().waiting_room_timeout ?? 600) * 1000
     const start = Date.now()
+    // A real connect resolves in a few seconds; if Zoom sits on the "Joining
+    // Meeting…" spinner far longer, the join is wedged. Bail out RETRYABLE so a
+    // fresh pod/IP tries again instead of silently recording the spinner.
+    const JOINING_STUCK_MS = 90_000
+    let joiningSince: number | null = null
 
     while (Date.now() - start < timeoutMs) {
       if (cancelCheck()) {
@@ -546,8 +589,8 @@ export class ZoomProvider implements MeetingProviderInterface {
       // IP-reputation-driven rather than deterministic for this meeting.
       const wall = await this.detectBotWall(page)
       if (wall) {
-        GLOBAL.setError(MeetingEndReason.ZoomRequiresRtms)
-        throw new Error(`[Zoom] zoom_requires_rtms: ${wall}`)
+        GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+        throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
       }
 
       // Rejected / meeting ended.
@@ -559,6 +602,30 @@ export class ZoomProvider implements MeetingProviderInterface {
         GLOBAL.setError(reason)
         throw new Error(`[Zoom] Rejected during admission: ${reason}`)
       }
+
+      // "Joining Meeting…" / connecting spinner. Zoom mounts an (empty)
+      // #video-share-layout video-player behind it, which the in-meeting detector
+      // would false-positive as "admitted" — so the bot starts recording the
+      // spinner. Treat the spinner as NOT admitted: keep waiting, and if it never
+      // resolves, bail out retryable rather than record a frozen page.
+      if (await this.isJoiningSpinner(page)) {
+        joiningSince ??= Date.now()
+        const stuckFor = Date.now() - joiningSince
+        if (stuckFor > JOINING_STUCK_MS) {
+          console.warn(
+            `[Zoom] Stuck on "Joining Meeting…" spinner for ${Math.round(stuckFor / 1000)}s — bailing out retryable`
+          )
+          GLOBAL.setShouldRetry(true)
+          GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
+          throw new Error("[Zoom] Stuck on Joining Meeting spinner")
+        }
+        console.log(
+          `[Zoom] "Joining Meeting…" spinner (${Math.round(stuckFor / 1000)}s) — not admitted yet`
+        )
+        await sleep(2000)
+        continue
+      }
+      joiningSince = null
 
       // Waiting room first (see method doc).
       const waiting = await zoomStateDetector.isWaitingRoom(page)
@@ -587,6 +654,26 @@ export class ZoomProvider implements MeetingProviderInterface {
       }, BOT_BLOCK_TEXTS)
     } catch {
       return null
+    }
+  }
+
+  /**
+   * True while Zoom shows the post-Join "Joining Meeting…" / connecting spinner.
+   * Distinct from the waiting-room copy ("please wait, the host will let you in"),
+   * so it won't shadow a genuine waiting room.
+   */
+  private async isJoiningSpinner(page: Page): Promise<boolean> {
+    try {
+      return await page.evaluate(() => {
+        const t = (document.body?.innerText || "").toLowerCase()
+        return (
+          t.includes("joining meeting") ||
+          t.includes("joining the meeting") ||
+          t.includes("connecting to the meeting")
+        )
+      })
+    } catch {
+      return false
     }
   }
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -911,6 +911,11 @@ export class ScreenRecorder extends EventEmitter {
       return
     }
 
+    // The recording is merged and we're now uploading — from here a crash/eviction
+    // must NOT requeue (that would re-record); the S3Uploader EFS-fallback +
+    // reconciliation job salvage any upload failure instead.
+    GLOBAL.markRecordingFinalized()
+
     const identifier = PathManager.getInstance().getIdentifier()
 
     try {

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -8,6 +8,7 @@ class Global {
   private endReason: MeetingEndReason | null = null
   private errorMessage: string | null = null
   private shouldRetry = false // NEW: Retry flag
+  private recordingFinalized = false // True once the recording is merged and entering upload (see markRecordingFinalized)
   private artifactKeys: ArtifactKey[] = []
   private audioChunks: ArtifactKey[] = []
   private participants: Participant[] = []
@@ -180,6 +181,22 @@ class Global {
 
   public getShouldRetry(): boolean {
     return this.shouldRetry
+  }
+
+  // Phase marker: true once the recording has been MERGED into its final output
+  // and is entering the upload phase. Crash/eviction handlers use it to decide
+  // requeue vs preserve:
+  //   - BEFORE finalize (join, or mid-recording): the only copy lives in ephemeral
+  //     /tmp, which dies with the pod — so REQUEUE to re-record (nothing to salvage).
+  //   - AFTER finalize (uploading): the merged output exists and the S3Uploader
+  //     EFS-fallback + reconciliation job salvage any upload failure — so do NOT
+  //     requeue (that would re-record and duplicate).
+  public markRecordingFinalized(): void {
+    this.recordingFinalized = true
+  }
+
+  public hasRecordingFinalized(): boolean {
+    return this.recordingFinalized
   }
 
   public getRetryCount(): number {

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -39,12 +39,12 @@ export enum MeetingEndReason {
   // SamlRejected triggers workspace-level auto-disable; Timeout is treated as transient.
   MeetLoginFailedSamlRejected = "meetLoginFailedSamlRejected",
   MeetLoginFailedTimeout = "meetLoginFailedTimeout",
-  // Zoom web-client (browser) specific failures. ZoomRequiresRtms is the
-  // post-Join anti-bot wall ("automated bots aren't allowed … must use Zoom
-  // RTMS") — keyed to the meeting/account, NOT IP reputation, so it is
-  // NON-RETRYABLE: retrying the same meeting always re-hits the wall. The
-  // api-server should route these to the native SDK / RTMS path instead.
-  ZoomRequiresRtms = "zoomRequiresRtms",
+  // Zoom web-client (browser) specific failures. ZoomAnonymousJoinNotAllowed is
+  // the post-Join anti-bot wall ("automated bots aren't allowed … must use Zoom
+  // RTMS") — the host account rejects anonymous/automated browser joins. Retried
+  // on a fresh exit IP (see main.ts); the durable fix is Zoom RTMS / the native
+  // SDK. Maps to the api-server's ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED error code.
+  ZoomAnonymousJoinNotAllowed = "zoomAnonymousJoinNotAllowed",
   ZoomPasscodeRequired = "zoomPasscodeRequired",
   Internal = "internalError"
 }
@@ -84,8 +84,8 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "Google rejected our SAML assertion (cert mismatch most likely). Workspace auto-disabled."
     case MeetingEndReason.MeetLoginFailedTimeout:
       return "SAML round-trip with Google did not complete in time."
-    case MeetingEndReason.ZoomRequiresRtms:
-      return "Zoom blocks automated browser joins for this meeting and requires Zoom RTMS. Route to the native SDK / RTMS path."
+    case MeetingEndReason.ZoomAnonymousJoinNotAllowed:
+      return "This Zoom meeting rejected the recording bot because it joined anonymously — the host's account blocks anonymous/automated browser joins. We recommend recording it via Zoom RTMS (or the native SDK with a user-authorized credential)."
     case MeetingEndReason.ZoomPasscodeRequired:
       return "Zoom meeting requires a passcode that was not supplied in the meeting URL (?pwd=)."
     case MeetingEndReason.Internal:

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -387,27 +387,52 @@ export async function uploadLogsToS3(): Promise<void> {
 }
 
 export function setupExitHandler() {
-  process.on("uncaughtException", async (error) => {
-    logger.error(`Uncaught Exception: ${error}`)
-    if (!GLOBAL.isServerless()) {
-      try {
-        await uploadLogsToS3()
-      } catch (uploadError) {
-        logger.error(`Failed to upload crash logs to S3: ${uploadError}`)
-      }
+  // Shared crash path for both uncaughtException and unhandledRejection: log,
+  // upload logs, best-effort requeue so the meeting retries instead of being lost
+  // (e.g. a setup ENOENT from a failed child-process spawn), then ALWAYS exit so
+  // the pod never hangs in a broken state.
+  const handleCrash = async (label: string, detail: unknown) => {
+    logger.error(`${label}: ${detail}`)
+    if (GLOBAL.isServerless()) {
+      process.exit(1)
     }
-  })
-
-  process.on("unhandledRejection", async (reason, promise) => {
-    logger.error(`Unhandled Rejection at: ${promise} reason: ${reason}`)
-    if (!GLOBAL.isServerless()) {
-      try {
-        await uploadLogsToS3()
-      } catch (uploadError) {
-        logger.error(`Failed to upload crash logs to S3: ${uploadError}`)
-      }
+    try {
+      await uploadLogsToS3()
+    } catch (uploadError) {
+      logger.error(`Failed to upload crash logs to S3: ${uploadError}`)
     }
-    // Force exit to avoid hanging processes
+    // Phase-aware recovery:
+    //  - AFTER finalize (recording merged, uploading) → do NOT requeue; that would
+    //    re-record. The merged output + S3Uploader EFS-fallback / reconciliation
+    //    salvage any upload failure.
+    //  - BEFORE finalize (join, or mid-recording where the only copy is ephemeral
+    //    /tmp that dies with the pod) → requeue to re-record.
+    // Dynamic import avoids a static import cycle (retry-handler → singleton).
+    try {
+      if (GLOBAL.hasRecordingFinalized()) {
+        logger.error(
+          "[Crash] Recording finalized/uploading — preserving artifacts for salvage (NOT requeuing)"
+        )
+      } else {
+        const { buildRetryMessage, requeueToSQS, getMaxRetryCount } = await import("./retry-handler")
+        GLOBAL.setShouldRetry(true)
+        if (GLOBAL.getRetryCount() < getMaxRetryCount()) {
+          await requeueToSQS(buildRetryMessage())
+          logger.error("[Crash] Early crash — requeued to SQS for retry")
+        } else {
+          logger.error("[Crash] Max retries reached — not requeuing")
+        }
+      }
+    } catch (e) {
+      logger.error(`[Crash] requeue skipped/failed: ${e}`)
+    }
     process.exit(1)
+  }
+
+  process.on("uncaughtException", (error) => {
+    void handleCrash("Uncaught Exception", error)
+  })
+  process.on("unhandledRejection", (reason, promise) => {
+    void handleCrash(`Unhandled Rejection at: ${promise} reason`, reason)
   })
 }

--- a/src/utils/retry-handler.ts
+++ b/src/utils/retry-handler.ts
@@ -3,6 +3,23 @@ import { GLOBAL } from "../singleton"
 import type { MeetingParams } from "../types"
 
 export const MAX_RETRY_COUNT = 2
+// Zoom web joins are probabilistic — the anti-bot / RTMS wall keys on the exit
+// IP's reputation, so each retry cycles onto a fresh residential IP. Give Zoom
+// more attempts than the default before giving up.
+export const ZOOM_WEB_MAX_RETRY_COUNT = 5
+
+/**
+ * Max SQS retries for the current bot: higher for Zoom (web) so it can cycle
+ * exit IPs past the anti-bot wall. Guarded so a crash before params are set
+ * (GLOBAL unset) falls back to the default instead of throwing.
+ */
+export function getMaxRetryCount(): number {
+  try {
+    return GLOBAL.get().meeting_platform === "zoom" ? ZOOM_WEB_MAX_RETRY_COUNT : MAX_RETRY_COUNT
+  } catch {
+    return MAX_RETRY_COUNT
+  }
+}
 
 /**
  * Creates SQS client with same credential logic as smart-rabbit
@@ -38,8 +55,8 @@ export function shouldAttemptRetry(currentRetryCount: number): boolean {
     return false
   }
 
-  // Check retry limit
-  if (currentRetryCount >= MAX_RETRY_COUNT) {
+  // Check retry limit (Zoom web gets more attempts — see getMaxRetryCount).
+  if (currentRetryCount >= getMaxRetryCount()) {
     return false
   }
 
@@ -121,7 +138,7 @@ export async function requeueToSQS(message: MeetingParams): Promise<void> {
   await client.send(command)
 
   const retryCount = message.retry_count
-  console.log(`✅ Requeued to SQS for retry ${retryCount}/${MAX_RETRY_COUNT}`)
+  console.log(`✅ Requeued to SQS for retry ${retryCount}/${getMaxRetryCount()}`)
 }
 
 /**
@@ -129,6 +146,6 @@ export async function requeueToSQS(message: MeetingParams): Promise<void> {
  */
 export function formatRetryErrorMessage(originalMessage: string, retryCount: number): string {
   const attemptNumber = retryCount + 1
-  const totalAttempts = MAX_RETRY_COUNT + 1
+  const totalAttempts = getMaxRetryCount() + 1
   return `${originalMessage} - Retrying (${attemptNumber}/${totalAttempts})`
 }


### PR DESCRIPTION
# fix(zoom): error handling, crash recovery, and join reliability

## Summary

Follow-up hardening for the Zoom **web** bot: a clearer rejection reason, more retries, phase-aware crash/eviction recovery, and two join fixes (the stuck "Joining Meeting…" spinner and a second consent gate).

### What changed

- **Reject reason** — renamed `ZoomRequiresRtms` → `ZoomAnonymousJoinNotAllowed` (maps to the api-server's existing `ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED`); the message now **recommends recording via Zoom RTMS / the native SDK**.
- **Retries** — Zoom web-join retry cap raised to **5** (platform-aware) so it can cycle exit IPs past the anti-bot wall.
- **Stuck "Joining Meeting…" spinner** — no longer mistaken for admission (it was recording a frozen page); bails out **retryable** if wedged > 90s.
- **In-page disclaimer** — the cookie banner (`#onetrust-*`) and the meeting consent (`#disclaimer_agree`) are distinct gates; the consent is now accepted **pre-join too** (previously cookie-only), with a text fallback that never hits the cookie banner or a Decline.
- **Crash / SIGTERM recovery — phase-aware:**
  - *Before finalize* (join / mid-recording; only copy is ephemeral `/tmp`, lost with the pod) → **requeue** to re-record.
  - *After finalize* (merged output exists + S3/EFS fallback) → **don't requeue**; leave it for salvage/reconciliation.
  - `uncaughtException` now exits cleanly (it previously could hang the pod); `SIGTERM` (k8s eviction) requeues instead of silently losing the meeting.
- **Bot-name hint** — on a Zoom rejection, logs a hint when the display name looks bot-like (`Notetaker`, `…Bot`, `AI …`). Log-only, never surfaced to the user.

## Testing

- Type-check clean.
- Disclaimer + stuck-spinner verified against the live Firefox Zoom flow.

## Notes

- No new error codes — `ZoomAnonymousJoinNotAllowed` reuses the api-server's existing `ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED`.