### PR TITLE
fix(audio): record at 48 kHz to match source — stop the garbled resample

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -18,7 +18,15 @@ import { SoundLevelMonitor } from "../utils/sound-level-monitor"
 
 const TRANSCRIPTION_CHUNK_DURATION = 7200 // Increased from 3600 to 7200, i.e. 2 hours because Gladia can now accept a 135 minutes long audio file
 const GRACE_PERIOD_SECONDS = 3
-const AUDIO_SAMPLE_RATE = 44_100 // Improved audio quality
+// Match the 48 kHz source (Zoom → PulseAudio virtual_speaker.monitor is s16 2ch
+// 48000 Hz). Using 44100 forced a 48000→44100 non-integer resample (ratio 1.0884)
+// on every capture; combined with `aresample=async=1` (which stretches/drops
+// samples to fix drift), that warbled/garbled the recorded audio under any capture
+// jitter. 48000 makes it a native passthrough — no rate conversion — so the async
+// filter only corrects drift. NOTE: this is the RECORDING rate only; the WebSocket
+// stream has its own independent rate (streaming.ts DEFAULT_SAMPLE_RATE / user
+// config) and does NOT use this constant, so consumers are unaffected.
+const AUDIO_SAMPLE_RATE = 48_000
 const AUDIO_BITRATE = "192k" // Improved audio bitrate
 const FLASH_SCREEN_SLEEP_TIME = 4500 // Increased from 4200 for better stability in prod
 const SCREENSHOT_PERIOD = 5 // every 5 seconds instead of 2


### PR DESCRIPTION
## Problem
Recorded audio is garbled on Zoom meetings. Confirmed live: `output.flac` is **44100 Hz mono**, but the source (`virtual_speaker.monitor`) is **s16 2ch 48000 Hz**.

The capture forces a **48000 → 44100** resample (`-ar 44100`, `AUDIO_SAMPLE_RATE`) — a **non-integer ratio (1.0884)** — on top of `aresample=async=1` (which stretches/drops samples to fix A/V drift). Under any capture jitter (worse on the CPU-contended preprod GP1-S nodes) the async resampler over-corrects → **warble/garble**. The `// Improved audio quality` comment was backwards: 44.1 kHz is *below* the 48 kHz source.

## Fix
`AUDIO_SAMPLE_RATE 44100 → 48000` — native passthrough, no rate conversion. The `aresample=async` filter then only corrects drift, not rate. One constant, used consistently across capture / silence-pad / chunks / merge.

## Not a consumer-breaking change
Scope is the **recorded artifact only**. The WebSocket stream has its **own** rate (`streaming.ts` `DEFAULT_SAMPLE_RATE` = 24 kHz / user `streaming_config.audio_frequency`) and does **not** reference `AUDIO_SAMPLE_RATE` (verified: no uses outside `ScreenRecorder.ts`). Streaming consumers are unaffected.

## Optional follow-up (not in this PR)
`-fflags nobuffer` on the pulse input is aggressive (the 4096 thread-queue already buffers); dropping it would further reduce jitter fed to the resampler. Left out to keep this surgical.

## Test
Deploy to preprod, record a Zoom meeting, listen to `output.flac` — should be clean 48 kHz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)