### PR TITLE
fix(teardown): address PR #231 review findings

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -5,6 +5,15 @@ import axios from "./axios-instance"
 export class Api {
   public static instance: Api | null = null // Singleton class
 
+  /**
+   * In-flight end-meeting report owned by the path that won
+   * GLOBAL.claimEndMeetingReport(). A path that loses the claim awaits this
+   * instead of returning immediately — otherwise the crash handler would
+   * "skip the duplicate", fall through to process.exit(1), and kill the
+   * owner's POST/backoff mid-flight.
+   */
+  private endMeetingReportPromise: Promise<void> | null = null
+
   constructor() {
     if (Api.instance instanceof Api) {
       console.error("Class is singleton, constructor cannot be called multiple times.")
@@ -26,6 +35,11 @@ export class Api {
     const resp = await axios({
       method: "POST",
       url: "/bot-process/end-meeting-trampoline",
+      // The shared instance retries network/5xx errors 3× (axios-instance.ts) —
+      // stacked under handleEndMeetingWithRetry's own 3 attempts that would be
+      // up to 12 sends of this non-idempotent POST. Retrying is owned by the
+      // manual loop ONLY; disable the transport-level layer for this request.
+      "axios-retry": { retries: 0 },
       params: {
         botId: GLOBAL.get().bot_id
       },
@@ -113,12 +127,23 @@ export class Api {
 
     // The trampoline is NOT idempotent server-side (it kicks off transcription
     // submission), so exactly one path may report it: the happy path or the
-    // crash handler's finalized branch. Loser of the claim stands down.
+    // crash handler's finalized branch. A loser of the claim must NOT return
+    // immediately — the crash handler would then exit(1) and kill the owner's
+    // in-flight POST — so it awaits the owner's promise instead.
     if (!GLOBAL.claimEndMeetingReport()) {
-      console.log("endMeetingTrampoline already reported (or in flight) — skipping duplicate")
+      console.log("endMeetingTrampoline already owned by another path — awaiting it")
+      if (this.endMeetingReportPromise) {
+        await this.endMeetingReportPromise
+      }
       return
     }
+    // No await between the claim above and this assignment, so a losing path
+    // always observes the promise (Node run-to-completion).
+    this.endMeetingReportPromise = this.runEndMeetingAttempts()
+    await this.endMeetingReportPromise
+  }
 
+  private async runEndMeetingAttempts(): Promise<void> {
     // A failed trampoline orphans the bot at recording_succeeded (the api-server
     // never learns artifacts/duration and never starts transcription), so retry
     // transient failures before giving up.
@@ -138,8 +163,10 @@ export class Api {
         )
       }
     }
-    // All attempts failed — release the claim so a later path (e.g. the crash
-    // handler) can still try, and continue execution rather than throwing.
+    // All attempts failed — clear the in-flight handle and release the claim so
+    // a later path (e.g. the crash handler) can still try; continue execution
+    // rather than throwing.
+    this.endMeetingReportPromise = null
     GLOBAL.releaseEndMeetingReport()
     console.warn("endMeetingTrampoline exhausted all attempts (continuing execution)")
   }

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -12,7 +12,7 @@ export class Api {
    * "skip the duplicate", fall through to process.exit(1), and kill the
    * owner's POST/backoff mid-flight.
    */
-  private endMeetingReportPromise: Promise<void> | null = null
+  private endMeetingReportPromise: Promise<boolean> | null = null
 
   constructor() {
     if (Api.instance instanceof Api) {
@@ -133,7 +133,13 @@ export class Api {
     if (!GLOBAL.claimEndMeetingReport()) {
       console.log("endMeetingTrampoline already owned by another path — awaiting it")
       if (this.endMeetingReportPromise) {
-        await this.endMeetingReportPromise
+        const ownerSucceeded = await this.endMeetingReportPromise
+        if (!ownerSucceeded) {
+          // The owner exhausted its attempts and released the claim. This path
+          // was already waiting to recover the report, so let it claim a fresh
+          // bounded attempt set instead of returning and exiting the process.
+          await this.handleEndMeetingWithRetry()
+        }
       }
       return
     }
@@ -143,7 +149,7 @@ export class Api {
     await this.endMeetingReportPromise
   }
 
-  private async runEndMeetingAttempts(): Promise<void> {
+  private async runEndMeetingAttempts(): Promise<boolean> {
     // A failed trampoline orphans the bot at recording_succeeded (the api-server
     // never learns artifacts/duration and never starts transcription), so retry
     // transient failures before giving up.
@@ -155,7 +161,7 @@ export class Api {
         }
         await this.endMeetingTrampoline()
         console.log(`API call to endMeetingTrampoline succeeded (attempt ${attempt})`)
-        return
+        return true
       } catch (error) {
         console.warn(
           `API call to endMeetingTrampoline failed (attempt ${attempt}/${delaysMs.length}):`,
@@ -169,5 +175,6 @@ export class Api {
     this.endMeetingReportPromise = null
     GLOBAL.releaseEndMeetingReport()
     console.warn("endMeetingTrampoline exhausted all attempts (continuing execution)")
+    return false
   }
 }

--- a/src/media_context.ts
+++ b/src/media_context.ts
@@ -34,9 +34,10 @@ abstract class MediaContext {
       return null
     }
 
-    this.process = spawn("ffmpeg", args, {
+    const child = spawn("ffmpeg", args, {
       stdio: ["pipe", "pipe", "pipe"]
     })
+    this.process = child
 
     const stdoutListener = (data: Buffer) => {
       console.log(`[ffmpeg stdout] ${data.toString()}`)
@@ -51,37 +52,49 @@ abstract class MediaContext {
       }
     }
 
-    this.process.stdout.addListener("data", stdoutListener)
-    this.process.stderr.addListener("data", stderrListener)
+    child.stdout.addListener("data", stdoutListener)
+    child.stderr.addListener("data", stderrListener)
     // Generic stdin guard for every MediaContext spawn (one-shot play() paths
     // included): without an "error" listener, a teardown-time EPIPE on the pipe
     // escalates to an uncaughtException that kills finalization.
-    this.process.stdin?.on("error", (err) => {
+    child.stdin?.on("error", (err) => {
       console.warn(`[MediaContext] ffmpeg stdin error (ignored during teardown): ${err}`)
     })
 
     this.promise = new Promise((resolve, reject) => {
-      this.process.on("exit", (code) => {
+      const cleanupListeners = () => {
+        child.stdout.removeListener("data", stdoutListener)
+        child.stderr.removeListener("data", stderrListener)
+      }
+
+      child.on("exit", (code) => {
         console.log(`process exited with code ${code}`)
-        // Remove event listeners to prevent memory leaks
-        this.process.stdout.removeListener("data", stdoutListener)
-        this.process.stderr.removeListener("data", stderrListener)
-        if (code === 0) {
+        cleanupListeners()
+        // Bind lifecycle cleanup to this child. A successful callback may start
+        // a replacement before the old child's close event arrives.
+        if (this.process === child) {
           this.process = null
+        }
+        if (code === 0) {
           after()
         }
         resolve(code)
       })
-      this.process.on("error", (err) => {
-        // Spawn/process failure (e.g. ENOENT). Log loudly and reset state so a
-        // later play()/switchTo() can start a fresh ffmpeg instead of hitting
-        // the "Already on execution" guard against a dead process forever.
+      child.on("error", (err) => {
         console.error("[MediaContext] ffmpeg process failed:", err)
-        // Remove event listeners to prevent memory leaks
-        this.process?.stdout?.removeListener("data", stdoutListener)
-        this.process?.stderr?.removeListener("data", stderrListener)
-        this.process = null
+        // Spawn failures have no live process and may safely release the slot
+        // immediately. Kill/signaling errors can leave ffmpeg running, so keep
+        // its handle until exit/close instead of allowing a duplicate spawn.
+        if (child.pid === undefined && this.process === child) {
+          this.process = null
+        }
         reject(err)
+      })
+      child.on("close", () => {
+        cleanupListeners()
+        if (this.process === child) {
+          this.process = null
+        }
       })
     })
     // Nobody awaits this.promise until stop_process(), so a spawn/process
@@ -91,7 +104,7 @@ abstract class MediaContext {
     // unaffected. Mark it handled here; stop_process() still observes the
     // rejection through its own .catch().
     this.promise.catch(() => {})
-    return this.process
+    return child
   }
 
   protected async stop_process() {
@@ -100,10 +113,12 @@ abstract class MediaContext {
       return
     }
 
-    const res = this.process.kill("SIGTERM")
+    const child = this.process
+    const processPromise = this.promise!
+    const res = child.kill("SIGTERM")
     console.log(`Signal sended to process : ${res}`)
 
-    await this.promise
+    await processPromise
       .then((code) => {
         console.log(`process exited with code ${code}`)
       })
@@ -111,8 +126,17 @@ abstract class MediaContext {
         console.log(`process exited with error ${err}`)
       })
       .finally(() => {
-        this.process = null
-        this.promise = null
+        // An error from kill/signaling can reject while ffmpeg is still alive.
+        // Keep that child's handle until its exit/close handler clears it.
+        if (
+          this.process === child &&
+          (child.exitCode !== null || child.signalCode !== null)
+        ) {
+          this.process = null
+        }
+        if (this.process !== child && this.promise === processPromise) {
+          this.promise = null
+        }
       })
   }
 

--- a/src/media_context.ts
+++ b/src/media_context.ts
@@ -73,16 +73,22 @@ abstract class MediaContext {
         resolve(code)
       })
       this.process.on("error", (err) => {
-        console.error(err)
+        // Spawn/process failure (e.g. ENOENT). Log loudly and reset state so a
+        // later play()/switchTo() can start a fresh ffmpeg instead of hitting
+        // the "Already on execution" guard against a dead process forever.
+        console.error("[MediaContext] ffmpeg process failed:", err)
         // Remove event listeners to prevent memory leaks
-        this.process.stdout.removeListener("data", stdoutListener)
-        this.process.stderr.removeListener("data", stderrListener)
+        this.process?.stdout?.removeListener("data", stdoutListener)
+        this.process?.stderr?.removeListener("data", stderrListener)
+        this.process = null
         reject(err)
       })
     })
     // Nobody awaits this.promise until stop_process(), so a spawn/process
     // "error" before then would surface as an unhandledRejection and trip the
-    // crash handler. Mark it handled here; stop_process() still observes the
+    // crash handler — crashing the whole bot over a degraded side-channel
+    // (branding camera / spoken audio), while the recording itself is
+    // unaffected. Mark it handled here; stop_process() still observes the
     // rejection through its own .catch().
     this.promise.catch(() => {})
     return this.process

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -923,6 +923,16 @@ export class ScreenRecorder extends EventEmitter {
     }
   }
 
+  private removeUploadedFile(filePath: string): void {
+    try {
+      fs.unlinkSync(filePath)
+    } catch (error) {
+      // Upload already succeeded and its manifest entry is authoritative. Local
+      // cleanup failure must not append a conflicting UPLOAD_FAILED entry.
+      console.warn(`Failed to remove uploaded local file ${filePath}:`, formatError(error))
+    }
+  }
+
   public async uploadToS3(): Promise<void> {
     if (this.filesUploaded || !S3Uploader.getInstance()) {
       return
@@ -961,7 +971,7 @@ export class ScreenRecorder extends EventEmitter {
           errorCode: null,
           errorMessage: null
         })
-        fs.unlinkSync(this.audioOutputPath)
+        this.removeUploadedFile(this.audioOutputPath)
       } else {
         GLOBAL.addArtifactKey({
           s3Key: null,
@@ -1015,7 +1025,7 @@ export class ScreenRecorder extends EventEmitter {
             errorCode: null,
             errorMessage: null
           })
-          fs.unlinkSync(this.outputPath)
+          this.removeUploadedFile(this.outputPath)
         } else {
           const recordingMode = GLOBAL.get().recording_mode
           GLOBAL.addArtifactKey({
@@ -1100,7 +1110,7 @@ export class ScreenRecorder extends EventEmitter {
             errorCode: null,
             errorMessage: null
           })
-          fs.unlinkSync(diarizationPath)
+          this.removeUploadedFile(diarizationPath)
           console.log("Diarization file uploaded successfully")
         }
       } else {

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1005,7 +1005,6 @@ export class ScreenRecorder extends EventEmitter {
             envVars.AWS_S3_ARTIFACTS_BUCKET,
             s3Key
           )
-          fs.unlinkSync(this.outputPath)
           GLOBAL.addArtifactKey({
             s3Key,
             filePath: this.outputPath,
@@ -1016,6 +1015,7 @@ export class ScreenRecorder extends EventEmitter {
             errorCode: null,
             errorMessage: null
           })
+          fs.unlinkSync(this.outputPath)
         } else {
           const recordingMode = GLOBAL.get().recording_mode
           GLOBAL.addArtifactKey({
@@ -1090,8 +1090,6 @@ export class ScreenRecorder extends EventEmitter {
             envVars.AWS_S3_ARTIFACTS_BUCKET,
             s3Key
           )
-          fs.unlinkSync(diarizationPath)
-          console.log("Diarization file uploaded successfully")
           GLOBAL.addArtifactKey({
             s3Key,
             filePath: diarizationPath,
@@ -1102,6 +1100,8 @@ export class ScreenRecorder extends EventEmitter {
             errorCode: null,
             errorMessage: null
           })
+          fs.unlinkSync(diarizationPath)
+          console.log("Diarization file uploaded successfully")
         }
       } else {
         GLOBAL.addArtifactKey({
@@ -1131,6 +1131,10 @@ export class ScreenRecorder extends EventEmitter {
     }
 
     this.filesUploaded = true
+    // Every expected artifact now has a manifest entry, including failed
+    // uploads copied to EFS. Crash recovery may safely submit this payload:
+    // the api-server can either continue or defer it for reconciliation.
+    GLOBAL.markEndMeetingPayloadReady()
   }
 
   public async stopRecording(): Promise<void> {

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -11,6 +11,7 @@ class Global {
   private recoveryClaimed = false // True once a termination/crash path has taken ownership of log-upload + requeue (see claimRecovery)
   private endMeetingReportClaimed = false // True while/after a path owns the end-meeting-trampoline report (see claimEndMeetingReport)
   private recordingFinalized = false // True once the recording is merged and entering upload (see markRecordingFinalized)
+  private endMeetingPayloadReady = false // True once uploadToS3 has recorded the complete artifact manifest
   private artifactKeys: ArtifactKey[] = []
   private audioChunks: ArtifactKey[] = []
   private participants: Participant[] = []
@@ -281,6 +282,14 @@ class Global {
 
   public hasRecordingFinalized(): boolean {
     return this.recordingFinalized
+  }
+
+  public markEndMeetingPayloadReady(): void {
+    this.endMeetingPayloadReady = true
+  }
+
+  public hasEndMeetingPayloadReady(): boolean {
+    return this.endMeetingPayloadReady
   }
 
   public getRetryCount(): number {

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -456,6 +456,9 @@ export function setupExitHandler() {
 
           const requiredArtifactTypes =
             GLOBAL.get().recording_mode === "audio_only" ? ["audio"] : ["audio", "video"]
+          // Uploaded chunks can preserve transcription, but they cannot replace
+          // missing customer-facing recording outputs. Require final artifact
+          // metadata after the EFS mirror instead of treating chunks as ready.
           const artifactManifestReady = requiredArtifactTypes.every((type) =>
             GLOBAL.getArtifactKeys().some((artifact) => artifact.type === type)
           )

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -440,14 +440,31 @@ export function setupExitHandler() {
         // orphaning the bot at recording_succeeded: artifacts in S3 but the
         // api-server never told to start transcription/completion — and no
         // server-side job sweeps that state. Best-effort report it from here.
-        // handleEndMeetingWithRetry claims the shared report token, so this is a
-        // no-op when the happy path already reported (or is in flight).
+        // handleEndMeetingWithRetry claims the shared report token (and awaits
+        // the owner when the happy path is mid-report), so it never double-POSTs.
+        //
+        // Gate: hasRecordingFinalized() is set BEFORE uploadToS3(), so a crash
+        // mid-upload can land here with nothing (or only part) in S3. Reporting
+        // an empty payload would COMPLETE the bot with no transcript/artifacts —
+        // strictly worse than staying at recording_succeeded, which is at least
+        // salvageable. Only report when the payload is useful: an uploaded audio
+        // chunk (transcription possible) or an uploaded recording artifact.
         try {
-          const { Api } = await import("../api/methods")
-          if (Api.instance) {
-            await Api.instance.handleEndMeetingWithRetry()
+          const chunkUploaded = GLOBAL.getAudioChunks().some((c) => c.uploaded)
+          const artifactUploaded = GLOBAL.getArtifactKeys().some(
+            (a) => a.uploaded && (a.type === "video" || a.type === "audio")
+          )
+          if (chunkUploaded || artifactUploaded) {
+            const { Api } = await import("../api/methods")
+            if (Api.instance) {
+              await Api.instance.handleEndMeetingWithRetry()
+            } else {
+              logger.error("[Crash] Api instance not initialized — cannot report end-meeting")
+            }
           } else {
-            logger.error("[Crash] Api instance not initialized — cannot report end-meeting")
+            logger.error(
+              "[Crash] No uploaded audio/video yet — NOT reporting end-meeting (empty payload would complete the bot with no artifacts)"
+            )
           }
         } catch (trampolineError) {
           logger.error(`[Crash] end-meeting report failed (non-fatal): ${trampolineError}`)

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -443,18 +443,24 @@ export function setupExitHandler() {
         // handleEndMeetingWithRetry claims the shared report token (and awaits
         // the owner when the happy path is mid-report), so it never double-POSTs.
         //
-        // Gate: hasRecordingFinalized() is set BEFORE uploadToS3(), so a crash
-        // mid-upload can land here with nothing (or only part) in S3. Reporting
-        // an empty payload would COMPLETE the bot with no transcript/artifacts —
-        // strictly worse than staying at recording_succeeded, which is at least
-        // salvageable. Only report when the payload is useful: an uploaded audio
-        // chunk (transcription possible) or an uploaded recording artifact.
+        // hasRecordingFinalized() is set BEFORE uploadToS3(), so a crash can land
+        // here before the artifact manifest is complete. Mirror any remaining
+        // outputs to EFS first; copyDirToEFS records them as pending so the
+        // api-server defers the bot to awaiting_reconciliation instead of
+        // completing it with missing audio/video.
         try {
-          const chunkUploaded = GLOBAL.getAudioChunks().some((c) => c.uploaded)
-          const artifactUploaded = GLOBAL.getArtifactKeys().some(
-            (a) => a.uploaded && (a.type === "video" || a.type === "audio")
+          if (!GLOBAL.hasEndMeetingPayloadReady()) {
+            logger.error("[Crash] Artifact manifest incomplete — mirroring final outputs to EFS")
+            await S3Uploader.getInstance()?.copyDirToEFS(PathManager.getInstance().getBasePath())
+          }
+
+          const requiredArtifactTypes =
+            GLOBAL.get().recording_mode === "audio_only" ? ["audio"] : ["audio", "video"]
+          const artifactManifestReady = requiredArtifactTypes.every((type) =>
+            GLOBAL.getArtifactKeys().some((artifact) => artifact.type === type)
           )
-          if (chunkUploaded || artifactUploaded) {
+
+          if (GLOBAL.hasEndMeetingPayloadReady() || artifactManifestReady) {
             const { Api } = await import("../api/methods")
             if (Api.instance) {
               await Api.instance.handleEndMeetingWithRetry()
@@ -463,7 +469,7 @@ export function setupExitHandler() {
             }
           } else {
             logger.error(
-              "[Crash] No uploaded audio/video yet — NOT reporting end-meeting (empty payload would complete the bot with no artifacts)"
+              "[Crash] Recording manifest still incomplete after EFS mirror — NOT reporting end-meeting"
             )
           }
         } catch (trampolineError) {


### PR DESCRIPTION
Follow-up to #231 (merged): fixes the four blocking findings from the post-merge review.

## 1. Retry stacking — up to 12 sends of a non-idempotent POST
`axios-instance.ts` runs `axios-retry` with `retries: 3` and a custom `retryCondition` (`isNetworkError || isRetryableError`) that — unlike the axios-retry default — does **not** exclude POSTs. Stacked under `handleEndMeetingWithRetry`'s 3 manual attempts that is up to 12 sends of the trampoline POST, which kicks off transcription submission server-side. Fixed with a per-request `"axios-retry": { retries: 0 }` so the manual loop is the only retry layer.

> Note: true lost-response dedup (server processed, reply lost, we resend) needs an idempotency guard in the api-server trampoline handler — tracked for the monorepo, out of scope here.

## 2. Claim loser raced the owner's in-flight POST
A path losing `claimEndMeetingReport()` returned immediately; when that loser was the crash handler it fell through to `process.exit(1)` and killed the owner's POST/backoff mid-flight. The owner now publishes a shared result promise. Losers await it; if the owner exhausts its attempts and releases the claim, one waiter reclaims it for a fresh bounded attempt set.

## 3. Finalized marker precedes artifact manifest
`markRecordingFinalized()` fires after merge but before `uploadToS3()`. A crash mid-upload could report a partial manifest and permanently lose customer-facing recording outputs. Normal completion now marks `endMeetingPayloadReady` only after every expected artifact has metadata. A crash before that marker mirrors remaining outputs to EFS, records pending entries, and reports only when required audio/video manifest entries exist. Uploaded chunks alone are insufficient because they preserve transcription, not final recording files.

Successful artifact metadata is also recorded before local deletion. Cleanup failures are logged separately and cannot append conflicting `UPLOAD_FAILED` entries.

## 4. MediaContext process lifecycle
FFmpeg lifecycle handlers now capture the spawned child instead of dereferencing mutable `this.process`. Spawn failures release the slot for respawn; kill/signaling errors retain the live child handle until exit/close, preventing stale cleanup from clearing a newer process or allowing duplicate FFmpeg instances.

## Testing
- `tsc --noEmit` clean
- `src/meeting` suite 14/14 pass
- `git diff --check` clean
- urlParser failures pre-exist on `v2-improvements`, untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)