### PR TITLE
fix(audio): isolate bot mic from speaker monitor to stop meeting echo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,8 +164,24 @@ fi\n\
 # delivers 48 kHz and matches AUDIO_SAMPLE_RATE in ScreenRecorder.ts.\n\
 pactl load-module module-null-sink sink_name=virtual_speaker rate=48000 \\\n\
     sink_properties=device.description=Virtual_Speaker,device.class=sound\n\
-pactl load-module module-virtual-source source_name=virtual_mic\n\
+\n# Dedicated input sink for mic INJECTION. Its monitor is the master of the\n\
+# virtual_mic source, so audio written to virtual_mic_input becomes the bot's\n\
+# OUTGOING mic. Without this dedicated sink (and the explicit master= below),\n\
+# module-virtual-source defaults its master to the server default source —\n\
+# which is virtual_speaker.monitor (incoming meeting audio) — so a bot that\n\
+# grants microphone (streaming_input / talking bots) captures the meeting's\n\
+# own audio and echoes it back. Recording-only bots never granted the mic, so\n\
+# this loopback was latent until the audio-streaming path. (Ported from a\n\
+# downstream fork's live PulseAudio debugging.)\n\
+pactl load-module module-null-sink sink_name=virtual_mic_input rate=48000 \\\n\
+    sink_properties=device.description=Virtual_Mic_Input,device.class=sound\n\
+pactl load-module module-virtual-source source_name=virtual_mic \\\n\
+    master=virtual_mic_input.monitor\n\
 pactl set-default-sink virtual_speaker\n\
+\n# Make virtual_mic the default source so Chrome getUserMedia captures the\n\
+# isolated mic, not virtual_speaker.monitor (previously unset → defaulted to\n\
+# the speaker monitor = echo).\n\
+pactl set-default-source virtual_mic\n\
 \n\
 # Optimize audio quality and latency\n\
 pactl set-sink-volume virtual_speaker 100%\n\

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -25,6 +25,11 @@ export const envVars = cleanEnv(process.env, {
   DISPLAY: str({ default: ":99" }),
   VIRTUAL_SPEAKER_MONITOR: str({ default: "virtual_speaker.monitor" }),
   VIRTUAL_MIC: str({ default: "virtual_mic" }),
+  // Sink the bot WRITES injected/played mic audio into. Its monitor is the
+  // master of the VIRTUAL_MIC source, so this is the bot's outgoing-mic input —
+  // kept separate from VIRTUAL_MIC (which Chrome READS) to avoid the
+  // speaker→mic loopback. See the null-sink topology in the Dockerfile.
+  VIRTUAL_MIC_SINK: str({ default: "virtual_mic_input" }),
   VIRTUAL_SPEAKER: str({ default: "virtual_speaker" }),
   VIDEO_DEVICE: str({ default: "/dev/video10" }),
   EFS_MOUNT_POINT: str({ default: "/mnt/efs" }),

--- a/src/media_context.ts
+++ b/src/media_context.ts
@@ -4,8 +4,12 @@ import type internal from "stream"
 import { envVars } from "./config/env-vars"
 
 // sudo apt install linux-modules-extra-`uname -r`
-// The env variable VIRTUAL_MIC is used to set the virtual mic name. It needs to be prefixed with 'pulse:'
-const MICRO_DEVICE: string = `pulse:${envVars.VIRTUAL_MIC}` // pulseaudio virtual mic
+// Playback into the bot's outgoing mic targets the dedicated INPUT SINK
+// (VIRTUAL_MIC_SINK), whose monitor is the master of the VIRTUAL_MIC source
+// Chrome reads. Writing here — not to the VIRTUAL_MIC source name — keeps the
+// outgoing mic isolated from virtual_speaker (incoming meeting audio), so
+// streaming/talking bots don't echo the meeting back into itself.
+const MICRO_DEVICE: string = `pulse:${envVars.VIRTUAL_MIC_SINK}` // pulseaudio mic-injection sink
 const CAMERA_DEVICE: string = envVars.VIDEO_DEVICE
 
 // This abstract claas contains the current ffmpeg process


### PR DESCRIPTION
Ported from a full read of the one active downstream fork (`suren-pm/max-bot`, 107 commits ahead — they built an interactive/talking bot on our base and debugged this live with a `/diag/pulse` endpoint).

## The bug

The bot's outgoing mic was wired to incoming meeting audio, two ways:

1. `module-virtual-source virtual_mic` is created with **no `master=`**, so PulseAudio defaults its master to the server default source — which is `virtual_speaker.monitor` (the meeting's own audio).
2. We `set-default-sink virtual_speaker` but **never `set-default-source`**, so Chrome `getUserMedia` also defaults to `virtual_speaker.monitor`.

Either path: a bot that grants the microphone captures the meeting's audio as its own mic and **echoes it back into the call**.

## Scope / severity

Recording-only bots grant **camera only** (see `meet.ts openMeetingPage`), never the mic — so this is **latent** for the recording product and **active only on the audio-streaming / talking-bot path** (`streaming_input` set). No impact on existing recordings.

## Fix (topology from the fork, adapted to our env)

- Add a dedicated `virtual_mic_input` null-sink; make its monitor the `master=` of `virtual_mic` → only injected audio becomes the outgoing mic
- `set-default-source virtual_mic`
- Write played/injected mic audio to `virtual_mic_input` (new `VIRTUAL_MIC_SINK` env, default `virtual_mic_input`) instead of to the source name
- Recording capture (`virtual_speaker.monitor`) unchanged

## ⚠️ Verification required before merge (draft)

Changes prod audio routing — must run on preprod:
- one **streaming_input** bot → confirm no meeting echo + injected audio is audible to participants
- one **recording-only** bot → confirm recording + transcript unaffected

## Also found in the fork (not ported here)

- **Meet warm-up**: visit google.com to accumulate NID cookies before the Meet join, to reduce "You can't join this video call" denials — stack-independent, worth an opt-in A/B against our denied-entry rate (separate change).
- **Meet stealth negative result**: they found Meet *detects* the puppeteer-extra `iframe.contentWindow` and `media.codecs` evasions and serves the denial page. Informational for whoever tunes our cloakbrowser evasion set — not directly portable (cloakbrowser is a separate lib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)