### PR TITLE
fix(privacy): audio_only bots no longer capture or upload any visual frames

### DIFF
--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -458,20 +458,29 @@ export class ScreenRecorder extends EventEmitter {
       "-avoid_negative_ts",
       "make_zero",
       "-y",
-      this.rawAudioPath,
+      this.rawAudioPath
+    )
 
-      // === OUTPUT 3: SCREENSHOTS (every 5 seconds) - fixed resolution ===
-      "-map",
-      "0:v:0",
-      "-vf",
-      `fps=${1 / SCREENSHOT_PERIOD},crop=${res.width}:${res.height}:0:140,scale=${SCREENSHOT_WIDTH}:${SCREENSHOT_HEIGHT}`,
-      "-q:v",
-      "3", // High quality JPEG compression
-      "-f",
-      "image2",
-      "-y",
-      screenshotPattern,
+    // === OUTPUT 3: SCREENSHOTS (every 5 seconds) - fixed resolution ===
+    // Compliance: audio_only customers explicitly opted out of visual capture —
+    // never write image frames for them (previously screenshots were captured
+    // AND uploaded in every mode; only the mp4 upload was skipped).
+    if (GLOBAL.get().recording_mode !== "audio_only") {
+      args.push(
+        "-map",
+        "0:v:0",
+        "-vf",
+        `fps=${1 / SCREENSHOT_PERIOD},crop=${res.width}:${res.height}:0:140,scale=${SCREENSHOT_WIDTH}:${SCREENSHOT_HEIGHT}`,
+        "-q:v",
+        "3", // High quality JPEG compression
+        "-f",
+        "image2",
+        "-y",
+        screenshotPattern
+      )
+    }
 
+    args.push(
       // === OUTPUT 4: SOUND LEVEL MONITORING (stdout) ===
       // This output is CRITICAL for automatic leave detection
       // It feeds the SoundLevelMonitor which is independent of streaming
@@ -1558,7 +1567,15 @@ export class ScreenRecorder extends EventEmitter {
     }
 
     // 7. Upload raw video for debugging (if enabled)
-    if (UPLOAD_RAW_VIDEO && fs.existsSync(rawVideoPath) && S3Uploader.getInstance()) {
+    // Compliance: never persist ANY video off-pod for audio_only bots — the
+    // customer opted out of visual capture; the raw frames exist only as a
+    // transient sync/duration reference and die with the pod.
+    if (
+      UPLOAD_RAW_VIDEO &&
+      GLOBAL.get().recording_mode !== "audio_only" &&
+      fs.existsSync(rawVideoPath) &&
+      S3Uploader.getInstance()
+    ) {
       try {
         const identifier = PathManager.getInstance().getIdentifier()
         const stats = fs.statSync(rawVideoPath)

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -227,6 +227,13 @@ export function setupConsoleLogger() {
 }
 
 export async function uploadScreenshotsToS3(): Promise<void> {
+  // Compliance belt-and-braces: audio_only bots no longer capture screenshots
+  // at all (ScreenRecorder skips the ffmpeg image output), but never upload
+  // any that might exist either — the customer opted out of visual capture.
+  if (GLOBAL.get().recording_mode === "audio_only") {
+    console.log("Skipping screenshot upload — audio_only mode (no visual capture)")
+    return
+  }
   const pathManager = PathManager.getInstance()
   const logPath = currentBotLogFile || pathManager.getIdentifier()
 


### PR DESCRIPTION
## Problem

`audio_only` customers explicitly opt out of video recording — but the bot still:

1. **Captured screenshots every 5 s** (ffmpeg `image2` output ran in every mode) **and uploaded all of them** to the artifacts bucket (`<uuid>/screenshots/`, up to ~800 JPEGs per hour-long meeting). Only the `output.mp4` upload was gated on recording mode.
2. **Uploaded the full raw meeting video** (`raw_video.mp4`) to the **logs bucket** whenever `UPLOAD_RAW_VIDEO` is on — which it is in prod — regardless of mode.

Both are compliance violations for audio-only recordings: full visual capture of a meeting whose participants were told only audio is recorded.

## Fix (applies to all platforms — Meet/Teams/Zoom-web share this recorder)

| Path | Change |
|---|---|
| `buildNativeFFmpegArgs` | Screenshot output **not built at all** for `audio_only` — image frames never touch disk |
| Finalize step 7 | `raw_video.mp4` never uploaded for `audio_only`, even with `UPLOAD_RAW_VIDEO` on |
| `uploadScreenshotsToS3` | Early-return on `audio_only` — belt-and-braces, also covers the crash-handler upload path |

## Reviewed and deliberately unchanged

- **Transient raw video in /tmp**: the merge/trim pipeline uses the x11grab stream for A/V sync + duration; it never leaves the pod and dies with it. Dropping x11grab entirely for audio_only (big CPU win too — x264 is the bot's main CPU draw) is a larger pipeline refactor — worth a follow-up ticket.
- **Fingerprint-probe screenshot**: pre-join Zoom anti-bot diagnostic (join wall page) — no meeting content.
- **HTML snapshots**: DOM text dumps, not imagery (do contain participant names — same as the transcript itself).

## Testing

- `tsc --noEmit` clean.
- Verify on preprod: run one `audio_only` bot + one `speaker_view` bot → audio_only: no `screenshots/` prefix in artifacts, no `raw_video.mp4` in logs bucket, `output.flac` + transcript delivered normally; speaker_view unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)