### PR TITLE
fix(audio): relax aresample async=1 -> 1000 (stop glitch/click garble)

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -431,12 +431,17 @@ export class ScreenRecorder extends EventEmitter {
       "-map",
       "1:a:0",
       "-vn",
-      // Stretch/pad audio to match capture timestamps: PulseAudio xruns and
-      // sample-clock drift otherwise accumulate against the wall-clock-paced
-      // video (x11grab dups/drops frames to hold 30fps), desyncing long
-      // recordings even when the start was aligned perfectly.
+      // Reconcile the audio sample-clock against the wall-clock-paced video
+      // (x11grab dups/drops frames to hold 30fps) so long recordings don't desync.
+      // async=1 caps soft compensation at ~1 sample/sec, so ANY drift beyond that
+      // is corrected by HARD fill/trim (insert silence / drop samples) at every
+      // timestamp discontinuity from PulseAudio xruns — each a click/glitch, which
+      // shows up as the vertical-streak artefacts in the recording's spectrogram.
+      // async=1000 lets it absorb drift by gently STRETCHING (up to ~1000 samples/
+      // sec ≈ 21 ms/sec) instead of hard-cutting, removing the per-discontinuity
+      // clicks while still holding A/V sync over long recordings.
       "-af",
-      "aresample=async=1:first_pts=0",
+      "aresample=async=1000:first_pts=0",
       "-sample_fmt",
       "s16",
       "-ac",


### PR DESCRIPTION
## Evidence
Spectrogram of bot `04aa0bf8`'s `output.flac` (48 kHz): the garble is **transient glitch/click streaks** (vertical lines across the spectrogram), not a rate problem — 48 kHz is now correct and the 12 kHz cutoff is normal Zoom super-wideband Opus voice. The clicks persist even at moderate node load, so it's not purely CPU contention.

## Cause
`aresample=async=1` caps **soft** compensation at ~1 sample/sec. Any drift beyond that (PulseAudio xruns vs the wall-clock-paced x11grab video) is corrected by **hard fill/trim** — inserting silence / dropping samples at each timestamp discontinuity. Each hard cut is a click → the streaks.

## Fix
`async=1 → async=1000`: lets the resampler absorb the same drift by **gently stretching** (~1000 samples/sec ≈ 21 ms/sec) instead of hard-cutting, so it stops clicking at every discontinuity while still holding A/V sync over long recordings.

## Scope / caveat
Recording-only (WS stream has its own path). This is **hypothesis-driven from the spectrogram** — I couldn't A/B it in-loop, so validate by ear on a fresh recording after deploy. If clicks remain, the residual source is upstream jitter (Firefox WebRTC / PulseAudio under CPU starvation) and the fix moves to node sizing / buffering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)