### PR TITLE
feat: emit non-terminal `retrying` status on SQS requeue

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -74,6 +74,16 @@ export class Events {
     })
   }
 
+  // Non-terminal retry event. Emitted when a failed attempt is being re-queued
+  // to SQS for a fresh pod (fresh exit IP). Carries the attempt number and cap so
+  // the dashboard can show "Retrying… (attempt N/max)" instead of flashing a
+  // failure between attempts. A terminal recording_failed follows ONLY if all
+  // retries are exhausted. Waits for delivery because the pod exits right after.
+  static async retrying(attempt: number, max: number) {
+    console.log(`📤 Events.retrying called: attempt ${attempt}/${max}`)
+    return Events.EVENTS?.sendOnce("retrying", { attempt, max }, true)
+  }
+
   // Final webhook events (replacing sendWebhookOnce)
   static async recordingSucceeded() {
     return Events.EVENTS?.sendOnce("recording_succeeded", {}, true)

--- a/src/events.ts
+++ b/src/events.ts
@@ -81,7 +81,16 @@ export class Events {
   // retries are exhausted. Waits for delivery because the pod exits right after.
   static async retrying(attempt: number, max: number) {
     console.log(`📤 Events.retrying called: attempt ${attempt}/${max}`)
-    return Events.EVENTS?.sendOnce("retrying", { attempt, max }, true)
+    const delivered = await Events.EVENTS?.sendReliable("retrying", { attempt, max })
+    if (delivered === false) {
+      // The job is ALREADY requeued to SQS, so a stale status here is
+      // self-correcting (the retry pod emits joining_call). Never downgrade to
+      // recording_failed — just surface that the retrying status didn't land.
+      console.warn(
+        "[Events] 'retrying' status not confirmed delivered after retries — will refresh when the retry pod joins"
+      )
+    }
+    return delivered
   }
 
   // Final webhook events (replacing sendWebhookOnce)
@@ -124,10 +133,35 @@ export class Events {
     }
   }
 
+  // Fire-and-forget wrapper (delivery failure is swallowed — used by sendOnce).
   private async send(code: string, additionalData: Record<string, unknown> = {}): Promise<void> {
+    await this.postStatus(code, additionalData)
+  }
+
+  // Deliver a status with bounded retries; returns whether it was confirmed
+  // delivered. Use for statuses that must land before the pod exits (e.g. the
+  // retrying status emitted right before an SQS requeue).
+  private async sendReliable(
+    code: string,
+    additionalData: Record<string, unknown> = {},
+    attempts = 3
+  ): Promise<boolean> {
+    for (let i = 1; i <= attempts; i++) {
+      if (await this.postStatus(code, additionalData)) return true
+      if (i < attempts) await new Promise((resolve) => setTimeout(resolve, i * 500))
+    }
+    return false
+  }
+
+  // POST a status update. Returns true on delivery (or serverless skip), false
+  // on failure — so callers can observe success instead of silently continuing.
+  private async postStatus(
+    code: string,
+    additionalData: Record<string, unknown> = {}
+  ): Promise<boolean> {
     if (envVars.SERVERLESS) {
       console.log(`Serverless mode, skipping event delivery for ${code}`)
-      return
+      return true
     }
     try {
       await axios({
@@ -142,6 +176,7 @@ export class Events {
         }
       })
       console.log("Event sent successfully:", code, this.botId)
+      return true
     } catch (error) {
       if (error instanceof Error) {
         console.warn(
@@ -151,6 +186,7 @@ export class Events {
           error.message
         )
       }
+      return false
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,6 @@ import { BotMessageSchema } from "./utils/meeting-params-schema"
 import { PathManager } from "./utils/PathManager"
 import {
   buildRetryMessage,
-  formatRetryErrorMessage,
   getMaxRetryCount,
   requeueToSQS,
   shouldAttemptRetry
@@ -207,12 +206,16 @@ async function handleFailedRecording(): Promise<void> {
       const retryMessage = buildRetryMessage()
       await requeueToSQS(retryMessage)
 
-      // Send webhook with retry indication
-      const retryErrorMessage = formatRetryErrorMessage(
-        originalErrorMessage || "Recording failed",
-        currentRetryCount
+      // A retry is now pending. Emit the non-terminal `retrying` status (NOT
+      // recording_failed) so the dashboard shows "Retrying… (attempt N/max)"
+      // instead of flashing a failure between attempts. The real reason is only
+      // surfaced on the terminal path below once all retries are exhausted.
+      const attempt = currentRetryCount + 1
+      const cap = getMaxRetryCount()
+      console.log(
+        `📤 Emitting retrying status (attempt ${attempt}/${cap}) — reason: ${originalErrorMessage || endReason || "Recording failed"}`
       )
-      await Events.recordingFailed(retryErrorMessage)
+      await Events.retrying(attempt, cap)
 
       console.log("✅ Job requeued successfully - exiting without calling backend")
       // Exit cleanly - new pod will handle retry


### PR DESCRIPTION
## What
When a Zoom web bot hits the probabilistic anti-bot wall (`zoomAnonymousJoinNotAllowed`), the recorder marks it retryable and re-queues to SQS so a fresh pod lands a fresh exit IP (up to the Zoom cap of 5). That requeue path fired `Events.recordingFailed(...)` on **every** attempt, so the backend flipped the bot to `recording_failed` and the dashboard flashed "Recording Failed" between attempts — even though a retry was pending.

This emits a new **non-terminal** `retrying` event on the requeue (retry-pending) path instead:
- `Events.retrying(attempt, max)` POSTs `event_code: "retrying"` with `event_data: { attempt, max }`, where `attempt = currentRetryCount + 1` and `max = getMaxRetryCount()` (platform-aware; Zoom = 5).
- `Events.recordingFailed(...)` is now sent **only** on the terminal path (retries exhausted / not retryable), so the final failure still carries the real end reason and the backend resolves it to the real error code (e.g. `ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED`).

## State flow
attempt-1 fail → `retrying (1/5)` emitted + requeue → fresh pod → `joining_call` → … → on final exhaustion `recording_failed` (terminal) with the real end reason.

## Semantics change (call-out)
Today each requeue fires a `recording_failed` webhook; now each requeue fires a `bot.status_change` with code `retrying`. Terminal `recording_failed`/`bot.failed` is unchanged.

## Verify
`tsc --skipLibCheck -p tsconfig.release.json --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)