### PR TITLE
feat(zoom): in-process fast retry on anti-bot wall before SQS requeue

### DIFF
--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -49,16 +49,23 @@ export async function establishBrowserSession(
   for (let attempt = 1; attempt <= LAUNCH_ATTEMPTS; attempt++) {
     try {
       console.info(`Browser setup attempt ${attempt}/${LAUNCH_ATTEMPTS}`)
+      // Hoist the timer id so it's cleared once the race settles (either side).
+      // Leaving it pending keeps the event loop alive, delays shutdown, and — in
+      // the in-process retry loop — accumulates one dangling 60s timer per attempt.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
       const timeoutPromise = new Promise<never>((_, reject) => {
-        const id = setTimeout(() => {
-          clearTimeout(id)
+        timeoutId = setTimeout(() => {
           reject(new Error(`Browser setup timeout (${LAUNCH_TIMEOUT_MS}ms)`))
         }, LAUNCH_TIMEOUT_MS)
       })
-      const result = await Promise.race([openBrowser(session.proxyUrl), timeoutPromise])
-      session.browserContext = result.browser
-      console.info("Browser setup completed successfully")
-      return
+      try {
+        const result = await Promise.race([openBrowser(session.proxyUrl), timeoutPromise])
+        session.browserContext = result.browser
+        console.info("Browser setup completed successfully")
+        return
+      } finally {
+        clearTimeout(timeoutId)
+      }
     } catch (error) {
       lastError = error as Error
       console.error(`Browser setup attempt ${attempt} failed:`, formatError(error))

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,0 +1,91 @@
+import type { BrowserContext } from "@playwright/test"
+import { startToggleProxy, stopToggleProxy } from "../proxy/toggle-proxy"
+import { GLOBAL } from "../singleton"
+import { MAX_RETRY_COUNT } from "../utils/retry-handler"
+import { formatError } from "../utils/Logger"
+import { openBrowser } from "./browser"
+
+const LAUNCH_ATTEMPTS = 3
+const LAUNCH_TIMEOUT_MS = 60_000
+
+// Minimal slice of MeetingContext this module owns: the residential proxy URL
+// and the live browser context. Kept structural so both the state machine
+// context and the in-process retry can pass their context in directly.
+type BrowserSession = { proxyUrl?: string; browserContext?: BrowserContext }
+
+/**
+ * Start the residential proxy (Meet/Zoom) and launch the browser against it,
+ * writing proxyUrl + browserContext into `session`. The proxy session id is
+ * derived from the SQS retry count (a new pod → a new exit IP) plus an optional
+ * `sessionSuffix` that advances the exit IP for an in-process retry in the same
+ * pod. Launch is retried a few times. Reused by InitializationState and the
+ * in-process fast-retry so both share one launch/proxy path.
+ */
+export async function establishBrowserSession(
+  session: BrowserSession,
+  opts: { sessionSuffix?: string } = {}
+): Promise<void> {
+  const platform = GLOBAL.get().meeting_platform
+  const retryCount = GLOBAL.getRetryCount()
+
+  if (!session.proxyUrl && (platform === "meet" || platform === "zoom")) {
+    // Meet's "last retry runs without proxy" fallback does NOT apply to Zoom:
+    // the browser-join wall blocks datacenter/pod IPs outright, so every Zoom
+    // attempt must egress through the proxy — its retry value comes from cycling
+    // to a fresh exit IP, not from dropping the proxy.
+    if (platform === "meet" && retryCount >= MAX_RETRY_COUNT) {
+      console.log("[BrowserSession] Last retry attempt — running without proxy")
+    } else {
+      const proxyUrl = await startToggleProxy(
+        GLOBAL.get().bot_uuid,
+        retryCount,
+        opts.sessionSuffix
+      )
+      if (proxyUrl) session.proxyUrl = proxyUrl
+    }
+  }
+
+  let lastError: Error | null = null
+  for (let attempt = 1; attempt <= LAUNCH_ATTEMPTS; attempt++) {
+    try {
+      console.info(`Browser setup attempt ${attempt}/${LAUNCH_ATTEMPTS}`)
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        const id = setTimeout(() => {
+          clearTimeout(id)
+          reject(new Error(`Browser setup timeout (${LAUNCH_TIMEOUT_MS}ms)`))
+        }, LAUNCH_TIMEOUT_MS)
+      })
+      const result = await Promise.race([openBrowser(session.proxyUrl), timeoutPromise])
+      session.browserContext = result.browser
+      console.info("Browser setup completed successfully")
+      return
+    } catch (error) {
+      lastError = error as Error
+      console.error(`Browser setup attempt ${attempt} failed:`, formatError(error))
+      if (attempt < LAUNCH_ATTEMPTS) {
+        const waitTime = attempt * 5000 // 5s, 10s progressive backoff
+        console.info(`Waiting ${waitTime}ms before retry...`)
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
+      }
+    }
+  }
+  throw lastError || new Error("Browser setup failed after multiple attempts")
+}
+
+/**
+ * Tear down the browser context + residential proxy so the next
+ * establishBrowserSession() launches cleanly on a fresh exit IP. Xvfb,
+ * PulseAudio and the screen recorder stay up — only the browser + proxy chain
+ * are recycled. Best-effort: errors are logged, never thrown.
+ */
+export async function teardownBrowserSession(session: BrowserSession): Promise<void> {
+  try {
+    // Closing the context closes all its pages.
+    await session.browserContext?.close()
+  } catch (error) {
+    console.warn("[BrowserSession] Error closing browser context:", formatError(error))
+  }
+  session.browserContext = undefined
+  await stopToggleProxy()
+  session.proxyUrl = undefined
+}

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv"
-import { bool, cleanEnv, port, str } from "envalid"
+import { bool, cleanEnv, num, port, str } from "envalid"
 
 dotenv.config()
 
@@ -77,7 +77,14 @@ export const envVars = cleanEnv(process.env, {
   // Absolute path to the stealthfox Firefox binary. Baked into the Docker image
   // at /opt/stealthfox/<tag>/firefox by scripts/fetch-stealthfox.sh. Empty =
   // stealthfox disabled (falls back to CloakBrowser).
-  STEALTHFOX_BINARY_PATH: str({ default: "" })
+  STEALTHFOX_BINARY_PATH: str({ default: "" }),
+  // Zoom web only: how many times to relaunch the browser on a FRESH proxy exit
+  // IP inside the SAME warm pod before falling back to the SQS requeue (fresh
+  // pod). The anti-bot wall keys on the exit IP, so an in-pod relaunch on a new
+  // residential IP clears it in ~5-10s vs the ~20-40s of a pod cold-start. 0
+  // disables in-process retry entirely (pure requeue behavior). Total budget =
+  // this + the remaining SQS pod requeues (see getMaxRetryCount, zoom=5).
+  IN_PROCESS_RETRY_MAX: num({ default: 2 })
 })
 
 export type EnvVars = typeof envVars

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -114,14 +114,20 @@ function logStats(label: string): void {
   )
 }
 
-export async function startToggleProxy(sessionId: string, retryCount = 0): Promise<string | null> {
+export async function startToggleProxy(
+  sessionId: string,
+  retryCount = 0,
+  sessionSuffix = ""
+): Promise<string | null> {
   if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
     console.log("[ToggleProxy] No RESIDENTIAL_PROXY_TEMPLATE configured, skipping proxy")
     return null
   }
   // Decodo session labels must be alphanumeric; bot UUIDs have hyphens.
-  // Append retry count so each SQS retry lands on a different residential IP.
-  const session = `${sessionId.replace(/-/g, "")}${retryCount}`
+  // Append the SQS retry count so each requeued pod lands on a different
+  // residential IP; sessionSuffix (e.g. "x1") advances the IP again for an
+  // in-process retry within the SAME pod without touching retry_count.
+  const session = `${sessionId.replace(/-/g, "")}${retryCount}${sessionSuffix}`
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
 
   // Reset stats, proxied-connection tracking, and exit IP for this new session

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -166,6 +166,18 @@ class Global {
     this.errorMessage = null
   }
 
+  /**
+   * Fully wipe the transient error / end-reason / retry flags so a bounded
+   * in-process join retry (fresh proxy IP, same pod) starts clean and a
+   * subsequent admission isn't treated as a failed run. Only call BETWEEN
+   * in-process attempts — never after a terminal decision.
+   */
+  public resetErrorState(): void {
+    this.endReason = null
+    this.errorMessage = null
+    this.shouldRetry = false
+  }
+
   public clearMeetSsoConfig(): void {
     if (this.meetingParams) {
       this.meetingParams.meet_sso_config = null

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs"
 import path from "node:path"
-import type { BrowserContext } from "@playwright/test"
 import {
   deferBrandingPlayback,
   generateBranding,
@@ -8,9 +7,7 @@ import {
   startBrandingAutoLoop,
   warmUpCamera
 } from "../../branding"
-import { openBrowser } from "../../browser/browser"
-import { startToggleProxy } from "../../proxy/toggle-proxy"
-import { MAX_RETRY_COUNT } from "../../utils/retry-handler"
+import { establishBrowserSession } from "../../browser/browser-session"
 import { GLOBAL } from "../../singleton"
 import { formatError } from "../../utils/Logger"
 import { PathManager } from "../../utils/PathManager"
@@ -75,79 +72,9 @@ export class InitializationState extends BaseState {
   }
 
   private async setupBrowser(): Promise<void> {
-    const maxRetries = 3
-    let lastError: Error | null = null
-
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        console.info(`Browser setup attempt ${attempt}/${maxRetries}`)
-
-        // Définir le type de retour attendu de openBrowser
-        type BrowserResult = {
-          browser: BrowserContext
-        }
-
-        // Augmenter le timeout pour les environnements plus lents
-        const timeoutMs = 60000 // 60 secondes au lieu de 30
-
-        // Create a promise that rejects after a delay
-        const timeoutPromise = new Promise<BrowserResult>((_, reject) => {
-          const id = setTimeout(() => {
-            clearTimeout(id)
-            reject(new Error(`Browser setup timeout (${timeoutMs}ms)`))
-          }, timeoutMs)
-        })
-
-        // Execute the promise to open the browser with a timeout
-        // Start toggle proxy for residential IP routing during join phase (Meet + Zoom).
-        // Pass bot_uuid so the per-bot sticky session label is unique — different
-        // bots land on different residential IPs, same bot keeps one IP throughout
-        // the join. Zoom is included to test whether residential egress moves the
-        // browser-join anti-bot / RTMS wall.
-        const platform = GLOBAL.get().meeting_platform
-        if (!this.context.proxyUrl && (platform === "meet" || platform === "zoom")) {
-          const retryCount = GLOBAL.getRetryCount()
-          // Meet's "last retry runs without proxy" fallback does NOT apply to
-          // Zoom: the browser-join wall blocks datacenter/pod IPs outright, so
-          // every Zoom attempt (including the final retry) must egress through
-          // the proxy. Zoom's retry value comes from cycling to a fresh exit IP,
-          // not from dropping the proxy.
-          if (platform === "meet" && retryCount >= MAX_RETRY_COUNT) {
-            console.log("[InitializationState] Last retry attempt — running without proxy")
-          } else {
-            const proxyUrl = await startToggleProxy(GLOBAL.get().bot_uuid, retryCount)
-            if (proxyUrl) {
-              this.context.proxyUrl = proxyUrl
-            }
-          }
-        }
-
-        const result = await Promise.race<BrowserResult>([
-          openBrowser(this.context.proxyUrl),
-          timeoutPromise
-        ])
-
-        // If we get here, openBrowser has succeeded
-        this.context.browserContext = result.browser
-
-        console.info("Browser setup completed successfully")
-        return // Exit the function if successful
-      } catch (error) {
-        lastError = error as Error
-        console.error(`Browser setup attempt ${attempt} failed:`, formatError(error))
-
-        // Si ce n'est pas la dernière tentative, attendre avant de réessayer
-        if (attempt < maxRetries) {
-          const waitTime = attempt * 5000 // Attente progressive: 5s, 10s, 15s...
-          console.info(`Waiting ${waitTime}ms before retry...`)
-          await new Promise((resolve) => setTimeout(resolve, waitTime))
-        }
-      }
-    }
-
-    // Si on arrive ici, c'est que toutes les tentatives ont échoué
-    console.error("All browser setup attempts failed:", lastError ? formatError(lastError) : {})
-    throw lastError || new Error("Browser setup failed after multiple attempts")
+    // Proxy start + browser launch (with retries) live in the shared
+    // browser-session helper so the in-process fast-retry uses the same path.
+    await establishBrowserSession(this.context)
   }
 
   private async setupPathManager(): Promise<void> {

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -1,5 +1,10 @@
 import { dehumanize } from "../../utils/dehumanize"
 import { notifyJoinReady } from "../../branding"
+import {
+  establishBrowserSession,
+  teardownBrowserSession
+} from "../../browser/browser-session"
+import { envVars } from "../../config/env-vars"
 import { Events } from "../../events"
 import { setDirectMode } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
@@ -85,43 +90,10 @@ export class WaitingRoomState extends BaseState {
         }
       }
 
-      // Open the meeting page
-      await this.openMeetingPage(meetingLink)
-
-      // Start Pulse → output WebSocket capture only when output streaming is enabled.
-      // Input-only bots still need Streaming (for input WebSocket) but must not run FFmpeg capture.
-      if (this.context.streamingService && GLOBAL.get().streaming_output) {
-        this.context.streamingService.startAudioCapture()
-      }
-
-      // Signal that the meeting page is open and the platform has confirmed
-      // the camera works. If multi-image branding was deferred, this triggers
-      // the switch from warmup placeholder to real branding.
-      notifyJoinReady()
-
-      // Start the dialog observer immediately after page is opened
-      // This ensures it can start monitoring dialogs right away
-      this.startDialogObserver()
-
-      // Capture DOM state after meeting page is opened (void to avoid blocking)
-      if (this.context.playwrightPage) {
-        const htmlSnapshot = HtmlSnapshotService.getInstance()
-        void htmlSnapshot.captureSnapshot(this.context.playwrightPage, "waiting_room_page_opened")
-      }
-
-      // Capture DOM state after meeting page is opened (void to avoid blocking)
-      if (this.context.playwrightPage) {
-        const htmlSnapshot = HtmlSnapshotService.getInstance()
-        void htmlSnapshot.captureSnapshot(this.context.playwrightPage, "waiting_room_page_opened")
-      }
-
-      ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
-
-      // Send waiting room event after the page is open
-      Events.inWaitingRoom()
-
-      // Wait for acceptance into the meeting
-      await this.waitForAcceptance()
+      // Open the page and wait for admission, with bounded in-process retries on
+      // Zoom's IP-keyed anti-bot wall (relaunch on a fresh exit IP in this warm
+      // pod before the SQS requeue). Non-Zoom platforms run exactly one attempt.
+      await this.joinWithInProcessRetry(meetingLink)
       console.info("Successfully joined meeting")
 
       // If everything is fine, move to the InCall state
@@ -172,6 +144,75 @@ export class WaitingRoomState extends BaseState {
       }
 
       return this.handleError(error as Error)
+    }
+  }
+
+  /**
+   * Open the meeting page and wait for admission. On Zoom's IP-keyed anti-bot
+   * wall (zoomAnonymousJoinNotAllowed) — and only that reason — relaunch the
+   * browser on a fresh residential exit IP in THIS pod, up to
+   * IN_PROCESS_RETRY_MAX times, before letting the failure propagate to the SQS
+   * requeue (a genuinely fresh pod). Xvfb/PulseAudio/screen-recorder scaffolding
+   * stays up across attempts; only the browser context + proxy session recycle.
+   * The one-time, device/display-level side effects (audio capture, branding
+   * switch, dialog observer, waiting-room webhook) run only on the first attempt.
+   */
+  private async joinWithInProcessRetry(meetingLink: string): Promise<void> {
+    const isZoom = GLOBAL.get().meeting_platform === "zoom"
+    const maxInProc = isZoom ? envVars.IN_PROCESS_RETRY_MAX : 0
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.openMeetingPage(meetingLink)
+
+        if (attempt === 0) {
+          // Pulse → output WebSocket capture (output streaming only). Device-level
+          // and self-guarded, so it survives a browser relaunch — start it once.
+          if (this.context.streamingService && GLOBAL.get().streaming_output) {
+            this.context.streamingService.startAudioCapture()
+          }
+          // Branding switch (warmup placeholder → real image) — idempotent trigger.
+          notifyJoinReady()
+          // Dialog observer polls context.playwrightPage live, so wiring it once
+          // picks up the relaunched page automatically (Meet-only; no-op on Zoom).
+          this.startDialogObserver()
+          // Waiting-room webhook — fire once, not per relaunch.
+          Events.inWaitingRoom()
+        }
+
+        if (this.context.playwrightPage) {
+          void HtmlSnapshotService.getInstance().captureSnapshot(
+            this.context.playwrightPage,
+            "waiting_room_page_opened"
+          )
+        }
+
+        // x11grab captures the display, self-guards on isRecording (no-op after
+        // the first attempt), so the recording spans the relaunch seamlessly.
+        ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
+
+        await this.waitForAcceptance()
+        return
+      } catch (error) {
+        const reason = GLOBAL.getEndReason()
+        // Only the IP-reputation wall is worth an in-process relaunch; every other
+        // reason (invalid URL, host denial, passcode, timeout) is not IP-keyed and
+        // must fall through to the outer catch → SQS requeue / terminal failure.
+        const canInProcessRetry =
+          attempt < maxInProc && reason === MeetingEndReason.ZoomAnonymousJoinNotAllowed
+        if (!canInProcessRetry) throw error
+
+        console.log(
+          `[Zoom] Anti-bot wall (${reason}) — in-process retry ${attempt + 1}/${maxInProc} on a fresh exit IP`
+        )
+        // Wipe the wall's error/end-reason/retry flags so the cleared attempt
+        // doesn't leak into the next join or the final wasRecordingSuccessful check.
+        GLOBAL.resetErrorState()
+        // Recycle browser + proxy onto a new Decodo session id (suffix "x<n>") →
+        // a different residential exit IP for the next launch.
+        await teardownBrowserSession(this.context)
+        await establishBrowserSession(this.context, { sessionSuffix: `x${attempt + 1}` })
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
Zoom web bots hit a probabilistic anti-bot wall (`zoomAnonymousJoinNotAllowed`, the *"automated bots aren't allowed"* / RTMS wall) whose pass/fail keys on the **exit-IP reputation** — our residential pool mixes clean and burned IPs. Today the only recourse is: mark retryable → **requeue to SQS** → KEDA spawns a **fresh pod** → cold-start (image pull, Xvfb, PulseAudio, browser launch) → join. That's **~20–40s of overhead per retry**, dominated by pod spin-up, even though the fix is just *"try a different exit IP"*.

## What this does
On the wall, retry **first in the same warm pod** by relaunching the browser on a **fresh Decodo residential exit IP**, skipping SQS + pod spawn + Xvfb/browser cold start → **~5–10s**. Only after `IN_PROCESS_RETRY_MAX` in-process attempts fail does it fall through to the **existing SQS requeue** for a genuinely fresh pod. The robust fallback is unchanged, so nothing regresses.

## Design — hybrid, bounded, feature-flagged
- **Flag:** `IN_PROCESS_RETRY_MAX` (env, default **2**). `0` disables in-process retry entirely → pure current behavior, so it can be dialed back instantly if it misbehaves.
- **Fresh IP per attempt:** `startToggleProxy` gains a `sessionSuffix` (`"x1"`, `"x2"`, …) appended to the Decodo session id. The base session is still `${uuid}${retryCount}`, so **attempt 0 is byte-identical to today**; in-process attempts advance the session id → a different residential IP — **without touching the SQS `retry_count`**. Pod requeues keep incrementing `retry_count` as before, so the pod-requeue budget, the proxy-session interplay, and the frontend retry display all stay coherent (no double-count).
- **IP-keyed only:** only `zoomAnonymousJoinNotAllowed` triggers an in-process relaunch. Every other reason (invalid URL, host denial, passcode, waiting-room timeout, `cannotJoinMeeting` — which isn't reliably IP-driven) propagates to the existing outer catch → SQS requeue / terminal failure, exactly as before.
- **Scaffolding stays up:** Xvfb / PulseAudio / the `ScreenRecorder` x11grab are **not** touched — only the `BrowserContext` + proxy chain recycle. One-time device/display side effects (Pulse→WS audio capture, branding switch, dialog observer wiring, waiting-room webhook) run **only on the first attempt**; `startAudioCapture()` and `startRecording()` are self-guarded no-ops anyway, and the dialog observer polls `context.playwrightPage` live so it picks up the relaunched page. `GLOBAL.resetErrorState()` wipes the cleared wall so a later admission isn't scored as a failed run.
- **No leaks:** `teardownBrowserSession()` closes the old context (→ closes its pages) and stops the old proxy chain **before** the next launch.

## Hybrid boundary / flow
1. **Attempt 1** join fails on the wall (`zoomAnonymousJoinNotAllowed`).
2. In-process relaunch: reset error state → teardown browser+proxy → `establishBrowserSession({ sessionSuffix: "x1" })` (fresh exit IP, same pod, no cold start) → re-open page → `waitForAcceptance`. **Attempt 2**, fast.
3. … up to **`IN_PROCESS_RETRY_MAX`** in-process attempts.
4. Still failing → error propagates to the existing waiting-room catch → `handleFailedRecording` → **`requeueToSQS`** (fresh pod, `retry_count + 1`).
5. … up to the Zoom SQS cap (`getMaxRetryCount` = **5**) → final failure.

So the total budget is e.g. **2 in-process + remaining pod requeues**. Latency win: the first N retries drop from ~20–40s to ~5–10s each.

## Files
- `config/env-vars.ts` — add `IN_PROCESS_RETRY_MAX` (num, default 2).
- `proxy/toggle-proxy.ts` — `startToggleProxy(sessionId, retryCount, sessionSuffix?)`; suffix advances the exit IP in-pod.
- `browser/browser-session.ts` **(new)** — `establishBrowserSession` / `teardownBrowserSession`, the shared proxy-start + launch(+retry) path.
- `state-machine/states/initialization-state.ts` — `setupBrowser` now delegates to `establishBrowserSession` (same behavior, one source of truth).
- `state-machine/states/waiting-room-state.ts` — `joinWithInProcessRetry()` loop around open-page → admission.
- `singleton.ts` — `resetErrorState()` (wipes endReason/errorMessage/shouldRetry between in-process attempts).

## Verify
`tsc --skipLibCheck -p tsconfig.release.json` passes clean.

## Risks
- **Browser-relaunch state:** each attempt is a brand-new `BrowserContext`/page; old context closed first. Screen recording spans the relaunch (x11grab is display-level, `isRecording`-guarded).
- **Audio-device reuse:** Pulse→WS capture is device-level and self-guarded — started once, survives relaunch (not re-init'd).
- **Scope:** in-process retry is Zoom-only and gated on the single IP-keyed reason; Meet/Teams run exactly one attempt (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)