### PR TITLE
fix(teardown): harden finalize window against orphaning crashes

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -111,15 +111,36 @@ export class Api {
       return
     }
 
-    try {
-      await this.endMeetingTrampoline()
-      console.log("API call to endMeetingTrampoline succeeded")
-    } catch (error) {
-      console.warn(
-        "API call to endMeetingTrampoline failed (continuing execution):",
-        error instanceof Error ? error.message : error
-      )
-      // Don't throw - continue execution even if API call fails
+    // The trampoline is NOT idempotent server-side (it kicks off transcription
+    // submission), so exactly one path may report it: the happy path or the
+    // crash handler's finalized branch. Loser of the claim stands down.
+    if (!GLOBAL.claimEndMeetingReport()) {
+      console.log("endMeetingTrampoline already reported (or in flight) — skipping duplicate")
+      return
     }
+
+    // A failed trampoline orphans the bot at recording_succeeded (the api-server
+    // never learns artifacts/duration and never starts transcription), so retry
+    // transient failures before giving up.
+    const delaysMs = [0, 2000, 6000]
+    for (let attempt = 1; attempt <= delaysMs.length; attempt++) {
+      try {
+        if (delaysMs[attempt - 1] > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delaysMs[attempt - 1]))
+        }
+        await this.endMeetingTrampoline()
+        console.log(`API call to endMeetingTrampoline succeeded (attempt ${attempt})`)
+        return
+      } catch (error) {
+        console.warn(
+          `API call to endMeetingTrampoline failed (attempt ${attempt}/${delaysMs.length}):`,
+          error instanceof Error ? error.message : error
+        )
+      }
+    }
+    // All attempts failed — release the claim so a later path (e.g. the crash
+    // handler) can still try, and continue execution rather than throwing.
+    GLOBAL.releaseEndMeetingReport()
+    console.warn("endMeetingTrampoline exhausted all attempts (continuing execution)")
   }
 }

--- a/src/media_context.ts
+++ b/src/media_context.ts
@@ -53,6 +53,12 @@ abstract class MediaContext {
 
     this.process.stdout.addListener("data", stdoutListener)
     this.process.stderr.addListener("data", stderrListener)
+    // Generic stdin guard for every MediaContext spawn (one-shot play() paths
+    // included): without an "error" listener, a teardown-time EPIPE on the pipe
+    // escalates to an uncaughtException that kills finalization.
+    this.process.stdin?.on("error", (err) => {
+      console.warn(`[MediaContext] ffmpeg stdin error (ignored during teardown): ${err}`)
+    })
 
     this.promise = new Promise((resolve, reject) => {
       this.process.on("exit", (code) => {
@@ -74,6 +80,11 @@ abstract class MediaContext {
         reject(err)
       })
     })
+    // Nobody awaits this.promise until stop_process(), so a spawn/process
+    // "error" before then would surface as an unhandledRejection and trip the
+    // crash handler. Mark it handled here; stop_process() still observes the
+    // rejection through its own .catch().
+    this.promise.catch(() => {})
     return this.process
   }
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -177,6 +177,12 @@ export class ScreenRecorder extends EventEmitter {
         stdio: ["pipe", "pipe", "pipe"]
       })
 
+      // stdin is piped but unused; guard it so a stray EPIPE at kill time can't
+      // escalate to an uncaughtException mid-finalization (see media_context.ts).
+      this.ffmpegProcess.stdin?.on("error", (err) => {
+        console.warn(`[ScreenRecorder] ffmpeg stdin error (ignored): ${err}`)
+      })
+
       this.isRecording = true
       this.recordingStartTime = Date.now()
       this.gracePeriodActive = false
