### PR TITLE
fix(audio): increase FFmpeg buffer sizes and match 48kHz source to prevent clicking artifacts

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -369,6 +369,8 @@ export class ScreenRecorder extends EventEmitter {
       "-f",
       "x11grab",
       "-video_size",
+      "-thread_queue_size",
+      "1024",   // video frames are large; small queue avoids bloat
       `${res.width}x${res.captureHeight}`,
       "-framerate",
       "30",
@@ -386,7 +388,11 @@ export class ScreenRecorder extends EventEmitter {
       // pipe uses its own `-flush_packets 1`), so buffer normally and give the
       // capture generous headroom instead.
       "-thread_queue_size",
-      "16384",
+      "65536", // ~1.4s at 48kHz = enough headroom for x264 CPA bursts
+      "-rtbufsize",
+      "256k",    // Real-time buffer matching thread_queue_size
+      "-fflags",
+      "nobuffer",
       "-i",
       VIRTUAL_SPEAKER_MONITOR,
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -369,9 +369,9 @@ export class ScreenRecorder extends EventEmitter {
       "-f",
       "x11grab",
       "-video_size",
-      "-thread_queue_size",
-      "1024",   // video frames are large; small queue avoids bloat
       `${res.width}x${res.captureHeight}`,
+      "-thread_queue_size",
+      "1024",   // 1024 packets — ~34 s at 30 fps, generous without memory bloat
       "-framerate",
       "30",
       "-i",
@@ -388,9 +388,9 @@ export class ScreenRecorder extends EventEmitter {
       // pipe uses its own `-flush_packets 1`), so buffer normally and give the
       // capture generous headroom instead.
       "-thread_queue_size",
-      "65536", // ~1.4s at 48kHz = enough headroom for x264 CPA bursts
+      "65536",
       "-rtbufsize",
-      "256k",    // Real-time buffer matching thread_queue_size
+      "256k",
       "-fflags",
       "nobuffer",
       "-i",

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -146,6 +146,7 @@ export class Streaming {
       "-analyzeduration", "0",
       "-fflags", "nobuffer",
       "-flags", "low_delay",
+      "-thread_queue_size", "16384",
       "-f", "pulse",
       "-i", source,
       // Output: mono Float32 at target rate, flush every packet

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -146,7 +146,7 @@ export class Streaming {
       "-analyzeduration", "0",
       "-fflags", "nobuffer",
       "-flags", "low_delay",
-      "-thread_queue_size", "16384",
+      "-thread_queue_size", "256",
       "-f", "pulse",
       "-i", source,
       // Output: mono Float32 at target rate, flush every packet


### PR DESCRIPTION
bump PulseAudio thread_queue_size and set native 48kHz to fix buffer clicks