### PR TITLE
fix(meet): fast UI-observer fallback when network diarization never produced a segment

### DIFF
--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -35,6 +35,7 @@ export class DiarizationTracker {
   private recentSegments: DiarizationSegment[] = [] // Last 5 closed segments
   private filePath: string
   private isEnded = false
+  private hasTrackedAnySegment = false // True once ANY speaker segment was ever opened
 
   private constructor(tempDir: string) {
     this.filePath = join(tempDir, "diarization.jsonl")
@@ -87,6 +88,17 @@ export class DiarizationTracker {
       startTime: relativeTime,
       userId: speaker.id
     }
+    this.hasTrackedAnySegment = true
+  }
+
+  /**
+   * True once at least one speaker segment was ever opened this meeting.
+   * Distinguishes "network diarization NEVER produced data" (source is dead —
+   * fall back fast) from "was producing, currently quiet" (normal silence —
+   * debounce before falling back).
+   */
+  public hasEverTrackedSegment(): boolean {
+    return this.hasTrackedAnySegment
   }
 
   /**

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -1,3 +1,4 @@
+import { DiarizationTracker } from "../../diarization-tracker"
 import { Events } from "../../events"
 import { stopNetworkInterception } from "../../meeting/meet/network-interception"
 import { startUIBasedObserver } from "../../meeting/meet/ui-observer"
@@ -49,6 +50,13 @@ const ALONE_IN_MEETING_GRACE_PERIOD_MS = 5 * 60 * 1000
 
 // How many consecutive stale events trigger fallback to UI-based diarization - increased from 5 to 10 to avoid false positives
 const STALE_EVENT_THRESHOLD = 10
+// Fast-path threshold when network diarization has NEVER produced a single
+// segment: the source is dead, not flapping, so 10 events (>=50s of speech at
+// the 5s health-check throttle) only loses labels. Two events (~10s of sound
+// with zero segments ever) is enough evidence to fall back. Short meetings
+// (e.g. ticket 19961784714714: 60s solo test calls, transcript speakers all
+// "Unknown") could mathematically never reach the 10-event threshold.
+const NEVER_PRODUCED_STALE_THRESHOLD = 2
 
 export class RecordingState extends BaseState {
   private isProcessing = true
@@ -424,20 +432,25 @@ export class RecordingState extends BaseState {
       if (status.status === "stale") {
         this.consecutiveStaleCount++
         const meetingPlatform = GLOBAL.get().meeting_platform
+        // Never-produced = the network source is dead, not flapping — use the
+        // fast threshold so short meetings still get speaker labels via the UI
+        // observer instead of ending with an empty diarization ("Unknown").
+        const neverProduced = !DiarizationTracker.getInstance().hasEverTrackedSegment()
+        const threshold = neverProduced ? NEVER_PRODUCED_STALE_THRESHOLD : STALE_EVENT_THRESHOLD
         console.log(
-          `[DiarizationHealth] [${meetingPlatform}] ⚠️ Stale event ${this.consecutiveStaleCount}/${STALE_EVENT_THRESHOLD}`
+          `[DiarizationHealth] [${meetingPlatform}] ⚠️ Stale event ${this.consecutiveStaleCount}/${threshold}${neverProduced ? " (no segment ever produced — fast fallback)" : ""}`
         )
 
-        // Check if we should trigger fallback (Meet only, network diarization active, 5 consecutive stale events)
+        // Check if we should trigger fallback (Meet only, network diarization active)
         if (
-          this.consecutiveStaleCount >= STALE_EVENT_THRESHOLD &&
+          this.consecutiveStaleCount >= threshold &&
           meetingPlatform === "meet" &&
           !GLOBAL.hasNetworkInterceptionSetupFailed() &&
           !GLOBAL.hasDiarizationFallbackTriggered() &&
           this.context.playwrightPage
         ) {
           console.log(
-            `[DiarizationHealth] [${meetingPlatform}] 🔄 Triggering fallback to UI-based diarization after ${STALE_EVENT_THRESHOLD} consecutive stale events`
+            `[DiarizationHealth] [${meetingPlatform}] 🔄 Triggering fallback to UI-based diarization after ${this.consecutiveStaleCount} consecutive stale events`
           )
 
           // Stop network interception to prevent duplicate logs


### PR DESCRIPTION
Ticket **19961784714714** — Meet transcripts with every speaker `Unknown` and no diarization file. Bots `100f1753`, `ecdaa804` (broken) vs `1627db17` (identical setup 3 min later, worked).

## Root cause

Meet network-based speaker detection can come up "active" yet never emit a single speaker event for a given meeting (silent per-meeting failure — Meet-side variance). In that mode:

- No `network_interception_failed` track event is ever emitted, so the in-call fallback path (`in-call-state.ts:304`) never fires — it only reacted at cleanup, after the meeting ended.
- The only other rescue is the `DiarizationHealth` stale debounce in `RecordingState`: **10 consecutive stale events**, polled at most **every 5s**, and **only during sound activity** → ≥50 s of stale speech required before fallback.
- The affected meetings were ~60 s test calls: one stale event fired (`❌ Stale: No segments in last 5min despite sound activity` — our own monitor caught the failure live), then the meeting ended. Threshold mathematically unreachable → empty diarization → `speakers: null` → transcript `Unknown`.

## Fix

Split the stale modes:

| Mode | Evidence | Threshold |
|---|---|---|
| **Never produced any segment** | source is dead, not flapping | **2** stale events (~10 s of sound) → fall back to UI observer |
| Produced, then went quiet | normal silence / flap | unchanged 10-event debounce (that guard exists to avoid killing healthy network diarization, keep it) |

`DiarizationTracker.hasEverTrackedSegment()` (new) tells the modes apart. Fallback body unchanged — same guards (`meet` only, not already failed/triggered, page present).

## Testing
- `tsc --noEmit` clean.
- Failure-mode replay: with zero segments ever and sound activity, fallback now triggers at stale event 2 (~15-20 s into speech) instead of never — inside even a 60 s meeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)