@@ -275,6 +281,9 @@ export class ScreenRecorder extends EventEmitter {
 
         const exitCode = await new Promise<number>((resolve) => {
           checkProcess.on("close", resolve)
+          // Without an "error" listener a spawn failure (e.g. ENOENT) is an
+          // uncaughtException AND "close" never fires, hanging this await.
+          checkProcess.on("error", () => resolve(-1))
         })
 
         if (exitCode === 0 && output.includes(VIRTUAL_SPEAKER_MONITOR)) {
@@ -312,6 +321,8 @@ export class ScreenRecorder extends EventEmitter {
 
       const testExitCode = await new Promise<number>((resolve) => {
         testProcess.on("close", resolve)
+        // Same spawn-failure guard as checkProcess above.
+        testProcess.on("error", () => resolve(-1))
       })
 
       if (testExitCode === 0) {

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -9,6 +9,7 @@ class Global {
   private errorMessage: string | null = null
   private shouldRetry = false // NEW: Retry flag
   private recoveryClaimed = false // True once a termination/crash path has taken ownership of log-upload + requeue (see claimRecovery)
+  private endMeetingReportClaimed = false // True while/after a path owns the end-meeting-trampoline report (see claimEndMeetingReport)
   private recordingFinalized = false // True once the recording is merged and entering upload (see markRecordingFinalized)
   private artifactKeys: ArtifactKey[] = []
   private audioChunks: ArtifactKey[] = []
@@ -241,6 +242,29 @@ class Global {
    */
   public isRecoveryClaimed(): boolean {
     return this.recoveryClaimed
+  }
+
+  /**
+   * Atomic ownership claim for the end-meeting-trampoline report, shared by the
+   * happy path (handleSuccessfulRecording → handleEndMeetingWithRetry) and the
+   * crash handler's finalized branch (Logger handleCrash). The first caller wins;
+   * a loser can safely conclude another path is reporting (or already reported)
+   * and skip — a double POST would double-submit transcription server-side.
+   *
+   * Same claim/release discipline as claimRecovery(): release ONLY when every
+   * attempt to send the report failed, so a later path (e.g. the crash handler
+   * after the happy path crashed mid-flight) can take over.
+   */
+  public claimEndMeetingReport(): boolean {
+    if (this.endMeetingReportClaimed) {
+      return false
+    }
+    this.endMeetingReportClaimed = true
+    return true
+  }
+
+  public releaseEndMeetingReport(): void {
+    this.endMeetingReportClaimed = false
   }
 
   // Phase marker: true once the recording has been MERGED into its final output

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -162,6 +162,12 @@ export class Streaming {
       stdio: ["pipe", "pipe", "pipe"]
     })
 
+    // stdin is piped but unused; still guard it so a stray EPIPE on teardown
+    // can't escalate to an uncaughtException (see media_context.ts).
+    this.ffmpegProcess.stdin?.on("error", (err) => {
+      console.warn(`[Streaming] ffmpeg stdin error (ignored): ${err}`)
+    })
+
     this.ffmpegProcess.stderr?.on("data", (data: Buffer) => {
       const output = data.toString().trim()
       // FFmpeg outputs diagnostic info to stderr; only log non-progress lines

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -435,6 +435,23 @@ export function setupExitHandler() {
         logger.error(
           "[Crash] Recording finalized/uploading — preserving artifacts for salvage (NOT requeuing)"
         )
+        // A crash in the finalize window (e.g. the 2026-07-20 ffmpeg-stdin EPIPE)
+        // used to exit before the happy path reached the end-meeting trampoline,
+        // orphaning the bot at recording_succeeded: artifacts in S3 but the
+        // api-server never told to start transcription/completion — and no
+        // server-side job sweeps that state. Best-effort report it from here.
+        // handleEndMeetingWithRetry claims the shared report token, so this is a
+        // no-op when the happy path already reported (or is in flight).
+        try {
+          const { Api } = await import("../api/methods")
+          if (Api.instance) {
+            await Api.instance.handleEndMeetingWithRetry()
+          } else {
+            logger.error("[Crash] Api instance not initialized — cannot report end-meeting")
+          }
+        } catch (trampolineError) {
+          logger.error(`[Crash] end-meeting report failed (non-fatal): ${trampolineError}`)
+        }
       } else {
         const { buildRetryMessage, requeueToSQS } = await import("./retry-handler")
         const { getMaxRetryCount } = await import("../config/retry-config")


### PR DESCRIPTION
Stacked on #230.

## Context

Prod bot `13fb3f4d` (Vidext, 2026-07-20) crashed on an ffmpeg-stdin EPIPE between `recording_succeeded` and the end-meeting trampoline. All artifacts were in S3, but the api-server was never told the meeting ended: no transcription submitted, `ended_at` null, bot frozen at `recording_succeeded` forever — no server-side job sweeps that state. #230 guards the specific EPIPE trigger; this PR closes the remaining bot-side crash surface in the finalize window.

## Changes

- **Logger `handleCrash`**: the finalized branch now best-effort reports the end-meeting trampoline before `exit(1)`, instead of only preserving artifacts. Any crash type in the finalize window (S3 SDK, axios, redis…) no longer orphans the bot.
- **`Api.handleEndMeetingWithRetry`**: actually retries now (3 attempts, 0/2s/6s backoff) — previously a single POST with the error swallowed, so a transient api-server blip silently orphaned the bot.
- **`GLOBAL.claimEndMeetingReport()`**: atomic report-ownership token (same discipline as `claimRecovery()`) so the happy path and the crash path can never double-POST the trampoline (it is not idempotent server-side — a double POST would double-submit transcription). Released only when every attempt failed, so a later path can take over.
- **`MediaContext.execute`**: `this.promise` is only awaited at `stop_process()`, so an earlier ffmpeg `error` event was an unhandledRejection → crash handler. Marked handled at creation. Also adds a generic stdin EPIPE guard covering the one-shot `play()` paths.
- **streaming.ts / ScreenRecorder**: guard the unused piped stdins of the audio-capture and recording ffmpeg processes.
- **`waitForAudioDevices`**: the `pactl`/ffmpeg probe spawns had no `error` listener — a spawn failure was an uncaughtException AND hung the await (`close` never fires). Now resolve −1.

## Not covered (needs api-server work)

Pod OOM-kill / node preemption mid-finalize runs no bot code. Only a server-side sweeper (`recording_succeeded` + `ended_at IS NULL` + age > 15 min → `runPostMeetingDownstream`) closes that class; separate PR in the monorepo.

## Testing

- `tsc --noEmit` clean.
- Jest: 18 pre-existing urlParser failures on the base branch, untouched by this diff; remaining suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)