### PR TITLE
fix(teams,zoom): classify invalid meeting URLs instead of retryable unknown

### DIFF
--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -39,6 +39,36 @@ interface TeamsChatWindow extends Window {
 // Create a singleton detector instance for Microsoft Teams
 const teamsStateDetector = createStateDetector(TEAMS_STATE_CONFIG)
 
+/**
+ * Fetch the meeting URL out-of-band to learn its HTTP status. Used to classify
+ * a goto() that threw ERR_HTTP_RESPONSE_CODE_FAILURE (Firefox throws instead of
+ * resolving the response, so the in-page status check never runs). Returns the
+ * final status after redirects, or null when the probe itself failed — callers
+ * must treat null as "unknown", not as an error status.
+ */
+async function probeUrlStatus(url: string): Promise<number | null> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10000)
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal
+      })
+      return response.status
+    } finally {
+      clearTimeout(timeout)
+    }
+  } catch (probeError) {
+    console.warn(
+      "[Teams] URL status probe failed:",
+      probeError instanceof Error ? probeError.message : probeError
+    )
+    return null
+  }
+}
+
 export class TeamsProvider implements MeetingProviderInterface {
   async parseMeetingUrl(meeting_url: string) {
     return parseMeetingUrlFromJoinInfos(meeting_url)
@@ -386,6 +416,34 @@ export class TeamsProvider implements MeetingProviderInterface {
       return page
     } catch (error) {
       console.error("Error in openMeetingPage:", formatError(error))
+      // Firefox/cloakbrowser goto() THROWS net::ERR_HTTP_RESPONSE_CODE_FAILURE
+      // on ANY HTTP error status — unlike Chromium, which resolves the response
+      // and reaches the >=500 check above. So both a dead link (4xx) and a Teams
+      // outage (5xx) land here and used to fail as retryable UNKNOWN_ERROR
+      // (bot eb1eaceb, 2026-07-21: customer sent teams.microsoft.com/123 and
+      // burned 3 SQS attempts on a URL that can never work). Probe the URL
+      // out-of-band to classify:
+      //   4xx -> terminal InvalidMeetingUrl, do NOT retry;
+      //   5xx -> CannotJoinMeeting, retryable (transient edge failure);
+      //   probe failed -> keep the generic retryable path.
+      const errMsg = error instanceof Error ? error.message : String(error)
+      if (errMsg.includes("ERR_HTTP_RESPONSE_CODE_FAILURE")) {
+        const status = await probeUrlStatus(link)
+        if (status !== null && status >= 400 && status < 500) {
+          console.log(`🔴 Teams URL returned HTTP ${status} — invalid meeting URL, not retrying`)
+          GLOBAL.setError(
+            MeetingEndReason.InvalidMeetingUrl,
+            `Teams returned HTTP ${status} for the meeting URL — the link is invalid or expired`
+          )
+          throw error
+        }
+        if (status !== null && status >= 500) {
+          GLOBAL.setError(
+            MeetingEndReason.CannotJoinMeeting,
+            `Teams returned HTTP ${status} - service unavailable`
+          )
+        }
+      }
       // Mark as retryable - bot hasn't joined yet, so retrying is safe
       console.log("🔄 Error occurred before joining - marking as retryable")
       GLOBAL.setShouldRetry(true)


### PR DESCRIPTION
## Problem

Cloakbrowser (Chromium) resolves `page.goto()` on an HTTP error response **with a body** (the existing ≥500 check catches those), but **throws** `net::ERR_HTTP_RESPONSE_CODE_FAILURE` when the error response is **bodyless** — Teams answers a bogus meeting path with a bodyless 400. The existing in-page `response.status() >= 500` check (added for the 2026-04-27 Teams 503 incident) therefore never runs on our current browser — every HTTP failure falls into the generic catch, gets marked retryable, and terminates as `UNKNOWN_ERROR`.

Real case — bot `eb1eaceb` (Video.Taxi, 2026-07-21): customer sent `https://teams.microsoft.com/123` (no meeting ID). The bot burned 3 full SQS attempts on a link that can never work (~30s + 2 dashboard "Retrying" entries) and then reported `UNKNOWN_ERROR`, telling the customer nothing about the actual problem.

## Fix

On `ERR_HTTP_RESPONSE_CODE_FAILURE` in `openMeetingPage`, probe the URL out-of-band (`fetch`, follow redirects, 10s abort):

| Probe result | Classification | Retry |
|---|---|---|
| 4xx | `InvalidMeetingUrl` — webhook names the real problem | no |
| 5xx | `CannotJoinMeeting` (same as the existing Chromium-path check) | yes |
| probe failed | unchanged generic path | yes |

Null-probe is treated as "unknown", never as an error status, so a network blip on the probe can't misclassify a live meeting link as invalid.

## Verified

- `tsc --noEmit` clean
- `curl -L https://teams.microsoft.com/123` → **HTTP 400** after redirects: yesterday's failure maps to `InvalidMeetingUrl` with zero retries

## Notes

- Draft: needs a decision on whether Meet/Zoom want the same probe (Meet URLs are shape-validated up front so a 4xx there is rarer; Zoom goes through the web-view path).
- Deeper fix candidate (separate change): reject `teams.microsoft.com` URLs without `/l/meetup-join/` or `/meet/<id>` at the API layer so bogus links never reach a pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)