### PR TITLE
fix(zoom): re-arm dialog observer after in-process retry (consent modal not dismissed on wall-retry bots)

### DIFF
--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -175,6 +175,16 @@ export class WaitingRoomState extends BaseState {
       try {
         await this.openMeetingPage(meetingLink)
 
+        // (Re)start the dialog observer for THIS attempt's page, EVERY attempt.
+        // The observer self-stops when the page closes during an in-process retry
+        // teardown ("Page closed -> stop"), so wiring it once (attempt 0) leaves a
+        // bot that hits the anti-bot wall with NO observer on the relaunched page —
+        // and the in-call "This meeting is being recorded" consent modal is never
+        // dismissed on the successful retry (seen live: bot 26f60d13). setupGlobal
+        // DialogObserver stops-then-starts, so re-arming each attempt is idempotent.
+        // Meet + Zoom only; no-op on other platforms.
+        this.startDialogObserver()
+
         if (attempt === 0) {
           // Pulse → output WebSocket capture (output streaming only). Device-level
           // and self-guarded, so it survives a browser relaunch — start it once.
@@ -183,10 +193,6 @@ export class WaitingRoomState extends BaseState {
           }
           // Branding switch (warmup placeholder → real image) — idempotent trigger.
           notifyJoinReady()
-          // Dialog observer polls context.playwrightPage live, so wiring it once
-          // picks up the relaunched page automatically (runs on Meet + Zoom;
-          // no-op on other platforms).
-          this.startDialogObserver()
           // Waiting-room webhook — fire once, not per relaunch.
           Events.inWaitingRoom()
         }


### PR DESCRIPTION
## Problem (live: bot 26f60d13 "Cyril")
The "This meeting is being recorded" modal covered the whole recording — **even with Amr's visibility fix (#236)** — because the dialog observer **wasn't running when the modal appeared**:
```
14:40:42  Starting dialog observer (attempt 0)
14:40:57  Anti-bot wall -> in-process retry
14:40:58  Page closed -> Stopped dialog observer   ← self-terminates on teardown
14:41:24  Admitted (retried IP) -> modal appears -> nothing dismisses it
```

The observer self-stops when its page closes, and it was **only started on attempt 0** of `joinWithInProcessRetry`. Any bot that hits the anti-bot wall does an in-process retry (teardown closes the page → observer stops → browser relaunches), then gets admitted on the retried IP with **no observer** → the consent modal is never dismissed. Bots admitted on attempt 0 (no wall) kept their observer, which is why it worked for them.

## Fix
Move `startDialogObserver()` out of the `attempt === 0` gate so it re-arms for **every** attempt's page. `setupGlobalDialogObserver` stops-then-starts, so it's idempotent. Streaming / branding / waiting-room-webhook stay gated (genuinely once).

## Note
This is orthogonal to Amr's `isVisible` fix (#236) — that's correct; it just never ran on wall-retry bots. Also unrelated to the audio garble: `nobuffer` is already dropped + `AUDIO_SAMPLE_RATE=48000` in this branch, yet Cyril's 48 kHz recording is still garbled, so that cause is elsewhere (async-resample / CPU) — separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)