### PR TITLE
Fix/cold start audio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,8 +147,8 @@ pactl set-default-sink virtual_speaker\n\
 pactl set-sink-volume virtual_speaker 100%\n\
 # 10ms latency offset gives PulseAudio buffer headroom against CPU\n\
 # contention (x264 CPA bursts) — recording doesn't need sub-ms latency.\n\
-pactl set-sink-latency-offset virtual_speaker 10000 2>/dev/null || true\n\
-pactl set-source-latency-offset virtual_speaker.monitor 10000 2>/dev/null || true\n\
+pactl set-sink-latency-offset virtual_speaker 10000 2>/dev/null || echo '[pulse] failed to set sink latency-offset — may be unsupported on this PulseAudio version' >&2\n\
+pactl set-source-latency-offset virtual_speaker.monitor 10000 2>/dev/null || echo '[pulse] failed to set source-monitor latency-offset — may be unsupported on this PulseAudio version' >&2\n\
 \n\
 # speex-float-3 balances quality and CPU (vs speex-float-10) — speech audio is\n\
 # not perceptibly different and the lower CPU leaves headroom for x264 encoding.\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ mkdir -p /etc/pulse\n\
 cat > /etc/pulse/daemon.conf <<PULSECONF\n\
 default-sample-rate = 48000\n\
 default-sample-format = s16le\n\
-default-fragments = 8\n\
+default-fragments = 12\n\
 default-fragment-size-msec = 10\n\
 resample-method = speex-float-3\n\
 PULSECONF\n\
@@ -145,8 +145,10 @@ pactl set-default-sink virtual_speaker\n\
 \n\
 # Optimize audio quality and latency\n\
 pactl set-sink-volume virtual_speaker 100%\n\
-pactl set-sink-latency-offset virtual_speaker 0 2>/dev/null || true\n\
-pactl set-source-latency-offset virtual_speaker.monitor 0 2>/dev/null || true\n\
+# 10ms latency offset gives PulseAudio buffer headroom against CPU\n\
+# contention (x264 CPA bursts) — recording doesn't need sub-ms latency.\n\
+pactl set-sink-latency-offset virtual_speaker 10000 2>/dev/null || true\n\
+pactl set-source-latency-offset virtual_speaker.monitor 10000 2>/dev/null || true\n\
 \n\
 # speex-float-3 balances quality and CPU (vs speex-float-10) — speech audio is\n\
 # not perceptibly different and the lower CPU leaves headroom for x264 encoding.\n\

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -272,7 +272,7 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
     // ========================================
     "--use-pulseaudio", // Force Chromium to use PulseAudio
     "--enable-audio-service-sandbox=false", // Disable audio service sandbox for virtual devices
-    "--audio-buffer-size=2048", // Set buffer size for better audio handling
+    "--audio-buffer-size=8192", // ~170ms at 48kHz — absorbs CPU contention xruns
     "--disable-features=AudioServiceSandbox", // Additional sandbox disable
     "--autoplay-policy=no-user-gesture-required", // Allow autoplay for meeting platforms
 

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -196,9 +196,12 @@ export class ScreenRecorder extends EventEmitter {
           VIRTUAL_SPEAKER,
           "-y"
         ], { stdio: "ignore", timeout: 5000 })
-        await new Promise<void>((resolve) => {
-          primeFfmpeg.on("close", () => resolve())
-          primeFfmpeg.on("error", () => resolve())
+        await new Promise<void>((resolve, reject) => {
+          primeFfmpeg.on("close", (code, signal) => {
+            if (code === 0 && !signal) return resolve()
+            reject(new Error(`ffmpeg prime exited code=${code} signal=${signal}`))
+          })
+          primeFfmpeg.on("error", (err) => reject(err))
         })
       } catch (_e) {
         // best-effort — recording still works even if priming fails

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -182,6 +182,21 @@ export class ScreenRecorder extends EventEmitter {
       // Wait for audio devices to be ready before starting FFmpeg
       await this.waitForAudioDevices()
 
+      // Prime the PulseAudio monitor buffer with a short silent burst so
+      // FFmpeg doesn't read an empty buffer on its first capture — a cold
+      // PulseAudio null-sink has zero samples buffered, causing an initial
+      // xrun/click at recording start (especially on new pods where the
+      // sink was just created and no audio has flowed yet).
+      try {
+        await execAsync(
+          `ffmpeg -f lavfi -i anullsrc=r=48000:cl=mono -t 0.3 -f pulse ${VIRTUAL_SPEAKER} -y 2>/dev/null`,
+          { timeout: 5000 }
+        )
+      } catch (_e) {
+        // best-effort — recording still works even if priming fails
+          console.warn("[ScreenRecorder] audio buffer priming failed — initial capture may have xrun", _e)
+      }
+
       const ffmpegArgs = this.buildNativeFFmpegArgs()
 
       this.ffmpegProcess = spawn("ffmpeg", ffmpegArgs, {

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -188,13 +188,21 @@ export class ScreenRecorder extends EventEmitter {
       // xrun/click at recording start (especially on new pods where the
       // sink was just created and no audio has flowed yet).
       try {
-        await execAsync(
-          `ffmpeg -f lavfi -i anullsrc=r=48000:cl=mono -t 0.3 -f pulse ${VIRTUAL_SPEAKER} -y 2>/dev/null`,
-          { timeout: 5000 }
-        )
+        const primeFfmpeg = spawn("ffmpeg", [
+          "-f", "lavfi",
+          "-i", "anullsrc=r=48000:cl=mono",
+          "-t", "0.3",
+          "-f", "pulse",
+          VIRTUAL_SPEAKER,
+          "-y"
+        ], { stdio: "ignore", timeout: 5000 })
+        await new Promise<void>((resolve) => {
+          primeFfmpeg.on("close", () => resolve())
+          primeFfmpeg.on("error", () => resolve())
+        })
       } catch (_e) {
         // best-effort — recording still works even if priming fails
-          console.warn("[ScreenRecorder] audio buffer priming failed — initial capture may have xrun", _e)
+        console.warn("[ScreenRecorder] audio buffer priming failed — initial capture may have xrun", _e)
       }
 
       const ffmpegArgs = this.buildNativeFFmpegArgs()


### PR DESCRIPTION
## Root Cause
On cold pods, FFmpeg connects to `virtual_speaker.monitor` before PulseAudio has buffered any audio data. The empty buffer produces an initial xrun → hard fill/trim at every timestamp discontinuity → clicks at the beginning of recordings. Under CPU contention (4 bots/node sharing 16 cores, all encoding x264), PulseAudio loses its scheduling timeslice periodically, producing random xruns → random clicks.

Second recording is better because the PulseAudio buffer is warm, Chromium JIT is compiled, and the CPU scheduler has established cgroup balances.

## Fixes
| Layer| What| Why|
|--------|--------|--------|
| FFmpeg| Queue 16384→32768 + rtbufsize 128k| 2× burst absorption for x264 CPA spikes. aresample=async=1000 (PR #243) softens residual xruns by stretching|
| PulseAudio| Fragments 8→12 (80→120ms) + latency–offset 0→10000us| Fragment ring absorbs CPU scheduling gaps, 10ms offset gives PulseAudio per-sink buffer headroom |
| Chromium | Audio buffer 2048→8192 (43→170ms)| use less audio-thread wake-ups/sec for only 24KB (not portable on FireFox) |
| App | 300ms silence prime before FFmpeg spawn | Eliminates the initial empty-buffer xrun. FFmpeg gets a populated monitor on first read | 