### PR TITLE
Zoom retry hardening + finalization fixes (all-in-one)

### DIFF
--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -49,16 +49,23 @@ export async function establishBrowserSession(
   for (let attempt = 1; attempt <= LAUNCH_ATTEMPTS; attempt++) {
     try {
       console.info(`Browser setup attempt ${attempt}/${LAUNCH_ATTEMPTS}`)
+      // Hoist the timer id so it's cleared once the race settles (either side).
+      // Leaving it pending keeps the event loop alive, delays shutdown, and — in
+      // the in-process retry loop — accumulates one dangling 60s timer per attempt.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
       const timeoutPromise = new Promise<never>((_, reject) => {
-        const id = setTimeout(() => {
-          clearTimeout(id)
+        timeoutId = setTimeout(() => {
           reject(new Error(`Browser setup timeout (${LAUNCH_TIMEOUT_MS}ms)`))
         }, LAUNCH_TIMEOUT_MS)
       })
-      const result = await Promise.race([openBrowser(session.proxyUrl), timeoutPromise])
-      session.browserContext = result.browser
-      console.info("Browser setup completed successfully")
-      return
+      try {
+        const result = await Promise.race([openBrowser(session.proxyUrl), timeoutPromise])
+        session.browserContext = result.browser
+        console.info("Browser setup completed successfully")
+        return
+      } finally {
+        clearTimeout(timeoutId)
+      }
     } catch (error) {
       lastError = error as Error
       console.error(`Browser setup attempt ${attempt} failed:`, formatError(error))

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,0 +1,91 @@
+import type { BrowserContext } from "@playwright/test"
+import { startToggleProxy, stopToggleProxy } from "../proxy/toggle-proxy"
+import { GLOBAL } from "../singleton"
+import { MAX_RETRY_COUNT } from "../utils/retry-handler"
+import { formatError } from "../utils/Logger"
+import { openBrowser } from "./browser"
+
+const LAUNCH_ATTEMPTS = 3
+const LAUNCH_TIMEOUT_MS = 60_000
+
+// Minimal slice of MeetingContext this module owns: the residential proxy URL
+// and the live browser context. Kept structural so both the state machine
+// context and the in-process retry can pass their context in directly.
+type BrowserSession = { proxyUrl?: string; browserContext?: BrowserContext }
+
+/**
+ * Start the residential proxy (Meet/Zoom) and launch the browser against it,
+ * writing proxyUrl + browserContext into `session`. The proxy session id is
+ * derived from the SQS retry count (a new pod → a new exit IP) plus an optional
+ * `sessionSuffix` that advances the exit IP for an in-process retry in the same
+ * pod. Launch is retried a few times. Reused by InitializationState and the
+ * in-process fast-retry so both share one launch/proxy path.
+ */
+export async function establishBrowserSession(
+  session: BrowserSession,
+  opts: { sessionSuffix?: string } = {}
+): Promise<void> {
+  const platform = GLOBAL.get().meeting_platform
+  const retryCount = GLOBAL.getRetryCount()
+
+  if (!session.proxyUrl && (platform === "meet" || platform === "zoom")) {
+    // Meet's "last retry runs without proxy" fallback does NOT apply to Zoom:
+    // the browser-join wall blocks datacenter/pod IPs outright, so every Zoom
+    // attempt must egress through the proxy — its retry value comes from cycling
+    // to a fresh exit IP, not from dropping the proxy.
+    if (platform === "meet" && retryCount >= MAX_RETRY_COUNT) {
+      console.log("[BrowserSession] Last retry attempt — running without proxy")
+    } else {
+      const proxyUrl = await startToggleProxy(
+        GLOBAL.get().bot_uuid,
+        retryCount,
+        opts.sessionSuffix
+      )
+      if (proxyUrl) session.proxyUrl = proxyUrl
+    }
+  }
+
+  let lastError: Error | null = null
+  for (let attempt = 1; attempt <= LAUNCH_ATTEMPTS; attempt++) {
+    try {
+      console.info(`Browser setup attempt ${attempt}/${LAUNCH_ATTEMPTS}`)
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        const id = setTimeout(() => {
+          clearTimeout(id)
+          reject(new Error(`Browser setup timeout (${LAUNCH_TIMEOUT_MS}ms)`))
+        }, LAUNCH_TIMEOUT_MS)
+      })
+      const result = await Promise.race([openBrowser(session.proxyUrl), timeoutPromise])
+      session.browserContext = result.browser
+      console.info("Browser setup completed successfully")
+      return
+    } catch (error) {
+      lastError = error as Error
+      console.error(`Browser setup attempt ${attempt} failed:`, formatError(error))
+      if (attempt < LAUNCH_ATTEMPTS) {
+        const waitTime = attempt * 5000 // 5s, 10s progressive backoff
+        console.info(`Waiting ${waitTime}ms before retry...`)
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
+      }
+    }
+  }
+  throw lastError || new Error("Browser setup failed after multiple attempts")
+}
+
+/**
+ * Tear down the browser context + residential proxy so the next
+ * establishBrowserSession() launches cleanly on a fresh exit IP. Xvfb,
+ * PulseAudio and the screen recorder stay up — only the browser + proxy chain
+ * are recycled. Best-effort: errors are logged, never thrown.
+ */
+export async function teardownBrowserSession(session: BrowserSession): Promise<void> {
+  try {
+    // Closing the context closes all its pages.
+    await session.browserContext?.close()
+  } catch (error) {
+    console.warn("[BrowserSession] Error closing browser context:", formatError(error))
+  }
+  session.browserContext = undefined
+  await stopToggleProxy()
+  session.proxyUrl = undefined
+}

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,3 +1,4 @@
+import { execFile } from "child_process"
 import type { BrowserContext } from "@playwright/test"
 import { startToggleProxy, stopToggleProxy } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
@@ -7,6 +8,25 @@ import { openBrowser } from "./browser"
 
 const LAUNCH_ATTEMPTS = 3
 const LAUNCH_TIMEOUT_MS = 60_000
+// Cap how long we wait for a graceful context.close() before force-reaping the
+// process tree — a hung/stuck page (anti-bot wall) can make close() never resolve.
+const BROWSER_CLOSE_TIMEOUT_MS = 8_000
+
+/**
+ * Force-reap any Firefox/stealthfox processes still alive after context.close().
+ * One stealthfox is ~15 processes (main + content/utility/RDD/socket children,
+ * ~2.4GB total); a hung or botched close leaves that tree running, and each
+ * in-process retry then stacks another ~2.4GB → OOMKill at the 8Gi limit. Each
+ * pod runs exactly ONE bot and teardown only runs on the in-process-retry recycle
+ * (never during a live good recording), so SIGKILL-ing every firefox process is
+ * safe. Best-effort — a missing pkill / no matching process must not throw.
+ */
+async function killBrowserProcesses(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    // -9: content processes ignore SIGTERM; -f: match the binary path in argv.
+    execFile("pkill", ["-9", "-f", "firefox"], () => resolve())
+  })
+}
 
 // Minimal slice of MeetingContext this module owns: the residential proxy URL
 // and the live browser context. Kept structural so both the state machine
@@ -87,12 +107,20 @@ export async function establishBrowserSession(
  */
 export async function teardownBrowserSession(session: BrowserSession): Promise<void> {
   try {
-    // Closing the context closes all its pages.
-    await session.browserContext?.close()
+    // Closing a persistent context closes its pages AND the browser — but on a
+    // hung/stuck page (e.g. the anti-bot wall) close() can hang or reject. Bound
+    // it so a stuck close can't block the in-process retry indefinitely.
+    await Promise.race([
+      session.browserContext?.close() ?? Promise.resolve(),
+      new Promise<void>((resolve) => setTimeout(resolve, BROWSER_CLOSE_TIMEOUT_MS))
+    ])
   } catch (error) {
     console.warn("[BrowserSession] Error closing browser context:", formatError(error))
   }
   session.browserContext = undefined
+  // Reap any Firefox tree that survived (or outran) the close, so the next
+  // establishBrowserSession() never stacks a second ~2.4GB browser → OOMKill.
+  await killBrowserProcesses()
   await stopToggleProxy()
   session.proxyUrl = undefined
 }

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,7 +1,7 @@
 import type { BrowserContext } from "@playwright/test"
 import { startToggleProxy, stopToggleProxy } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
-import { MAX_RETRY_COUNT } from "../utils/retry-handler"
+import { MAX_RETRY_COUNT } from "../config/retry-config"
 import { formatError } from "../utils/Logger"
 import { openBrowser } from "./browser"
 

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -8,9 +8,13 @@ import { openBrowser } from "./browser"
 
 const LAUNCH_ATTEMPTS = 3
 const LAUNCH_TIMEOUT_MS = 60_000
-// Cap how long we wait for a graceful context.close() before force-reaping the
-// process tree — a hung/stuck page (anti-bot wall) can make close() never resolve.
-const BROWSER_CLOSE_TIMEOUT_MS = 8_000
+// Give the graceful context.close() only a tiny window before force-reaping the
+// tree. This isn't about flushing data (the profile is a throwaway temp dir) — a
+// brief close lets Playwright's local juggler transport detach cleanly, so a cold
+// SIGKILL doesn't leave in-flight page ops rejecting with "Target closed" (which
+// would trip the crash handler). It's a local transport, not a network round-trip,
+// so ~750ms is plenty; pkill -9 below is instant, keeping the fast retry fast.
+const BROWSER_CLOSE_TIMEOUT_MS = 750
 
 /**
  * Force-reap any Firefox/stealthfox processes still alive after context.close().

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -82,8 +82,9 @@ export const envVars = cleanEnv(process.env, {
   // IP inside the SAME warm pod before falling back to the SQS requeue (fresh
   // pod). The anti-bot wall keys on the exit IP, so an in-pod relaunch on a new
   // residential IP clears it in ~5-10s vs the ~20-40s of a pod cold-start. 0
-  // disables in-process retry entirely (pure requeue behavior). Total budget =
-  // this + the remaining SQS pod requeues (see getMaxRetryCount, zoom=5).
+  // disables in-process retry entirely (pure requeue behavior). Envalid-validated
+  // here; consumed/re-exported via config/retry-config.ts, the single retry-count
+  // source (total-budget math lives there).
   IN_PROCESS_RETRY_MAX: num({ default: 2 })
 })
 

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv"
-import { bool, cleanEnv, port, str } from "envalid"
+import { bool, cleanEnv, num, port, str } from "envalid"
 
 dotenv.config()
 
@@ -77,7 +77,14 @@ export const envVars = cleanEnv(process.env, {
   // Absolute path to the stealthfox Firefox binary. Baked into the Docker image
   // at /opt/stealthfox/<tag>/firefox by scripts/fetch-stealthfox.sh. Empty =
   // stealthfox disabled (falls back to CloakBrowser).
-  STEALTHFOX_BINARY_PATH: str({ default: "" })
+  STEALTHFOX_BINARY_PATH: str({ default: "" }),
+  // Zoom web only: how many times to relaunch the browser on a FRESH proxy exit
+  // IP inside the SAME warm pod before falling back to the SQS requeue (fresh
+  // pod). The anti-bot wall keys on the exit IP, so an in-pod relaunch on a new
+  // residential IP clears it in ~5-10s vs the ~20-40s of a pod cold-start. 0
+  // disables in-process retry entirely (pure requeue behavior). Total budget =
+  // this + the remaining SQS pod requeues (see getMaxRetryCount, zoom=5).
+  IN_PROCESS_RETRY_MAX: num({ default: 2 })
 })
 
 export type EnvVars = typeof envVars

--- a/src/config/retry-config.ts
+++ b/src/config/retry-config.ts
@@ -1,0 +1,41 @@
+import { GLOBAL } from "../singleton"
+import { envVars } from "./env-vars"
+
+/**
+ * Single source of truth for every bot retry count.
+ *
+ * A failed join burns two independent budgets, in order:
+ *   1. IN_PROCESS_RETRY_MAX  — in-pod relaunches: fast (~5-10s), fresh proxy
+ *      exit IP, SAME warm pod. Zoom web only (0 elsewhere). See waiting-room-state.
+ *   2. getMaxRetryCount()    — SQS pod-requeues: slow (~20-40s cold start), fresh
+ *      pod. Zoom=ZOOM_WEB_MAX_RETRY_COUNT, else MAX_RETRY_COUNT.
+ * Total attempts ≈ (IN_PROCESS_RETRY_MAX per pod) × (getMaxRetryCount() + 1 pods).
+ *
+ * NOT the same knob: apps/sqs-consumer's bot-launcher.ts has its own
+ * MAX_RETRY_COUNT capping early-crash requeues on the consumer side — a
+ * deliberately separate cap in a different app. Keep the two independent.
+ */
+
+// SQS pod-requeue cap (Meet/Teams default).
+export const MAX_RETRY_COUNT = 2
+
+// SQS pod-requeue cap for Zoom web — higher to cycle exit IPs past the
+// probabilistic anti-bot / RTMS wall, which keys on the exit IP's reputation.
+export const ZOOM_WEB_MAX_RETRY_COUNT = 5
+
+// In-pod fast relaunches on a fresh exit IP before the first SQS requeue.
+// Envalid-validated declaration + default (2) lives in env-vars.ts; re-exported
+// here so all retry counts have one import surface.
+export const IN_PROCESS_RETRY_MAX = envVars.IN_PROCESS_RETRY_MAX
+
+/**
+ * Platform-aware SQS requeue cap: Zoom web gets more attempts. Guarded so a
+ * crash before params are set (GLOBAL unset) falls back to the default.
+ */
+export function getMaxRetryCount(): number {
+  try {
+    return GLOBAL.get().meeting_platform === "zoom" ? ZOOM_WEB_MAX_RETRY_COUNT : MAX_RETRY_COUNT
+  } catch {
+    return MAX_RETRY_COUNT
+  }
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -74,6 +74,16 @@ export class Events {
     })
   }
 
+  // Non-terminal retry event. Emitted when a failed attempt is being re-queued
+  // to SQS for a fresh pod (fresh exit IP). Carries the attempt number and cap so
+  // the dashboard can show "Retrying… (attempt N/max)" instead of flashing a
+  // failure between attempts. A terminal recording_failed follows ONLY if all
+  // retries are exhausted. Waits for delivery because the pod exits right after.
+  static async retrying(attempt: number, max: number) {
+    console.log(`📤 Events.retrying called: attempt ${attempt}/${max}`)
+    return Events.EVENTS?.sendOnce("retrying", { attempt, max }, true)
+  }
+
   // Final webhook events (replacing sendWebhookOnce)
   static async recordingSucceeded() {
     return Events.EVENTS?.sendOnce("recording_succeeded", {}, true)

--- a/src/events.ts
+++ b/src/events.ts
@@ -81,7 +81,16 @@ export class Events {
   // retries are exhausted. Waits for delivery because the pod exits right after.
   static async retrying(attempt: number, max: number) {
     console.log(`📤 Events.retrying called: attempt ${attempt}/${max}`)
-    return Events.EVENTS?.sendOnce("retrying", { attempt, max }, true)
+    const delivered = await Events.EVENTS?.sendReliable("retrying", { attempt, max })
+    if (delivered === false) {
+      // The job is ALREADY requeued to SQS, so a stale status here is
+      // self-correcting (the retry pod emits joining_call). Never downgrade to
+      // recording_failed — just surface that the retrying status didn't land.
+      console.warn(
+        "[Events] 'retrying' status not confirmed delivered after retries — will refresh when the retry pod joins"
+      )
+    }
+    return delivered
   }
 
   // Final webhook events (replacing sendWebhookOnce)
@@ -124,10 +133,35 @@ export class Events {
     }
   }
 
+  // Fire-and-forget wrapper (delivery failure is swallowed — used by sendOnce).
   private async send(code: string, additionalData: Record<string, unknown> = {}): Promise<void> {
+    await this.postStatus(code, additionalData)
+  }
+
+  // Deliver a status with bounded retries; returns whether it was confirmed
+  // delivered. Use for statuses that must land before the pod exits (e.g. the
+  // retrying status emitted right before an SQS requeue).
+  private async sendReliable(
+    code: string,
+    additionalData: Record<string, unknown> = {},
+    attempts = 3
+  ): Promise<boolean> {
+    for (let i = 1; i <= attempts; i++) {
+      if (await this.postStatus(code, additionalData)) return true
+      if (i < attempts) await new Promise((resolve) => setTimeout(resolve, i * 500))
+    }
+    return false
+  }
+
+  // POST a status update. Returns true on delivery (or serverless skip), false
+  // on failure — so callers can observe success instead of silently continuing.
+  private async postStatus(
+    code: string,
+    additionalData: Record<string, unknown> = {}
+  ): Promise<boolean> {
     if (envVars.SERVERLESS) {
       console.log(`Serverless mode, skipping event delivery for ${code}`)
-      return
+      return true
     }
     try {
       await axios({
@@ -142,6 +176,7 @@ export class Events {
         }
       })
       console.log("Event sent successfully:", code, this.botId)
+      return true
     } catch (error) {
       if (error instanceof Error) {
         console.warn(
@@ -151,6 +186,7 @@ export class Events {
           error.message
         )
       }
+      return false
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,14 @@ process.on("SIGTERM", async () => {
             GLOBAL.releaseRecovery()
             throw e
           }
+          // Requeue succeeded — surface `retrying` for SIGTERM-path requeues too,
+          // matching the graceful path. Best-effort; isolated so a failed emit
+          // can't release the successful recovery claim.
+          try {
+            await Events.retrying(GLOBAL.getRetryCount() + 1, getMaxRetryCount())
+          } catch (evErr) {
+            console.error("[SIGTERM] retrying status emit failed (non-fatal):", formatError(evErr))
+          }
         } else {
           console.log("[SIGTERM] Recovery claimed concurrently — skipping duplicate requeue")
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,17 +35,22 @@ const BOT_LIKE_NAME_RE =
 // (bounded by the retry cap), upload logs, and exit cleanly instead of being
 // force-killed. Best-effort and guarded (GLOBAL may be unset on a very early kill).
 //
-// Recovery (log-upload + requeue) is guarded by the single shared GLOBAL.claimRecovery()
-// token so a SIGTERM racing the normal shutdown or the crash handler can never
-// double-requeue the same meeting. If another path already owns recovery, just
-// exit cleanly.
+// Recovery double-requeue safety (#224 regression fix): the shared
+// GLOBAL.claimRecovery() token is taken ONLY at the moment of a requeue, never up
+// front. Up-front claiming here used to starve the primary failure-retry in
+// handleFailedRecording() whenever this handler won the claim but then took a
+// non-requeuing branch (finalized / serverless). Now we (a) stand down WITHOUT
+// exiting if a requeue is already in flight elsewhere — so we never kill it
+// mid-write — and (b) claim atomically only right before our own requeue, so at
+// most one requeue ever happens.
 process.on("SIGTERM", async () => {
-  if (!GLOBAL.claimRecovery()) {
-    // Another handler (normal shutdown / crash) already owns recovery and is
-    // awaiting its log-upload + requeue. Exiting here would kill that owner
-    // mid-write and lose the meeting — stand down and let the owner exit once
-    // its recovery completes.
-    console.log("[SIGTERM] Recovery already owned by another handler — standing down (owner will exit)")
+  if (GLOBAL.isRecoveryClaimed()) {
+    // A requeue-performing path already owns recovery and may be mid-write.
+    // Exiting here would kill it and lose the meeting — stand down (do NOT exit)
+    // and let that owner finish its requeue and exit.
+    console.log(
+      "[SIGTERM] Recovery already owned by a requeuing handler — standing down (owner will exit)"
+    )
     return
   }
   console.error("[SIGTERM] Pod termination received — requeuing so the meeting isn't lost")
@@ -57,7 +62,8 @@ process.on("SIGTERM", async () => {
   try {
     if (GLOBAL.hasRecordingFinalized()) {
       // Eviction during upload: the merged recording exists — preserve it for the
-      // S3/EFS salvage path rather than requeuing (which would re-record).
+      // S3/EFS salvage path rather than requeuing (which would re-record). NB: no
+      // claim on this branch — a non-requeuing path must never take the token.
       console.log(
         "[SIGTERM] Recording finalized/uploading — preserving artifacts for salvage (not requeuing)"
       )
@@ -66,8 +72,15 @@ process.on("SIGTERM", async () => {
       // requeue to re-record on a fresh pod.
       GLOBAL.setShouldRetry(true)
       if (shouldAttemptRetry(GLOBAL.getRetryCount())) {
-        await requeueToSQS(buildRetryMessage())
-        console.log("[SIGTERM] Requeued to SQS to re-record")
+        // Claim immediately before requeuing. If a concurrent path grabbed it
+        // first it has already requeued this meeting — skip to avoid a double
+        // re-record.
+        if (GLOBAL.claimRecovery()) {
+          await requeueToSQS(buildRetryMessage())
+          console.log("[SIGTERM] Requeued to SQS to re-record")
+        } else {
+          console.log("[SIGTERM] Recovery claimed concurrently — skipping duplicate requeue")
+        }
       }
     }
   } catch (e) {
@@ -190,14 +203,6 @@ async function handleFailedRecording(): Promise<void> {
   const shouldRetry = shouldAttemptRetry(currentRetryCount)
 
   if (shouldRetry) {
-    // Take the shared recovery claim before requeuing so a concurrent SIGTERM /
-    // crash handler can't also requeue this same meeting. If another path already
-    // owns recovery, it has (or will) requeue — skip to avoid a duplicate re-record.
-    if (!GLOBAL.claimRecovery()) {
-      console.log("🔁 Recovery already claimed by another handler — skipping requeue")
-      return
-    }
-
     console.log(
       `🔄 Error marked as retryable - attempting retry ${currentRetryCount + 1}/${getMaxRetryCount()}`
     )
@@ -205,6 +210,23 @@ async function handleFailedRecording(): Promise<void> {
     try {
       // Build and send retry message to SQS
       const retryMessage = buildRetryMessage()
+
+      // Take the shared recovery claim IMMEDIATELY before requeuing. #224
+      // regression fix: the claim is now held ONLY by paths that actually requeue,
+      // so losing it here means another handler (SIGTERM / crash) has ALREADY
+      // requeued this exact meeting — skip to avoid a duplicate re-record. This is
+      // the single-threaded PRIMARY retry path and must never be starved: the old
+      // code claimed up front in the SIGTERM / crash handlers (and the finally
+      // block), so a handler that won the claim but then took a NON-requeuing
+      // branch would make this claim fail and silently skip the retry — terminally
+      // failing Zoom web bots on attempt 1 instead of cycling exit IPs past the
+      // probabilistic anti-bot wall.
+      if (!GLOBAL.claimRecovery()) {
+        console.log(
+          "🔁 Recovery already requeued by another handler — skipping duplicate requeue"
+        )
+        return
+      }
       await requeueToSQS(retryMessage)
 
       // Send webhook with retry indication
@@ -316,9 +338,12 @@ async function handleFailedRecording(): Promise<void> {
     // Delegate to handleFailedRecording which includes retry logic
     await handleFailedRecording()
   } finally {
-    // Take the shared recovery claim so a SIGTERM during shutdown doesn't requeue
-    // an already-handled run. Idempotent: if a retry path already claimed it, this
-    // is a no-op; either way recovery is now owned by this normal path.
+    // Mark the run fully handled so a late SIGTERM / crash arriving during this
+    // final log upload stands down instead of spuriously re-recording an
+    // already-decided (e.g. terminally-failed) meeting. This runs AFTER
+    // handleFailedRecording(), so — unlike the old up-front claims in the SIGTERM /
+    // crash handlers — it can NEVER starve the primary retry's own claim (that
+    // claim, if the run retried, was already taken). It performs no requeue itself.
     GLOBAL.claimRecovery()
     if (!GLOBAL.isServerless()) {
       try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,8 +54,14 @@ process.on("SIGTERM", async () => {
       if (shouldAttemptRetry(GLOBAL.getRetryCount())) {
         // Claim right before requeue; a lost claim means another path already requeued.
         if (GLOBAL.claimRecovery()) {
-          await requeueToSQS(buildRetryMessage())
-          console.log("[SIGTERM] Requeued to SQS to re-record")
+          try {
+            await requeueToSQS(buildRetryMessage())
+            console.log("[SIGTERM] Requeued to SQS to re-record")
+          } catch (e) {
+            // Send failed — release so another path can requeue (see releaseRecovery).
+            GLOBAL.releaseRecovery()
+            throw e
+          }
         } else {
           console.log("[SIGTERM] Recovery claimed concurrently — skipping duplicate requeue")
         }
@@ -189,7 +195,15 @@ async function handleFailedRecording(): Promise<void> {
         console.log("🔁 Recovery already requeued by another handler — skipping duplicate requeue")
         return
       }
-      await requeueToSQS(retryMessage)
+      try {
+        await requeueToSQS(retryMessage)
+      } catch (requeueError) {
+        // Send failed — release the claim so a SIGTERM/crash handler can take over
+        // the requeue instead of standing down on a stuck claim (and losing the
+        // meeting). Rethrow into the outer catch → normal failure flow.
+        GLOBAL.releaseRecovery()
+        throw requeueError
+      }
 
       // A retry is now pending. Emit the non-terminal `retrying` status (NOT
       // recording_failed) so the dashboard shows "Retrying… (attempt N/max)"

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,32 +25,19 @@ import {
   shouldAttemptRetry
 } from "./utils/retry-handler"
 
-// Display names Zoom hosts commonly auto-reject as "obviously a bot". Surfaced as
-// a LOG hint (never the user-facing error) when a join is rejected.
+// Bot-like display-name tokens; log-only hint when a Zoom join is rejected.
 const BOT_LIKE_NAME_RE =
-  /note ?taker|recorder|recording|transcri|\bbots?\b|\bai\b|assistant|\bnotes?\b|meeting ?baas|fireflies|otter|read ?ai/i
+  /note ?taker|recorder|recording|transcri|\bbots?\b|\bai\b|assistant|\bnotes?\b/i
 
-// k8s evicts / scales down bot pods with SIGTERM. If it arrives BEFORE the run
-// has settled, the meeting would otherwise be lost — so requeue it to a fresh pod
-// (bounded by the retry cap), upload logs, and exit cleanly instead of being
-// force-killed. Best-effort and guarded (GLOBAL may be unset on a very early kill).
-//
-// Recovery double-requeue safety (#224 regression fix): the shared
-// GLOBAL.claimRecovery() token is taken ONLY at the moment of a requeue, never up
-// front. Up-front claiming here used to starve the primary failure-retry in
-// handleFailedRecording() whenever this handler won the claim but then took a
-// non-requeuing branch (finalized / serverless). Now we (a) stand down WITHOUT
-// exiting if a requeue is already in flight elsewhere — so we never kill it
-// mid-write — and (b) claim atomically only right before our own requeue, so at
-// most one requeue ever happens.
+// On SIGTERM (k8s eviction), requeue the meeting to a fresh pod so it isn't lost.
+// The shared GLOBAL.claimRecovery() token is taken ONLY right before a requeue, so
+// at most one requeue happens; a non-requeuing path must never take it (that would
+// starve the primary retry in handleFailedRecording).
 process.on("SIGTERM", async () => {
   if (GLOBAL.isRecoveryClaimed()) {
-    // A requeue-performing path already owns recovery and may be mid-write.
-    // Exiting here would kill it and lose the meeting — stand down (do NOT exit)
-    // and let that owner finish its requeue and exit.
-    console.log(
-      "[SIGTERM] Recovery already owned by a requeuing handler — standing down (owner will exit)"
-    )
+    // A requeuing path already owns recovery and may be mid-write — stand down
+    // (do NOT exit) so we don't kill it.
+    console.log("[SIGTERM] Recovery already owned by a requeuing handler — standing down")
     return
   }
   console.error("[SIGTERM] Pod termination received — requeuing so the meeting isn't lost")
@@ -61,20 +48,12 @@ process.on("SIGTERM", async () => {
   }
   try {
     if (GLOBAL.hasRecordingFinalized()) {
-      // Eviction during upload: the merged recording exists — preserve it for the
-      // S3/EFS salvage path rather than requeuing (which would re-record). NB: no
-      // claim on this branch — a non-requeuing path must never take the token.
-      console.log(
-        "[SIGTERM] Recording finalized/uploading — preserving artifacts for salvage (not requeuing)"
-      )
+      // Merged recording exists — preserve for S3/EFS salvage, don't requeue (no claim).
+      console.log("[SIGTERM] Recording finalized — preserving artifacts (not requeuing)")
     } else if (!GLOBAL.isServerless()) {
-      // Join or mid-recording: the only copy is ephemeral /tmp, lost with the pod —
-      // requeue to re-record on a fresh pod.
       GLOBAL.setShouldRetry(true)
       if (shouldAttemptRetry(GLOBAL.getRetryCount())) {
-        // Claim immediately before requeuing. If a concurrent path grabbed it
-        // first it has already requeued this meeting — skip to avoid a double
-        // re-record.
+        // Claim right before requeue; a lost claim means another path already requeued.
         if (GLOBAL.claimRecovery()) {
           await requeueToSQS(buildRetryMessage())
           console.log("[SIGTERM] Requeued to SQS to re-record")
@@ -188,18 +167,13 @@ async function handleFailedRecording(): Promise<void> {
     return
   }
 
-  // The Zoom browser-join anti-bot / RTMS wall is probabilistic: it keys on the
-  // exit IP's reputation, and our proxy pool mixes clean and burned IPs (a live
-  // test joined 1 of 4 bots with identical fingerprints — the pass/fail split was
-  // purely the exit IP). Mark the wall retryable so the bot requeues onto a FRESH
-  // exit IP — the proxy session token embeds the retry count, so each requeue
-  // lands a different IP — cycling past burned ones up to MAX_RETRY_COUNT.
+  // The Zoom anti-bot wall is probabilistic (keys on exit-IP reputation), so mark
+  // it retryable — each requeue lands a fresh exit IP, cycling past burned ones.
   if (endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) {
-    console.log("[Retry] Zoom RTMS wall — marking retryable to cycle exit IP")
+    console.log("[Retry] Zoom anti-bot wall — marking retryable to cycle exit IP")
     GLOBAL.setShouldRetry(true)
   }
 
-  // Check if we should retry instead of failing permanently
   const shouldRetry = shouldAttemptRetry(currentRetryCount)
 
   if (shouldRetry) {
@@ -208,23 +182,12 @@ async function handleFailedRecording(): Promise<void> {
     )
 
     try {
-      // Build and send retry message to SQS
       const retryMessage = buildRetryMessage()
 
-      // Take the shared recovery claim IMMEDIATELY before requeuing. #224
-      // regression fix: the claim is now held ONLY by paths that actually requeue,
-      // so losing it here means another handler (SIGTERM / crash) has ALREADY
-      // requeued this exact meeting — skip to avoid a duplicate re-record. This is
-      // the single-threaded PRIMARY retry path and must never be starved: the old
-      // code claimed up front in the SIGTERM / crash handlers (and the finally
-      // block), so a handler that won the claim but then took a NON-requeuing
-      // branch would make this claim fail and silently skip the retry — terminally
-      // failing Zoom web bots on attempt 1 instead of cycling exit IPs past the
-      // probabilistic anti-bot wall.
+      // Claim right before requeuing (primary retry path). A lost claim means a
+      // SIGTERM/crash handler already requeued this meeting — skip the duplicate.
       if (!GLOBAL.claimRecovery()) {
-        console.log(
-          "🔁 Recovery already requeued by another handler — skipping duplicate requeue"
-        )
+        console.log("🔁 Recovery already requeued by another handler — skipping duplicate requeue")
         return
       }
       await requeueToSQS(retryMessage)

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,6 @@ import { BotMessageSchema } from "./utils/meeting-params-schema"
 import { PathManager } from "./utils/PathManager"
 import {
   buildRetryMessage,
-  formatRetryErrorMessage,
   getMaxRetryCount,
   requeueToSQS,
   shouldAttemptRetry
@@ -207,12 +206,16 @@ async function handleFailedRecording(): Promise<void> {
       const retryMessage = buildRetryMessage()
       await requeueToSQS(retryMessage)
 
-      // Send webhook with retry indication
-      const retryErrorMessage = formatRetryErrorMessage(
-        originalErrorMessage || "Recording failed",
-        currentRetryCount
+      // A retry is now pending. Emit the non-terminal `retrying` status (NOT
+      // recording_failed) so the dashboard shows "Retrying… (attempt N/max)"
+      // instead of flashing a failure between attempts. The real reason is only
+      // surfaced on the terminal path below once all retries are exhausted.
+      const attempt = currentRetryCount + 1
+      const cap = getMaxRetryCount()
+      console.log(
+        `📤 Emitting retrying status (attempt ${attempt}/${cap}) — reason: ${originalErrorMessage || endReason || "Recording failed"}`
       )
-      await Events.recordingFailed(retryErrorMessage)
+      await Events.retrying(attempt, cap)
 
       console.log("✅ Job requeued successfully - exiting without calling backend")
       // Exit cleanly - new pod will handle retry

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,10 +17,10 @@ import {
 } from "./utils/Logger"
 import { BotMessageSchema } from "./utils/meeting-params-schema"
 import { PathManager } from "./utils/PathManager"
+import { getMaxRetryCount } from "./config/retry-config"
 import {
   buildRetryMessage,
   formatRetryErrorMessage,
-  getMaxRetryCount,
   requeueToSQS,
   shouldAttemptRetry
 } from "./utils/retry-handler"

--- a/src/media_context.ts
+++ b/src/media_context.ts
@@ -149,9 +149,16 @@ export class SoundContext extends MediaContext {
       "pcm_s16le",
       MICRO_DEVICE
     )
-    return super.execute(args, () => {
+    const stdin = super.execute(args, () => {
       console.warn("[play_stdin] Sequence ended")
     }).stdin
+    // Same EPIPE guard as the video feeder: audio writes (streaming.ts) can flush
+    // into ffmpeg's stdin after SIGTERM closes it, emitting EPIPE. Handle it here
+    // so it never escalates to an uncaughtException that kills finalization.
+    stdin.on("error", (err) => {
+      console.warn(`[play_stdin] ffmpeg stdin error (ignored during teardown): ${err}`)
+    })
+    return stdin
   }
 
   public async stop() {
@@ -279,6 +286,14 @@ export class VideoContext extends MediaContext {
     }
 
     this.ffmpegStdin = proc.stdin
+    // EPIPE guard: on teardown, ffmpeg is SIGTERM'd and closes its stdin read-end
+    // while buffered frames are still flushing. Without an "error" listener that
+    // EPIPE becomes an uncaughtException, which aborts finalization (the
+    // end-meeting trampoline that reports artifacts + duration) and orphans the
+    // bot record at recording_succeeded. Log and swallow it.
+    this.ffmpegStdin.on("error", (err) => {
+      console.warn(`[video feeder] ffmpeg stdin error (ignored during teardown): ${err}`)
+    })
     this.startFeeder()
   }
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -114,14 +114,20 @@ function logStats(label: string): void {
   )
 }
 
-export async function startToggleProxy(sessionId: string, retryCount = 0): Promise<string | null> {
+export async function startToggleProxy(
+  sessionId: string,
+  retryCount = 0,
+  sessionSuffix = ""
+): Promise<string | null> {
   if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
     console.log("[ToggleProxy] No RESIDENTIAL_PROXY_TEMPLATE configured, skipping proxy")
     return null
   }
   // Decodo session labels must be alphanumeric; bot UUIDs have hyphens.
-  // Append retry count so each SQS retry lands on a different residential IP.
-  const session = `${sessionId.replace(/-/g, "")}${retryCount}`
+  // Append the SQS retry count so each requeued pod lands on a different
+  // residential IP; sessionSuffix (e.g. "x1") advances the IP again for an
+  // in-process retry within the SAME pod without touching retry_count.
+  const session = `${sessionId.replace(/-/g, "")}${retryCount}${sessionSuffix}`
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
 
   // Reset stats, proxied-connection tracking, and exit IP for this new session

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -152,7 +152,13 @@ export class ScreenRecorder extends EventEmitter {
 
   public async startRecording(page: Page): Promise<void> {
     if (this.isRecording) {
-      throw new Error("Recording is already in progress")
+      // Already recording — no-op instead of throwing. The in-process retry loop
+      // relaunches the browser but the x11grab recording spans it (it captures the
+      // Xvfb display, not the page), so a second start is expected. Throwing here
+      // produced an unhandled rejection that crashed the pod and forced a futile
+      // SQS requeue (defeating the fast in-pod retry).
+      console.warn("[ScreenRecorder] startRecording called while already recording — ignoring")
+      return
     }
 
     // Capture DOM state before starting screen recording (void to avoid blocking)

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -294,7 +294,12 @@ export class SimpleDialogObserver {
     try {
       for (const pattern of modalPatterns) {
         try {
-          const modal = page.locator(pattern.selector)
+          // .first(): Zoom's consent modal selector (div:has-text(...)) matches
+          // several nested ancestor divs, so a bare locator throws Playwright's
+          // strict-mode "resolved to N elements" on isVisible(). Narrowing to the
+          // first (outermost) match — which still :has the OK button — makes the
+          // check single-element and lets tryDismissModal find the button inside.
+          const modal = page.locator(pattern.selector).first()
           const isVisible = await modal.isVisible({
             timeout: timeouts.VISIBLE_TIMEOUT
           })

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -97,34 +97,17 @@ const MEET_MODAL_PATTERNS: ModalPattern[] = [
 ]
 
 /**
- * Zoom (browser web-client) modal patterns.
- * Zoom renders these modals inside its web-client shadow DOM, so page.content()
- * won't serialize them and a bare class selector is brittle. Playwright's
- * text/role locators DO pierce open shadow roots, so we anchor on visible TEXT
- * and keep the button INSIDE the matched container so tryDismissModal finds it.
- * We deliberately do NOT assume div[role="dialog"] — Zoom may not set that role.
- * IMPORTANT: Order matters! Specific patterns before the generic fallback.
+ * Zoom (web client, app.zoom.us/wc) does NOT use Playwright's locator/isVisible
+ * path — the rest of the Zoom code (see zoom.ts) documents that Zoom's overlays
+ * make Playwright report its own controls as not-visible / not-actionable, so a
+ * locator.click() stalls and isVisible() gates skip the element entirely. That is
+ * exactly why the pattern-based observer never dismissed the "This meeting is
+ * being recorded" modal. Zoom is instead handled by checkAndDismissZoomModals(),
+ * which runs a single in-page pass that pierces open shadow roots, ignores
+ * Playwright visibility, and clicks with a full pointer/mouse/click sequence so
+ * the React handler always fires. Its trigger/acknowledge/never lists live inside
+ * that page.evaluate() (browser scope) rather than here.
  */
-const ZOOM_MODAL_PATTERNS: ModalPattern[] = [
-  // "This meeting is being recorded" consent modal — single OK button, no Leave.
-  // Left un-clicked it sits centered over the video for the whole recording and
-  // corrupts the MP4, so this is the primary reason the observer runs on Zoom.
-  {
-    name: "zoom_recording_consent",
-    // Anchor on a div (not a bare *:has-text) so it resolves to the modal
-    // container, not every html/body ancestor that also contains the text.
-    selector: 'div:has-text("This meeting is being recorded"):has(button)',
-    buttonTexts: ["OK", "Got it", "Continue"],
-    exitByEscape: false
-  },
-  // Generic consent/notification fallback — keep LAST.
-  {
-    name: "zoom_generic_dismiss",
-    selector: 'div:has-text("being recorded"):has(button), div:has-text("consent"):has(button)',
-    buttonTexts: ["OK", "Got it", "Continue", "Dismiss", "Close"],
-    exitByEscape: false
-  }
-]
 
 /**
  * Simplified dialog observer for auto-dismissing in-call modals.
@@ -268,14 +251,22 @@ export class SimpleDialogObserver {
   }
 
   /**
-   * Simplified modal detection using platform-keyed pattern sets.
-   * Meet and Zoom each supply their own ordered patterns (specific before
-   * generic); the detect/snapshot/dismiss loop below is shared.
+   * Simplified modal detection. Meet uses the Playwright locator + isVisible
+   * pattern loop below. Zoom takes an entirely different in-page path (see
+   * checkAndDismissZoomModals and the note above ZOOM patterns) because Zoom's
+   * web client defeats Playwright's visibility/actionability checks.
    */
   protected async checkAndDismissModals(
     page: Page,
     customTimeout = 0
   ): Promise<DialogObserverResult> {
+    const platform = GLOBAL.get().meeting_platform
+
+    // Zoom: robust in-page dismissal (shadow-piercing, no visibility gate).
+    if (platform === "zoom") {
+      return this.checkAndDismissZoomModals(page)
+    }
+
     const timeouts =
       customTimeout === 0
         ? TIMEOUTS
@@ -285,11 +276,9 @@ export class SimpleDialogObserver {
             PAGE_TIMEOUT: customTimeout
           }
 
-    const platform = GLOBAL.get().meeting_platform
     const detectionMethod = `simple_${platform}`
-    // Select the platform's ordered pattern set. Order matters within each set:
-    // more specific patterns must come before generic ones.
-    const modalPatterns = platform === "zoom" ? ZOOM_MODAL_PATTERNS : MEET_MODAL_PATTERNS
+    // Meet's ordered pattern set: more specific patterns before generic ones.
+    const modalPatterns = MEET_MODAL_PATTERNS
 
     try {
       for (const pattern of modalPatterns) {
@@ -357,6 +346,143 @@ export class SimpleDialogObserver {
         dismissed: false,
         modalType: "detection_error"
       }
+    }
+  }
+
+  /**
+   * Zoom-only in-page dialog dismissal.
+   *
+   * Runs ONE pass inside the page (page.evaluate) instead of via Playwright
+   * locators, because Zoom's web client makes Playwright report its own modals as
+   * not-visible / not-actionable (documented throughout zoom.ts) — which is why
+   * the locator/isVisible pattern loop never dismissed the "This meeting is being
+   * recorded" modal. The in-page pass:
+   *   1. Walks the light DOM AND all open shadow roots (Zoom nests UI in shadow DOM).
+   *   2. Considers only acknowledge buttons (OK / Got it / Continue / Dismiss / …)
+   *      and never destructive ones (Leave / End / Cancel / Decline / No).
+   *   3. Confirms the button belongs to a recording/consent modal (trigger text in
+   *      an ancestor, crossing shadow boundaries) OR sits inside a real dialog /
+   *      Zoom modal container — so a stray page button is never clicked.
+   *   4. Clicks with a full pointerdown→mousedown→mouseup→click→.click() sequence so
+   *      whichever event Zoom's React handler listens for fires.
+   * Safe by construction: it can only ever click an acknowledge button, so the
+   * worst case is a no-op — never a destructive or meeting-exiting action.
+   */
+  private async checkAndDismissZoomModals(page: Page): Promise<DialogObserverResult> {
+    const detectionMethod = "inpage_zoom"
+    try {
+      if (page.isClosed()) {
+        return { found: false, dismissed: false, modalType: null }
+      }
+
+      const dismissed = await page.evaluate<string | null>(() => {
+        const TRIGGER =
+          /being recorded|may view or share|is being recorded|is being transcribed|consent to/i
+        const ACK = /^(ok|okay|got it|continue|i understand|accept|agree|dismiss|close)$/i
+        const NEVER = /leave|end\b|cancel|decline|\bno\b|sign out|log out|don't|do not/i
+
+        // Collect every element across the light DOM and all OPEN shadow roots.
+        const nodes: Element[] = []
+        const walk = (root: Document | ShadowRoot) => {
+          for (const el of Array.from(root.querySelectorAll("*"))) {
+            nodes.push(el)
+            const sr = (el as HTMLElement).shadowRoot
+            if (sr) walk(sr)
+          }
+        }
+        walk(document)
+
+        const label = (el: Element) => (el.textContent || "").replace(/\s+/g, " ").trim()
+
+        // Hop up the ancestor chain, crossing shadow-root boundaries via host.
+        const parentAcross = (el: Element): Element | null => {
+          if (el.parentElement) return el.parentElement
+          const root = el.getRootNode()
+          return root instanceof ShadowRoot ? root.host : null
+        }
+
+        const clickHard = (btn: Element) => {
+          const opts: MouseEventInit = {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            view: window
+          }
+          try {
+            btn.dispatchEvent(new PointerEvent("pointerdown", opts))
+          } catch {}
+          btn.dispatchEvent(new MouseEvent("mousedown", opts))
+          try {
+            btn.dispatchEvent(new PointerEvent("pointerup", opts))
+          } catch {}
+          btn.dispatchEvent(new MouseEvent("mouseup", opts))
+          btn.dispatchEvent(new MouseEvent("click", opts))
+          ;(btn as HTMLElement).click?.()
+        }
+
+        const ackButtons = nodes.filter((el) => {
+          if (el.tagName !== "BUTTON" && el.getAttribute("role") !== "button") return false
+          const t = label(el)
+          return ACK.test(t) && !NEVER.test(t)
+        })
+
+        // Pass 1: acknowledge button tied to a recording/consent modal via ancestor text.
+        for (const btn of ackButtons) {
+          let node: Element | null = btn
+          let hops = 0
+          while (node && hops < 10) {
+            if (TRIGGER.test(node.textContent || "")) {
+              clickHard(btn)
+              return "zoom_recording_consent"
+            }
+            node = parentAcross(node)
+            hops++
+          }
+        }
+
+        // Pass 2: acknowledge button inside any real dialog / Zoom modal container.
+        const inDialog = (el: Element): boolean => {
+          let node: Element | null = el
+          let hops = 0
+          while (node && hops < 10) {
+            const role = node.getAttribute("role")
+            const cls = typeof node.className === "string" ? node.className : ""
+            if (
+              role === "dialog" ||
+              role === "alertdialog" ||
+              /zm-modal|zmu-modal|zm-dialog|ReactModal__Content/i.test(cls)
+            ) {
+              return true
+            }
+            node = parentAcross(node)
+            hops++
+          }
+          return false
+        }
+        for (const btn of ackButtons) {
+          if (inDialog(btn)) {
+            clickHard(btn)
+            return "zoom_generic_dialog"
+          }
+        }
+
+        return null
+      })
+
+      if (dismissed) {
+        console.info(`[SimpleDialogObserver] Zoom: dismissed ${dismissed} (in-page)`)
+        return { found: true, dismissed: true, modalType: dismissed, detectionMethod }
+      }
+      return { found: false, dismissed: false, modalType: null }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Target page, context or browser has been closed")
+      ) {
+        return { found: false, dismissed: false, modalType: null }
+      }
+      console.warn(`[SimpleDialogObserver] Zoom in-page dismissal error: ${error}`)
+      return { found: false, dismissed: false, modalType: "detection_error" }
     }
   }
 

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -111,7 +111,9 @@ const ZOOM_MODAL_PATTERNS: ModalPattern[] = [
   // corrupts the MP4, so this is the primary reason the observer runs on Zoom.
   {
     name: "zoom_recording_consent",
-    selector: ':has-text("This meeting is being recorded"):has(button)',
+    // Anchor on a div (not a bare *:has-text) so it resolves to the modal
+    // container, not every html/body ancestor that also contains the text.
+    selector: 'div:has-text("This meeting is being recorded"):has(button)',
     buttonTexts: ["OK", "Got it", "Continue"],
     exitByEscape: false
   },

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -16,9 +16,119 @@ const TIMEOUTS: DismissTimeouts = {
   PAGE_TIMEOUT: 2000
 }
 
+interface ModalPattern {
+  name: string
+  selector: string
+  buttonTexts: string[]
+  exitByEscape: boolean
+}
+
 /**
- * Simplified dialog observer specifically for Google Meet
- * Focuses on common Google Meet modal patterns
+ * Google Meet modal patterns.
+ * IMPORTANT: Order matters! More specific patterns must come before generic ones
+ * to avoid misidentification (e.g., transcription modal matching camera_permission).
+ */
+const MEET_MODAL_PATTERNS: ModalPattern[] = [
+  // People hover dialog (new UI Dec 2025) - dismiss with Escape
+  {
+    name: "people_hover_dialog",
+    selector: 'div[role="dialog"][aria-label*="people in the call" i]:has-text("People")',
+    buttonTexts: [], // No buttons to click, just dismiss with Escape
+    exitByEscape: true
+  },
+  // Recording/transcription modals - MUST come first (they may contain "camera"/"microphone" text)
+  {
+    name: "recording_notification",
+    selector: 'div[role="dialog"]:has-text("video call is being recorded"):has(button)',
+    buttonTexts: ["Join now"],
+    exitByEscape: false
+  },
+  {
+    name: "transcribe_notification",
+    selector: 'div[role="dialog"]:has-text("video call is being transcribed"):has(button)',
+    buttonTexts: ["Join now"],
+    exitByEscape: false
+  },
+  // Gemini/notes modal
+  {
+    name: "gemini_notification",
+    selector: 'div[role="dialog"]:has-text("Gemini"):has-text("taking notes"):has(button)',
+    buttonTexts: ["Join now"],
+    exitByEscape: false
+  },
+  // Privacy/notification modals
+  {
+    name: "privacy_notification",
+    selector: 'div[role="dialog"]:has-text("Others may see"):has(button)',
+    buttonTexts: ["Got it", "OK", "Dismiss", "Close"],
+    exitByEscape: false
+  },
+  // Video privacy modals
+  {
+    name: "video_privacy",
+    selector: 'div[role="dialog"]:has-text("video differently"):has(button)',
+    buttonTexts: ["Got it", "OK", "Continue"],
+    exitByEscape: false
+  },
+  // Background/feed modals
+  {
+    name: "background_feed",
+    selector:
+      'div[role="dialog"]:has-text("background"):has(button), div[role="dialog"]:has-text("feed"):has(button)',
+    buttonTexts: ["Got it", "OK", "Dismiss"],
+    exitByEscape: false
+  },
+  // Camera/microphone permission modals - after specific modals to avoid false positives
+  // These can be dismissed with Escape key if buttons are not found
+  {
+    name: "camera_permission",
+    selector:
+      'div[role="dialog"]:has-text("camera"):has(button), div[role="dialog"]:has-text("microphone"):has(button)',
+    buttonTexts: ["Allow", "Block", "Got it", "OK", "Join now"],
+    exitByEscape: true
+  },
+  // Generic dismiss modals (fallback)
+  {
+    name: "generic_dismiss",
+    selector: 'div[role="dialog"]:has(button)',
+    buttonTexts: ["Join now", "Got it", "OK", "Dismiss", "Close", "Continue"],
+    exitByEscape: false
+  }
+]
+
+/**
+ * Zoom (browser web-client) modal patterns.
+ * Zoom renders these modals inside its web-client shadow DOM, so page.content()
+ * won't serialize them and a bare class selector is brittle. Playwright's
+ * text/role locators DO pierce open shadow roots, so we anchor on visible TEXT
+ * and keep the button INSIDE the matched container so tryDismissModal finds it.
+ * We deliberately do NOT assume div[role="dialog"] — Zoom may not set that role.
+ * IMPORTANT: Order matters! Specific patterns before the generic fallback.
+ */
+const ZOOM_MODAL_PATTERNS: ModalPattern[] = [
+  // "This meeting is being recorded" consent modal — single OK button, no Leave.
+  // Left un-clicked it sits centered over the video for the whole recording and
+  // corrupts the MP4, so this is the primary reason the observer runs on Zoom.
+  {
+    name: "zoom_recording_consent",
+    selector: ':has-text("This meeting is being recorded"):has(button)',
+    buttonTexts: ["OK", "Got it", "Continue"],
+    exitByEscape: false
+  },
+  // Generic consent/notification fallback — keep LAST.
+  {
+    name: "zoom_generic_dismiss",
+    selector: 'div:has-text("being recorded"):has(button), div:has-text("consent"):has(button)',
+    buttonTexts: ["OK", "Got it", "Continue", "Dismiss", "Close"],
+    exitByEscape: false
+  }
+]
+
+/**
+ * Simplified dialog observer for auto-dismissing in-call modals.
+ * Handles Google Meet's notification/permission dialogs and Zoom's
+ * "This meeting is being recorded" consent modal via platform-keyed
+ * pattern sets sharing a single detect/dismiss code path.
  */
 export class SimpleDialogObserver {
   protected context: MeetingContext
@@ -79,10 +189,11 @@ export class SimpleDialogObserver {
   }
 
   setupGlobalDialogObserver() {
-    // Only start observer for Google Meet
-    if (GLOBAL.get().meeting_platform !== "meet") {
+    // Start observer for Google Meet and Zoom; no-op on other platforms.
+    const platform = GLOBAL.get().meeting_platform
+    if (platform !== "meet" && platform !== "zoom") {
       console.info(
-        `[SimpleDialogObserver] Observer not started: provider is not Google Meet (${GLOBAL.get().meeting_platform})`
+        `[SimpleDialogObserver] Observer not started: provider is not Meet or Zoom (${platform})`
       )
       return
     }
@@ -155,7 +266,9 @@ export class SimpleDialogObserver {
   }
 
   /**
-   * Simplified modal detection focusing on Google Meet's common patterns
+   * Simplified modal detection using platform-keyed pattern sets.
+   * Meet and Zoom each supply their own ordered patterns (specific before
+   * generic); the detect/snapshot/dismiss loop below is shared.
    */
   protected async checkAndDismissModals(
     page: Page,
@@ -170,78 +283,13 @@ export class SimpleDialogObserver {
             PAGE_TIMEOUT: customTimeout
           }
 
-    try {
-      // Google Meet specific modal patterns
-      // IMPORTANT: Order matters! More specific patterns must come before generic ones
-      // to avoid misidentification (e.g., transcription modal matching camera_permission)
-      const modalPatterns = [
-        // People hover dialog (new UI Dec 2025) - dismiss with Escape
-        {
-          name: "people_hover_dialog",
-          selector: 'div[role="dialog"][aria-label*="people in the call" i]:has-text("People")',
-          buttonTexts: [], // No buttons to click, just dismiss with Escape
-          exitByEscape: true
-        },
-        // Recording/transcription modals - MUST come first (they may contain "camera"/"microphone" text)
-        {
-          name: "recording_notification",
-          selector: 'div[role="dialog"]:has-text("video call is being recorded"):has(button)',
-          buttonTexts: ["Join now"],
-          exitByEscape: false
-        },
-        {
-          name: "transcribe_notification",
-          selector: 'div[role="dialog"]:has-text("video call is being transcribed"):has(button)',
-          buttonTexts: ["Join now"],
-          exitByEscape: false
-        },
-        // Gemini/notes modal
-        {
-          name: "gemini_notification",
-          selector: 'div[role="dialog"]:has-text("Gemini"):has-text("taking notes"):has(button)',
-          buttonTexts: ["Join now"],
-          exitByEscape: false
-        },
-        // Privacy/notification modals
-        {
-          name: "privacy_notification",
-          selector: 'div[role="dialog"]:has-text("Others may see"):has(button)',
-          buttonTexts: ["Got it", "OK", "Dismiss", "Close"],
-          exitByEscape: false
-        },
-        // Video privacy modals
-        {
-          name: "video_privacy",
-          selector: 'div[role="dialog"]:has-text("video differently"):has(button)',
-          buttonTexts: ["Got it", "OK", "Continue"],
-          exitByEscape: false
-        },
-        // Background/feed modals
-        {
-          name: "background_feed",
-          selector:
-            'div[role="dialog"]:has-text("background"):has(button), div[role="dialog"]:has-text("feed"):has(button)',
-          buttonTexts: ["Got it", "OK", "Dismiss"],
-          exitByEscape: false
-        },
-        // Camera/microphone permission modals - after specific modals to avoid false positives
-        // These can be dismissed with Escape key if buttons are not found
-        {
-          name: "camera_permission",
-          selector:
-            'div[role="dialog"]:has-text("camera"):has(button), div[role="dialog"]:has-text("microphone"):has(button)',
-          buttonTexts: ["Allow", "Block", "Got it", "OK", "Join now"],
-          exitByEscape: true
-        },
-        // Generic dismiss modals (fallback)
-        {
-          name: "generic_dismiss",
-          selector: 'div[role="dialog"]:has(button)',
-          buttonTexts: ["Join now", "Got it", "OK", "Dismiss", "Close", "Continue"],
-          exitByEscape: false
-        }
-      ]
+    const platform = GLOBAL.get().meeting_platform
+    const detectionMethod = `simple_${platform}`
+    // Select the platform's ordered pattern set. Order matters within each set:
+    // more specific patterns must come before generic ones.
+    const modalPatterns = platform === "zoom" ? ZOOM_MODAL_PATTERNS : MEET_MODAL_PATTERNS
 
+    try {
       for (const pattern of modalPatterns) {
         try {
           const modal = page.locator(pattern.selector)
@@ -279,7 +327,7 @@ export class SimpleDialogObserver {
               found: true,
               dismissed: true,
               modalType: pattern.name,
-              detectionMethod: "simple_google_meet"
+              detectionMethod
             }
           }
 
@@ -287,7 +335,7 @@ export class SimpleDialogObserver {
             found: true,
             dismissed: false,
             modalType: pattern.name,
-            detectionMethod: "simple_google_meet"
+            detectionMethod
           }
         } catch (error) {
           console.warn(`[SimpleDialogObserver] Error with pattern ${pattern.name}: ${error}`)

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -221,6 +221,18 @@ class Global {
   }
 
   /**
+   * Release a claim taken by claimRecovery() when the requeueToSQS() it guarded
+   * FAILED to send. Without this, a failed send leaves recoveryClaimed=true, so
+   * every other requeue path (SIGTERM / crash handler) sees isRecoveryClaimed()
+   * and stands down — and the meeting is never requeued (silently lost). Callers
+   * MUST release ONLY on send failure, and ONLY the caller that won the claim, so
+   * another path can take over the requeue. Never release after a successful send.
+   */
+  public releaseRecovery(): void {
+    this.recoveryClaimed = false
+  }
+
+  /**
    * Read-only peek at whether a recovery path already owns the claim. Terminator
    * handlers (SIGTERM / crash) use it only to STAND DOWN — return without calling
    * exit(), so they don't kill an in-flight requeue mid-write. They must NOT use it

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -185,14 +185,20 @@ class Global {
   }
 
   /**
-   * Single, atomic recovery-ownership claim shared by EVERY termination path
-   * (SIGTERM handler, normal completion/failure requeue, and the Logger crash
-   * handler). The first caller wins and receives `true`; every subsequent caller
-   * receives `false`. Callers that lose the claim must NOT perform log-upload +
-   * requeue work — this is what prevents concurrent paths (e.g. SIGTERM racing a
-   * crash, or a crash racing normal shutdown) from each requeuing the same
-   * meeting and re-recording it. Node's single-threaded run-to-completion model
-   * makes the check-and-set atomic with respect to other callers.
+   * Single, atomic recovery-ownership claim shared by the requeue sites (the
+   * primary failure-retry in handleFailedRecording, the SIGTERM handler's requeue
+   * branch, and the Logger crash handler's requeue branch). The first caller wins
+   * and receives `true`; every subsequent caller receives `false`.
+   *
+   * INVARIANT (see the #224 regression note in main.ts): this token is taken ONLY
+   * immediately before an actual requeueToSQS() — never up front by a handler that
+   * might then take a non-requeuing branch. Because of that, a caller that loses
+   * the claim can safely conclude the meeting has ALREADY been requeued by another
+   * path and skip its own requeue. Taking the claim without requeuing would starve
+   * the primary retry (which is exactly the #224 bug this rule fixes).
+   *
+   * Node's single-threaded run-to-completion model makes the check-and-set atomic
+   * with respect to other callers.
    */
   public claimRecovery(): boolean {
     if (this.recoveryClaimed) {
@@ -200,6 +206,17 @@ class Global {
     }
     this.recoveryClaimed = true
     return true
+  }
+
+  /**
+   * Read-only peek at whether a recovery path already owns the claim. Terminator
+   * handlers (SIGTERM / crash) use it only to STAND DOWN — return without calling
+   * exit(), so they don't kill an in-flight requeue mid-write. They must NOT use it
+   * to gate a requeue: only claimRecovery(), taken immediately before the requeue,
+   * may do that.
+   */
+  public isRecoveryClaimed(): boolean {
+    return this.recoveryClaimed
   }
 
   // Phase marker: true once the recording has been MERGED into its final output

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -166,6 +166,18 @@ class Global {
     this.errorMessage = null
   }
 
+  /**
+   * Fully wipe the transient error / end-reason / retry flags so a bounded
+   * in-process join retry (fresh proxy IP, same pod) starts clean and a
+   * subsequent admission isn't treated as a failed run. Only call BETWEEN
+   * in-process attempts — never after a terminal decision.
+   */
+  public resetErrorState(): void {
+    this.endReason = null
+    this.errorMessage = null
+    this.shouldRetry = false
+  }
+
   public clearMeetSsoConfig(): void {
     if (this.meetingParams) {
       this.meetingParams.meet_sso_config = null

--- a/src/state-machine/states/error-state.ts
+++ b/src/state-machine/states/error-state.ts
@@ -1,3 +1,4 @@
+import { getMaxRetryCount } from "../../config/retry-config"
 import { Events } from "../../events"
 import { HtmlSnapshotService } from "../../services/html-snapshot-service"
 import { GLOBAL } from "../../singleton"
@@ -70,6 +71,26 @@ export class ErrorState extends BaseState {
         reason: endReason,
         message: errorMessage
       })
+
+      // If a retry is pending, the requeue path (handleFailedRecording) will emit
+      // the non-terminal `retrying` status. Suppress the terminal error webhooks
+      // here so the customer doesn't receive a scary meeting_error/bot_rejected
+      // between attempts (observed live on bot 4d2c5040: meeting_error then
+      // retrying 5s later, then recovery). This mirrors handleFailedRecording's
+      // decision EXACTLY — same shouldRetry flag, same Zoom-anti-bot-wall retryable
+      // rule, same retry-count cap — so the two paths always agree on whether a
+      // terminal event should fire. ErrorState runs BEFORE handleFailedRecording,
+      // so the wall's late setShouldRetry(true) is OR'd in explicitly here.
+      const retryPending =
+        (GLOBAL.getShouldRetry() ||
+          endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) &&
+        GLOBAL.getRetryCount() < getMaxRetryCount()
+      if (retryPending) {
+        console.log(
+          `[ErrorState] Retry pending (reason: ${endReason}, attempt ${GLOBAL.getRetryCount()}/${getMaxRetryCount()}) — suppressing terminal error webhook; retrying status will be emitted on requeue`
+        )
+        return
+      }
 
       try {
         switch (endReason) {

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs"
 import path from "node:path"
-import type { BrowserContext } from "@playwright/test"
 import {
   deferBrandingPlayback,
   generateBranding,
@@ -8,9 +7,7 @@ import {
   startBrandingAutoLoop,
   warmUpCamera
 } from "../../branding"
-import { openBrowser } from "../../browser/browser"
-import { startToggleProxy } from "../../proxy/toggle-proxy"
-import { MAX_RETRY_COUNT } from "../../utils/retry-handler"
+import { establishBrowserSession } from "../../browser/browser-session"
 import { GLOBAL } from "../../singleton"
 import { formatError } from "../../utils/Logger"
 import { PathManager } from "../../utils/PathManager"
@@ -75,79 +72,9 @@ export class InitializationState extends BaseState {
   }
 
   private async setupBrowser(): Promise<void> {
-    const maxRetries = 3
-    let lastError: Error | null = null
-
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        console.info(`Browser setup attempt ${attempt}/${maxRetries}`)
-
-        // Définir le type de retour attendu de openBrowser
-        type BrowserResult = {
-          browser: BrowserContext
-        }
-
-        // Augmenter le timeout pour les environnements plus lents
-        const timeoutMs = 60000 // 60 secondes au lieu de 30
-
-        // Create a promise that rejects after a delay
-        const timeoutPromise = new Promise<BrowserResult>((_, reject) => {
-          const id = setTimeout(() => {
-            clearTimeout(id)
-            reject(new Error(`Browser setup timeout (${timeoutMs}ms)`))
-          }, timeoutMs)
-        })
-
-        // Execute the promise to open the browser with a timeout
-        // Start toggle proxy for residential IP routing during join phase (Meet + Zoom).
-        // Pass bot_uuid so the per-bot sticky session label is unique — different
-        // bots land on different residential IPs, same bot keeps one IP throughout
-        // the join. Zoom is included to test whether residential egress moves the
-        // browser-join anti-bot / RTMS wall.
-        const platform = GLOBAL.get().meeting_platform
-        if (!this.context.proxyUrl && (platform === "meet" || platform === "zoom")) {
-          const retryCount = GLOBAL.getRetryCount()
-          // Meet's "last retry runs without proxy" fallback does NOT apply to
-          // Zoom: the browser-join wall blocks datacenter/pod IPs outright, so
-          // every Zoom attempt (including the final retry) must egress through
-          // the proxy. Zoom's retry value comes from cycling to a fresh exit IP,
-          // not from dropping the proxy.
-          if (platform === "meet" && retryCount >= MAX_RETRY_COUNT) {
-            console.log("[InitializationState] Last retry attempt — running without proxy")
-          } else {
-            const proxyUrl = await startToggleProxy(GLOBAL.get().bot_uuid, retryCount)
-            if (proxyUrl) {
-              this.context.proxyUrl = proxyUrl
-            }
-          }
-        }
-
-        const result = await Promise.race<BrowserResult>([
-          openBrowser(this.context.proxyUrl),
-          timeoutPromise
-        ])
-
-        // If we get here, openBrowser has succeeded
-        this.context.browserContext = result.browser
-
-        console.info("Browser setup completed successfully")
-        return // Exit the function if successful
-      } catch (error) {
-        lastError = error as Error
-        console.error(`Browser setup attempt ${attempt} failed:`, formatError(error))
-
-        // Si ce n'est pas la dernière tentative, attendre avant de réessayer
-        if (attempt < maxRetries) {
-          const waitTime = attempt * 5000 // Attente progressive: 5s, 10s, 15s...
-          console.info(`Waiting ${waitTime}ms before retry...`)
-          await new Promise((resolve) => setTimeout(resolve, waitTime))
-        }
-      }
-    }
-
-    // Si on arrive ici, c'est que toutes les tentatives ont échoué
-    console.error("All browser setup attempts failed:", lastError ? formatError(lastError) : {})
-    throw lastError || new Error("Browser setup failed after multiple attempts")
+    // Proxy start + browser launch (with retries) live in the shared
+    // browser-session helper so the in-process fast-retry uses the same path.
+    await establishBrowserSession(this.context)
   }
 
   private async setupPathManager(): Promise<void> {

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -174,7 +174,8 @@ export class WaitingRoomState extends BaseState {
           // Branding switch (warmup placeholder → real image) — idempotent trigger.
           notifyJoinReady()
           // Dialog observer polls context.playwrightPage live, so wiring it once
-          // picks up the relaunched page automatically (Meet-only; no-op on Zoom).
+          // picks up the relaunched page automatically (runs on Meet + Zoom;
+          // no-op on other platforms).
           this.startDialogObserver()
           // Waiting-room webhook — fire once, not per relaunch.
           Events.inWaitingRoom()

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -1,5 +1,10 @@
 import { dehumanize } from "../../utils/dehumanize"
 import { notifyJoinReady } from "../../branding"
+import {
+  establishBrowserSession,
+  teardownBrowserSession
+} from "../../browser/browser-session"
+import { envVars } from "../../config/env-vars"
 import { Events } from "../../events"
 import { setDirectMode } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
@@ -85,43 +90,10 @@ export class WaitingRoomState extends BaseState {
         }
       }
 
-      // Open the meeting page
-      await this.openMeetingPage(meetingLink)
-
-      // Start Pulse → output WebSocket capture only when output streaming is enabled.
-      // Input-only bots still need Streaming (for input WebSocket) but must not run FFmpeg capture.
-      if (this.context.streamingService && GLOBAL.get().streaming_output) {
-        this.context.streamingService.startAudioCapture()
-      }
-
-      // Signal that the meeting page is open and the platform has confirmed
-      // the camera works. If multi-image branding was deferred, this triggers
-      // the switch from warmup placeholder to real branding.
-      notifyJoinReady()
-
-      // Start the dialog observer immediately after page is opened
-      // This ensures it can start monitoring dialogs right away
-      this.startDialogObserver()
-
-      // Capture DOM state after meeting page is opened (void to avoid blocking)
-      if (this.context.playwrightPage) {
-        const htmlSnapshot = HtmlSnapshotService.getInstance()
-        void htmlSnapshot.captureSnapshot(this.context.playwrightPage, "waiting_room_page_opened")
-      }
-
-      // Capture DOM state after meeting page is opened (void to avoid blocking)
-      if (this.context.playwrightPage) {
-        const htmlSnapshot = HtmlSnapshotService.getInstance()
-        void htmlSnapshot.captureSnapshot(this.context.playwrightPage, "waiting_room_page_opened")
-      }
-
-      ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
-
-      // Send waiting room event after the page is open
-      Events.inWaitingRoom()
-
-      // Wait for acceptance into the meeting
-      await this.waitForAcceptance()
+      // Open the page and wait for admission, with bounded in-process retries on
+      // Zoom's IP-keyed anti-bot wall (relaunch on a fresh exit IP in this warm
+      // pod before the SQS requeue). Non-Zoom platforms run exactly one attempt.
+      await this.joinWithInProcessRetry(meetingLink)
       console.info("Successfully joined meeting")
 
       // If everything is fine, move to the InCall state
@@ -172,6 +144,75 @@ export class WaitingRoomState extends BaseState {
       }
 
       return this.handleError(error as Error)
+    }
+  }
+
+  /**
+   * Open the meeting page and wait for admission. On Zoom's IP-keyed anti-bot
+   * wall (zoomAnonymousJoinNotAllowed) — and only that reason — relaunch the
+   * browser on a fresh residential exit IP in THIS pod, up to
+   * IN_PROCESS_RETRY_MAX times, before letting the failure propagate to the SQS
+   * requeue (a genuinely fresh pod). Xvfb/PulseAudio/screen-recorder scaffolding
+   * stays up across attempts; only the browser context + proxy session recycle.
+   * The one-time, device/display-level side effects (audio capture, branding
+   * switch, dialog observer, waiting-room webhook) run only on the first attempt.
+   */
+  private async joinWithInProcessRetry(meetingLink: string): Promise<void> {
+    const isZoom = GLOBAL.get().meeting_platform === "zoom"
+    const maxInProc = isZoom ? envVars.IN_PROCESS_RETRY_MAX : 0
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.openMeetingPage(meetingLink)
+
+        if (attempt === 0) {
+          // Pulse → output WebSocket capture (output streaming only). Device-level
+          // and self-guarded, so it survives a browser relaunch — start it once.
+          if (this.context.streamingService && GLOBAL.get().streaming_output) {
+            this.context.streamingService.startAudioCapture()
+          }
+          // Branding switch (warmup placeholder → real image) — idempotent trigger.
+          notifyJoinReady()
+          // Dialog observer polls context.playwrightPage live, so wiring it once
+          // picks up the relaunched page automatically (Meet-only; no-op on Zoom).
+          this.startDialogObserver()
+          // Waiting-room webhook — fire once, not per relaunch.
+          Events.inWaitingRoom()
+        }
+
+        if (this.context.playwrightPage) {
+          void HtmlSnapshotService.getInstance().captureSnapshot(
+            this.context.playwrightPage,
+            "waiting_room_page_opened"
+          )
+        }
+
+        // x11grab captures the display, self-guards on isRecording (no-op after
+        // the first attempt), so the recording spans the relaunch seamlessly.
+        ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
+
+        await this.waitForAcceptance()
+        return
+      } catch (error) {
+        const reason = GLOBAL.getEndReason()
+        // Only the IP-reputation wall is worth an in-process relaunch; every other
+        // reason (invalid URL, host denial, passcode, timeout) is not IP-keyed and
+        // must fall through to the outer catch → SQS requeue / terminal failure.
+        const canInProcessRetry =
+          attempt < maxInProc && reason === MeetingEndReason.ZoomAnonymousJoinNotAllowed
+        if (!canInProcessRetry) throw error
+
+        console.log(
+          `[Zoom] Anti-bot wall (${reason}) — in-process retry ${attempt + 1}/${maxInProc} on a fresh exit IP`
+        )
+        // Wipe the wall's error/end-reason/retry flags so the cleared attempt
+        // doesn't leak into the next join or the final wasRecordingSuccessful check.
+        GLOBAL.resetErrorState()
+        // Recycle browser + proxy onto a new Decodo session id (suffix "x<n>") →
+        // a different residential exit IP for the next launch.
+        await teardownBrowserSession(this.context)
+        await establishBrowserSession(this.context, { sessionSuffix: `x${attempt + 1}` })
+      }
     }
   }
 

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -188,9 +188,15 @@ export class WaitingRoomState extends BaseState {
           )
         }
 
-        // x11grab captures the display, self-guards on isRecording (no-op after
-        // the first attempt), so the recording spans the relaunch seamlessly.
-        ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
+        // Start the display recording once, on the first attempt only. x11grab
+        // captures the Xvfb display (not the page), so it spans in-process browser
+        // relaunches. Calling it again on a retry throws "Recording is already in
+        // progress" — an un-awaited, uncaught rejection that crashed the pod and
+        // forced a futile SQS requeue (defeating the fast in-pod retry). Gated here
+        // like the other one-time setup; startRecording is also idempotent now.
+        if (attempt === 0) {
+          ScreenRecorderManager.getInstance().startRecording(this.context.playwrightPage)
+        }
 
         await this.waitForAcceptance()
         return

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -4,7 +4,7 @@ import {
   establishBrowserSession,
   teardownBrowserSession
 } from "../../browser/browser-session"
-import { envVars } from "../../config/env-vars"
+import { IN_PROCESS_RETRY_MAX } from "../../config/retry-config"
 import { Events } from "../../events"
 import { setDirectMode } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
@@ -159,7 +159,7 @@ export class WaitingRoomState extends BaseState {
    */
   private async joinWithInProcessRetry(meetingLink: string): Promise<void> {
     const isZoom = GLOBAL.get().meeting_platform === "zoom"
-    const maxInProc = isZoom ? envVars.IN_PROCESS_RETRY_MAX : 0
+    const maxInProc = isZoom ? IN_PROCESS_RETRY_MAX : 0
 
     for (let attempt = 0; ; attempt++) {
       try {

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -451,6 +451,16 @@ export function setupExitHandler() {
               GLOBAL.releaseRecovery()
               throw e
             }
+            // Requeue succeeded — surface the non-terminal `retrying` status so the
+            // dashboard shows "Retrying" for crash-path requeues too, not only the
+            // graceful handleFailedRecording path. Best-effort; a failed emit must
+            // NOT release the (successful) recovery claim, so isolate it.
+            try {
+              const { Events } = await import("../events")
+              await Events.retrying(GLOBAL.getRetryCount() + 1, getMaxRetryCount())
+            } catch (evErr) {
+              logger.error(`[Crash] retrying status emit failed (non-fatal): ${evErr}`)
+            }
           } else {
             logger.error("[Crash] Recovery claimed concurrently — skipping duplicate requeue")
           }

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -443,8 +443,14 @@ export function setupExitHandler() {
           // Claim immediately before requeuing; if a concurrent path grabbed it
           // first it has already requeued — skip to avoid a double re-record.
           if (GLOBAL.claimRecovery()) {
-            await requeueToSQS(buildRetryMessage())
-            logger.error("[Crash] Early crash — requeued to SQS for retry")
+            try {
+              await requeueToSQS(buildRetryMessage())
+              logger.error("[Crash] Early crash — requeued to SQS for retry")
+            } catch (e) {
+              // Send failed — release so another path can requeue (see releaseRecovery).
+              GLOBAL.releaseRecovery()
+              throw e
+            }
           } else {
             logger.error("[Crash] Recovery claimed concurrently — skipping duplicate requeue")
           }

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -430,7 +430,8 @@ export function setupExitHandler() {
           "[Crash] Recording finalized/uploading — preserving artifacts for salvage (NOT requeuing)"
         )
       } else {
-        const { buildRetryMessage, requeueToSQS, getMaxRetryCount } = await import("./retry-handler")
+        const { buildRetryMessage, requeueToSQS } = await import("./retry-handler")
+        const { getMaxRetryCount } = await import("../config/retry-config")
         GLOBAL.setShouldRetry(true)
         if (GLOBAL.getRetryCount() < getMaxRetryCount()) {
           await requeueToSQS(buildRetryMessage())

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -406,9 +406,15 @@ export function setupExitHandler() {
     if (serverless) {
       process.exit(1)
     }
-    if (!GLOBAL.claimRecovery()) {
+    // #224 regression fix: do NOT claim recovery up front. When this crash handler
+    // hit the finalized/preserve branch below it used to grab the shared token
+    // without requeuing, starving the primary failure-retry in
+    // handleFailedRecording(). Instead, stand down WITHOUT exiting if a
+    // requeue-performing path already owns recovery (so we don't kill its in-flight
+    // requeue), and otherwise claim atomically only right before our own requeue.
+    if (GLOBAL.isRecoveryClaimed()) {
       logger.error(
-        "[Crash] Recovery already owned by another handler — standing down (owner will exit)"
+        "[Crash] Recovery already owned by a requeuing handler — standing down (owner will exit)"
       )
       return
     }
@@ -433,8 +439,14 @@ export function setupExitHandler() {
         const { buildRetryMessage, requeueToSQS, getMaxRetryCount } = await import("./retry-handler")
         GLOBAL.setShouldRetry(true)
         if (GLOBAL.getRetryCount() < getMaxRetryCount()) {
-          await requeueToSQS(buildRetryMessage())
-          logger.error("[Crash] Early crash — requeued to SQS for retry")
+          // Claim immediately before requeuing; if a concurrent path grabbed it
+          // first it has already requeued — skip to avoid a double re-record.
+          if (GLOBAL.claimRecovery()) {
+            await requeueToSQS(buildRetryMessage())
+            logger.error("[Crash] Early crash — requeued to SQS for retry")
+          } else {
+            logger.error("[Crash] Recovery claimed concurrently — skipping duplicate requeue")
+          }
         } else {
           logger.error("[Crash] Max retries reached — not requeuing")
         }

--- a/src/utils/dehumanize.ts
+++ b/src/utils/dehumanize.ts
@@ -86,15 +86,30 @@ export function dehumanize(page: Page): void {
 
   // Frame-level methods — patchFrames patches as own properties marked with
   // _humanPatched. Deleting them exposes the Playwright prototype originals.
-  for (const frame of page.frames()) {
-    const f = frame as unknown as Record<string, unknown>
-    if (!f._humanPatched) continue
-    for (const method of HUMANIZED_METHODS) {
-      if (Object.prototype.hasOwnProperty.call(f, method)) {
-        delete f[method]
+  //
+  // Guard the page: during an in-process retry (browser relaunched on a fresh
+  // exit IP) the page/context can be torn down while this runs. page.frames()
+  // then reads childFrames off an undefined mainFrame → an unhandled TypeError
+  // that trips the crash handler and wastes a whole SQS attempt. A closed page
+  // has nothing left to un-patch, so skip it.
+  if (page.isClosed()) {
+    console.log("[Humanize] Page already closed — skipping frame dehumanize")
+    return
+  }
+  try {
+    for (const frame of page.frames()) {
+      const f = frame as unknown as Record<string, unknown>
+      if (!f._humanPatched) continue
+      for (const method of HUMANIZED_METHODS) {
+        if (Object.prototype.hasOwnProperty.call(f, method)) {
+          delete f[method]
+        }
       }
+      delete f._humanPatched
     }
-    delete f._humanPatched
+  } catch (e) {
+    console.warn(`[Humanize] Frame dehumanize skipped (page torn down): ${e}`)
+    return
   }
 
   console.log("[Humanize] ✅ Dehumanized — native Playwright methods restored (page + frames)")

--- a/src/utils/retry-handler.ts
+++ b/src/utils/retry-handler.ts
@@ -1,25 +1,7 @@
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs"
+import { getMaxRetryCount } from "../config/retry-config"
 import { GLOBAL } from "../singleton"
 import type { MeetingParams } from "../types"
-
-export const MAX_RETRY_COUNT = 2
-// Zoom web joins are probabilistic — the anti-bot / RTMS wall keys on the exit
-// IP's reputation, so each retry cycles onto a fresh residential IP. Give Zoom
-// more attempts than the default before giving up.
-export const ZOOM_WEB_MAX_RETRY_COUNT = 5
-
-/**
- * Max SQS retries for the current bot: higher for Zoom (web) so it can cycle
- * exit IPs past the anti-bot wall. Guarded so a crash before params are set
- * (GLOBAL unset) falls back to the default instead of throwing.
- */
-export function getMaxRetryCount(): number {
-  try {
-    return GLOBAL.get().meeting_platform === "zoom" ? ZOOM_WEB_MAX_RETRY_COUNT : MAX_RETRY_COUNT
-  } catch {
-    return MAX_RETRY_COUNT
-  }
-}
 
 /**
  * Creates SQS client with same credential logic as smart-rabbit


### PR DESCRIPTION
Consolidated branch stacking every recorder fix from this line of work, in dependency order, on top of `v2-improvements`. Currently deployed to preprod (bundle `d3cb65f`) minus the last commit; the submodule bump for prod/preprod is [meeting-baas-v2#277](https://github.com/Meeting-BaaS/meeting-baas-v2/pull/277).

## Fixes included

1. **[#225](https://github.com/Meeting-BaaS/meet-teams-bot/pull/225) — retry-not-starved** *(prod regression)*
   The recovery-claim token was grabbed by non-requeuing handlers and starved the primary SQS requeue → Zoom bots failed at attempt 1 instead of retrying the anti-bot wall. Claim only at the requeue sites, so bots cycle onto fresh exit IPs again.

2. **[#227](https://github.com/Meeting-BaaS/meet-teams-bot/pull/227) — in-process fast retry**
   On the anti-bot wall, relaunch the browser on a fresh exit IP in the **same pod** before falling back to an SQS requeue (~5–10s vs ~20–40s). Includes the launch-timeout timer-leak fix (clear the timer when the open/timeout race settles).

3. **[#229](https://github.com/Meeting-BaaS/meet-teams-bot/pull/229) — consolidate retry counts** *(stacks on #227)*
   All retry-count constants into one `config/retry-config.ts` single source of truth (`MAX_RETRY_COUNT`, `ZOOM_WEB_MAX_RETRY_COUNT`, `IN_PROCESS_RETRY_MAX`, `getMaxRetryCount()`).

4. **[#226](https://github.com/Meeting-BaaS/meet-teams-bot/pull/226) — strip brand names** *(stacks on #225)*
   Remove competitor/own brand names from the log-only bot-name hint regex; trim comments.

5. **[#228](https://github.com/Meeting-BaaS/meet-teams-bot/pull/228) — non-terminal `retrying` status**
   Emit a non-terminal `retrying` status on requeue (observable, bounded-retry delivery via `sendReliable`) instead of flashing `recording_failed` between attempts. A failed delivery only warns — never downgrades to `recording_failed`.

6. **ffmpeg stdin EPIPE guard** *(latest — this branch's head)*
   On teardown ffmpeg is SIGTERM'd and closes stdin while buffered frames/audio flush; the unhandled EPIPE became an `uncaughtException` that crashed the process **before** the end-meeting trampoline ran → media in S3 but the record orphaned at `recording_succeeded` (`mp4/duration null`). Attach an `error` handler to both ffmpeg stdin writers (video feeder + audio `play_stdin`) so finalization completes. Caught live on preprod bot `dff50afe`.

## Net effect
Zoom browser bots retry the anti-bot wall correctly (fast in-pod IP cycling, then SQS), surface `retrying` instead of a scary `recording_failed`, and — with the EPIPE guard — actually finalize their record after a successful recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)