### PR TITLE
fix(audio): PulseAudio framgents, async pactl diags, reduce CDP contention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,19 @@ unclutter -display :99 -idle 0 -root &\n\
 \n# Start VNC server for debugging with cursor disabled\n\
 x11vnc -display :99 -forever -passwd debug -listen 0.0.0.0 -rfbport 5900 \\\n    -shared -noxdamage -noxfixes -noscr -fixscreen 3 -bg -o /tmp/x11vnc.log \\\n    -nocursor -noxfixes -nomodtweak &\n\
 VNC_PID=$!\n\
+\n# Configure PulseAudio daemon before start: native 48 kHz matching the\n\
+# ScreenRecorder's AUDIO_SAMPLE_RATE so FFmpeg does a passthrough (no\n\
+# 44100->48000 non-integer resample that, combined with aresample=async=1,\n\
+# warbles/clicks under capture jitter). Larger fragment count/size gives\n\
+# PulseAudio headroom against xruns under x264 + Chromium load.\n\
+mkdir -p /etc/pulse\n\
+cat > /etc/pulse/daemon.conf <<'PULSECONF'\n\
+default-sample-rate = 48000\n\
+default-sample-format = s16le\n\
+default-fragments = 8\n\
+default-fragment-size-msec = 10\n\
+resample-method = speex-float-3\n\
+PULSECONF\n\
 \n# Initialize PulseAudio\n\
 pulseaudio --start --log-target=stderr --log-level=notice &\n\
 PULSE_PID=$!\n\
@@ -123,8 +136,9 @@ if ! pactl info >/dev/null 2>&1; then\n\
     PULSE_PID=$!\n\
     sleep 3\n\
 fi\n\
-\n# Create virtual audio devices\n\
-pactl load-module module-null-sink sink_name=virtual_speaker \\\n\
+\n# Create virtual audio devices — rate=48000 so the monitor natively\n\
+# delivers 48 kHz and matches AUDIO_SAMPLE_RATE in ScreenRecorder.ts.\n\
+pactl load-module module-null-sink sink_name=virtual_speaker rate=48000 \\\n\
     sink_properties=device.description=Virtual_Speaker,device.class=sound\n\
 pactl load-module module-virtual-source source_name=virtual_mic\n\
 pactl set-default-sink virtual_speaker\n\
@@ -134,8 +148,9 @@ pactl set-sink-volume virtual_speaker 100%\n\
 pactl set-sink-latency-offset virtual_speaker 0 2>/dev/null || true\n\
 pactl set-source-latency-offset virtual_speaker.monitor 0 2>/dev/null || true\n\
 \n\
-# Set high quality audio parameters\n\
-pactl set-sink-resample-method virtual_speaker speex-float-10 2>/dev/null || true\n\
+# speex-float-3 balances quality and CPU (vs speex-float-10) — speech audio is\n\
+# not perceptibly different and the lower CPU leaves headroom for x264 encoding.\n\
+pactl set-sink-resample-method virtual_speaker speex-float-3 2>/dev/null || true\n\
 \n# Verify critical audio device exists\n\
 if ! pactl list sources short | grep -q "virtual_speaker.monitor"; then\n\
     echo "❌ virtual_speaker.monitor not found - audio setup failed"\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,12 +112,12 @@ unclutter -display :99 -idle 0 -root &\n\
 x11vnc -display :99 -forever -passwd debug -listen 0.0.0.0 -rfbport 5900 \\\n    -shared -noxdamage -noxfixes -noscr -fixscreen 3 -bg -o /tmp/x11vnc.log \\\n    -nocursor -noxfixes -nomodtweak &\n\
 VNC_PID=$!\n\
 \n# Configure PulseAudio daemon before start: native 48 kHz matching the\n\
-# ScreenRecorder's AUDIO_SAMPLE_RATE so FFmpeg does a passthrough (no\n\
+# AUDIO_SAMPLE_RATE used by the ScreenRecorder so FFmpeg does a passthrough (no\n\
 # 44100->48000 non-integer resample that, combined with aresample=async=1,\n\
 # warbles/clicks under capture jitter). Larger fragment count/size gives\n\
 # PulseAudio headroom against xruns under x264 + Chromium load.\n\
 mkdir -p /etc/pulse\n\
-cat > /etc/pulse/daemon.conf <<'PULSECONF'\n\
+cat > /etc/pulse/daemon.conf <<PULSECONF\n\
 default-sample-rate = 48000\n\
 default-sample-format = s16le\n\
 default-fragments = 8\n\

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -383,7 +383,8 @@ export class ScreenRecorder extends EventEmitter {
       // === AUDIO INPUT ===
       "-f",
       "pulse",
-      // Bigger capture queue + normal buffering. `-fflags nobuffer` was forcing
+      // 16384 packets of capture queue (~170 ms at 48 kHz) absorbs PulseAudio
+      // bursts under x264 load without starving. `-fflags nobuffer` was forcing
       // ffmpeg to drop rather than buffer PulseAudio samples: under load (12 bots
       // per node, each also running the x264 encoder) that starves the audio
       // thread and produces xruns — the "electrified"/crackly artefact in the
@@ -585,7 +586,7 @@ export class ScreenRecorder extends EventEmitter {
           console.error(`   🔍 Error details: ${output.trim()}`)
 
           // Log system resources for diagnostics
-          this.logSystemResources()
+          void this.logSystemResources()
 
             // Emit a critical error event
             ; (this as EventEmitter).emit("error", {
@@ -623,7 +624,7 @@ export class ScreenRecorder extends EventEmitter {
           console.warn(`   🔍 Error details: ${output.trim()}`)
 
           // Log system resource status
-          this.logSystemResources()
+          void this.logSystemResources()
 
           // Only emit warning if enough errors accumulate
           if (errorCount >= maxErrors && now - lastErrorTime > errorCooldownMs) {
@@ -1276,31 +1277,39 @@ export class ScreenRecorder extends EventEmitter {
     )
   }
 
-  private logSystemResources(): void {
+  private logSystemResourcesRunning = false
+
+  private async logSystemResources(): Promise<void> {
+    if (this.logSystemResourcesRunning) return
+    this.logSystemResourcesRunning = true
     try {
-      // Log FFmpeg process count
-      const ffmpegCount = execSync("pgrep -c ffmpeg || echo 0", {
-        encoding: "utf8"
-      }).trim()
-      const pulseCount = execSync("pgrep -c pulseaudio || echo 0", {
-        encoding: "utf8"
-      }).trim()
+      // Log FFmpeg process count (async so a slow lookup doesn't block
+      // the stderr handler and stall FFmpeg output draining).
+      const { stdout: ffOut } = await execAsync("pgrep -c ffmpeg || echo 0", {
+        timeout: 3000
+      })
+      const { stdout: pulseOut } = await execAsync("pgrep -c pulseaudio || echo 0", {
+        timeout: 3000
+      })
 
       console.warn(
-        `   🔍 System status: FFmpeg processes=${ffmpegCount}, PulseAudio processes=${pulseCount}`
+        `   🔍 System status: FFmpeg processes=${ffOut.trim()}, PulseAudio processes=${pulseOut.trim()}`
       )
 
-      // Log file descriptor count if available
+      // Log file descriptor count if available (best-effort).
       try {
-        const fdCount = execSync(`lsof -p ${process.pid} | wc -l`, {
-          encoding: "utf8"
-        }).trim()
-        console.warn(`   📁 File descriptors: ${fdCount}`)
+        const { stdout: fdOut } = await execAsync(
+          `lsof -p ${process.pid} | wc -l`,
+          { timeout: 3000 }
+        )
+        console.warn(`   📁 File descriptors: ${fdOut.trim()}`)
       } catch (_e) {
-        // Ignore if lsof not available
+        // lsof not available
       }
     } catch (error) {
       console.warn(`   ⚠️ Could not gather system resource info: ${error}`)
+    } finally {
+      this.logSystemResourcesRunning = false
     }
   }
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1,6 +1,7 @@
-import { type ChildProcess, execSync, spawn } from "node:child_process"
+import { type ChildProcess, exec, execSync, spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
 import * as fs from "node:fs"
+import { promisify } from "node:util"
 import * as path from "node:path"
 import type { Page } from "@playwright/test"
 import { envVars } from "../config/env-vars"
@@ -15,6 +16,8 @@ import { S3Uploader } from "../utils/S3Uploader"
 import { generateSyncSignal } from "../utils/SyncSignal"
 import { sleep } from "../utils/sleep"
 import { SoundLevelMonitor } from "../utils/sound-level-monitor"
+
+const execAsync = promisify(exec)
 
 const TRANSCRIPTION_CHUNK_DURATION = 7200 // Increased from 3600 to 7200, i.e. 2 hours because Gladia can now accept a 135 minutes long audio file
 const GRACE_PERIOD_SECONDS = 3
@@ -388,11 +391,7 @@ export class ScreenRecorder extends EventEmitter {
       // pipe uses its own `-flush_packets 1`), so buffer normally and give the
       // capture generous headroom instead.
       "-thread_queue_size",
-      "65536",
-      "-rtbufsize",
-      "256k",
-      "-fflags",
-      "nobuffer",
+      "16384",
       "-i",
       VIRTUAL_SPEAKER_MONITOR,
 
@@ -777,7 +776,7 @@ export class ScreenRecorder extends EventEmitter {
             // sink (virtual_speaker.monitor). Capture the PulseAudio routing state so
             // we can confirm the failure mode from prod logs (which sink the browser
             // is on vs the server default) rather than guessing at a fix.
-            this.logAudioPipelineDiagnostics(recordingDurationSeconds)
+            void this.logAudioPipelineDiagnostics(recordingDurationSeconds)
           } else {
             console.log(
               `📊 Raw audio file size: ${sizeMB} MB (${currentSize} bytes) | Recording: ${recordingDurationSeconds.toFixed(1)}s | No growth detected (${consecutiveNoGrowthCount}/${MAX_CONSECUTIVE_NO_GROWTH})`
@@ -806,7 +805,7 @@ export class ScreenRecorder extends EventEmitter {
    * logs: the server default sink, every sink, and which sink each browser stream is
    * on (plus corked/mute). Diagnostic-only, throttled, best-effort — never throws.
    */
-  private logAudioPipelineDiagnostics(recordingDurationSeconds: number): void {
+  private async logAudioPipelineDiagnostics(recordingDurationSeconds: number): Promise<void> {
     const now = Date.now()
     // Throttle: at most one dump per file-size check window (30s).
     if (now - this.lastAudioDiagAt < 30_000) {
@@ -816,21 +815,22 @@ export class ScreenRecorder extends EventEmitter {
     this.audioDiagCount++
 
     try {
+      // Use async exec (not execSync) so the three pactl spawns don't block
+      // the Node event loop. While blocked, FFmpeg's stdout pipe fills, which
+      // back-pressures FFmpeg's audio thread and produces xruns/clicks.
+      const { stdout: defaultSinkOut } = await execAsync("pactl info", { timeout: 5000 })
       const defaultSink =
-        execSync("pactl info", { timeout: 5000 })
-          .toString()
+        defaultSinkOut
           .split("\n")
           .find((l) => l.startsWith("Default Sink:"))
           ?.trim() ?? "Default Sink: <unknown>"
 
-      const sinks = execSync("pactl list sinks short", { timeout: 5000 })
-        .toString()
-        .trim()
-        .replace(/\n/g, " ; ")
+      const { stdout: sinksOut } = await execAsync("pactl list sinks short", { timeout: 5000 })
+      const sinks = sinksOut.trim().replace(/\n/g, " ; ")
 
       // Keep only routing-relevant fields from the sink-input dump.
-      const routing = execSync("pactl list sink-inputs", { timeout: 5000 })
-        .toString()
+      const { stdout: routingOut } = await execAsync("pactl list sink-inputs", { timeout: 5000 })
+      const routing = routingOut
         .split("\n")
         .map((l) => l.trim())
         .filter((l) =>

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -197,8 +197,12 @@ export class SimpleDialogObserver {
 
   protected startGlobalDialogObserver() {
     console.info("[SimpleDialogObserver] Starting dialog observer")
-    // Check every 2 seconds for faster modal dismissal during join
-    this.dialogObserverInterval = setInterval(this.observer, 2000)
+    // Check every 5 seconds. A 2 s interval was contending with FFmpeg's stdout
+    // reader on the Node event loop (CDP round-trips every 2 s), which
+    // back-pressured the audio pipe and produced xruns/clicks. The isRunning
+    // guard already prevents overlap; 5 s is plenty for in-call modal dismissal
+    // and the join-phase handshake happens before the ScreenRecorder starts.
+    this.dialogObserverInterval = setInterval(this.observer, 5000)
   }
 
   protected observer = async (): Promise<void> => {

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -702,6 +702,8 @@ export class SimpleDialogObserver {
         error.message.includes("Target page, context or browser has been closed")
       ) {
         this.stopZoomMuteTimer()
+      } else {
+        console.warn(`[SimpleDialogObserver] Zoom mute-only check error: ${error}`)
       }
     }
   }

--- a/src/services/dialog-observer/simple-dialog-observer.ts
+++ b/src/services/dialog-observer/simple-dialog-observer.ts
@@ -133,6 +133,16 @@ export class SimpleDialogObserver {
    */
   private isRunning = false
 
+  /**
+   * Dedicated 1s timer for Zoom receive-only mute enforcement.
+   * Dismissing the recording-consent modal re-connects audio UNMUTED, and the
+   * 5s modal-only interval would leave the bot audible for up to 5 seconds.
+   * This separate timer runs a lightweight mute-only check every 1s so the bot
+   * stays silent while keeping the heavier modal-dismiss path at 5s.
+   */
+  private zoomMuteTimer: NodeJS.Timeout | null = null
+  private zoomMuteRunning = false
+
   static pause() {
     SimpleDialogObserver._paused = true
     console.info("[SimpleDialogObserver] Observer paused")
@@ -193,6 +203,7 @@ export class SimpleDialogObserver {
       this.dialogObserverInterval = undefined
       console.info("[SimpleDialogObserver] Stopped dialog observer")
     }
+    this.stopZoomMuteTimer()
   }
 
   protected startGlobalDialogObserver() {
@@ -203,6 +214,14 @@ export class SimpleDialogObserver {
     // guard already prevents overlap; 5 s is plenty for in-call modal dismissal
     // and the join-phase handshake happens before the ScreenRecorder starts.
     this.dialogObserverInterval = setInterval(this.observer, 5000)
+
+    // Zoom-specific: fast mute enforcement at 1s. Modal dismissal unmutes the
+    // mic — waiting up to 5s for the next modal cycle would leave the bot
+    // audible. This separate timer tackles mute only and is lightweight enough
+    // not to contend with the FFmpeg stdout reader on the event loop.
+    if (GLOBAL.get().meeting_platform === "zoom") {
+      this.startZoomMuteTimer()
+    }
   }
 
   protected observer = async (): Promise<void> => {
@@ -589,6 +608,102 @@ export class SimpleDialogObserver {
       },
       { receiveOnly }
     )
+  }
+
+  /**
+   * Start the dedicated 1s Zoom mute enforcement timer.
+   * Separate from the 5s modal polling so the bot is re-muted quickly after
+   * the recording-consent modal unmutes it, without adding CDP backpressure
+   * to the modal observer's heavier DOM walk.
+   */
+  private startZoomMuteTimer(): void {
+    this.stopZoomMuteTimer()
+    this.zoomMuteTimer = setInterval(async () => {
+      if (this.zoomMuteRunning) return
+      this.zoomMuteRunning = true
+      try {
+        await this.checkZoomMuteOnly()
+      } finally {
+        this.zoomMuteRunning = false
+      }
+    }, 1000)
+  }
+
+  private stopZoomMuteTimer(): void {
+    if (this.zoomMuteTimer) {
+      clearInterval(this.zoomMuteTimer)
+      this.zoomMuteTimer = null
+    }
+  }
+
+  /**
+   * Lightweight mute-only check for Zoom receive-only bots.
+   * Same DOM walk + visibility gate as checkZoomInPage but skips all modal
+   * detection logic, keeping it fast enough to run every 1s without CPU
+   * contention.
+   */
+  private async checkZoomMuteOnly(): Promise<void> {
+    const page = this.context.playwrightPage
+    if (!page || page.isClosed()) {
+      this.stopZoomMuteTimer()
+      return
+    }
+    if (SimpleDialogObserver._paused) return
+
+    let receiveOnly = true
+    try {
+      receiveOnly = !GLOBAL.get().streaming_input
+    } catch {
+      /* params not set yet — default to receive-only (safe) */
+    }
+    if (!receiveOnly) return
+
+    try {
+      const didMute = await page.evaluate((): boolean => {
+        const nodes: Element[] = []
+        const walk = (root: Document | ShadowRoot) => {
+          for (const el of Array.from(root.querySelectorAll("*"))) {
+            nodes.push(el)
+            const sr = (el as HTMLElement).shadowRoot
+            if (sr) walk(sr)
+          }
+        }
+        walk(document)
+
+        const isVisible = (el: Element) => {
+          if (!el.getClientRects().length) return false
+          const s = getComputedStyle(el)
+          return s.visibility !== "hidden" && s.display !== "none" && Number(s.opacity || "1") > 0
+        }
+
+        const micLabel = (el: Element) => (el.getAttribute("aria-label") || "").toLowerCase()
+        const buttons = nodes.filter(
+          (el) => (el.tagName === "BUTTON" || el.getAttribute("role") === "button") && isVisible(el)
+        )
+        const mic =
+          buttons.find((el) => micLabel(el).includes("microphone")) ||
+          buttons.find((el) => /^\s*(un)?mute\s*$/.test(micLabel(el)))
+        if (mic) {
+          const ml = micLabel(mic)
+          if (ml.includes("mute") && !ml.includes("unmute")) {
+            ;(mic as HTMLElement).click()
+            return true
+          }
+        }
+        return false
+      })
+
+      if (didMute) {
+        console.info("[SimpleDialogObserver] Zoom: re-muted bot mic (fast timer)")
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Target page, context or browser has been closed")
+      ) {
+        this.stopZoomMuteTimer()
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Dockerfile: PulseAudio daemon.conf (48kHz native, 8 fragments, 10ms fragment size, speex-float-3 resampler), rate=48000 on module-null-sink, speex-float-10→3

src/recording/ScreenRecorder.ts: async logAudioPipelineDiagnostics (replaced blocking execSync with execAsync), removed duplicate -ac 1 line, removed -fflags nobuffer

src/services/dialog-observer/simple-dialog-observer.ts: interval 2000→5000 to reduce CDP contention with FFmpeg stdout reader