### PR TITLE
feat: report Meet bot-detection telemetry to api-server

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -1,3 +1,6 @@
+import { envVars } from "../config/env-vars"
+import type { MeetBotDetectionSignal } from "../meeting/meet/network-interception"
+import { getProxyTelemetry } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
 import { getErrorMessageFromCode, type MeetingEndReason } from "../state-machine/types"
 import axios from "./axios-instance"
@@ -116,6 +119,58 @@ export class Api {
       )
       return false
     }
+  }
+
+  public reportMeetBotDetection(signal: MeetBotDetectionSignal, pageAttempt: number): void {
+    if (GLOBAL.isServerless()) {
+      console.log("[MeetBotDetection] Serverless mode, skipping telemetry")
+      return
+    }
+
+    const params = GLOBAL.get()
+    const proxy = getProxyTelemetry()
+    const runContext = {
+      stack: "cloakbrowser_playwright",
+      humanize: true,
+      resolution: envVars.RESOLUTION,
+      authenticated: Boolean(params.meet_sso_config),
+      meet_sso_session_id_present: Boolean(params.meet_sso_config?.session_id),
+      recording_mode: params.recording_mode,
+      bot_image_loop_mode: params.bot_image_config?.loop_mode ?? null,
+      streaming_input_enabled: Boolean(params.streaming_input),
+      network_interception_setup_failed: GLOBAL.hasNetworkInterceptionSetupFailed(),
+      proxy
+    }
+
+    axios({
+      method: "POST",
+      url: "/bot-process/meet-bot-detection",
+      timeout: 5000,
+      data: {
+        bot_id: params.bot_id,
+        bot_uuid: params.bot_uuid,
+        detected_as_bot: signal.detectedAsBot,
+        decoded: signal.decoded,
+        raw_field: signal.rawField == null ? null : String(signal.rawField),
+        detected_at: new Date(signal.timestamp).toISOString(),
+        source: "create_meeting_device_response",
+        retry_count: params.retry_count ?? 0,
+        page_attempt: pageAttempt,
+        proxy,
+        run_context: runContext
+      }
+    })
+      .then(() => {
+        console.log(
+          `[MeetBotDetection] Stored signal: detected=${signal.detectedAsBot}, decoded=${signal.decoded}, proxy_ip=${proxy.exit_ip ?? "none"}`
+        )
+      })
+      .catch((error) => {
+        console.warn(
+          "[MeetBotDetection] Failed to store signal (continuing):",
+          error instanceof Error ? error.message : error
+        )
+      })
   }
 
   // Handle end meeting with retry logic

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -134,10 +134,23 @@ export class MeetProvider implements MeetingProviderInterface {
       // redirect before waiting for that heavy page to reach networkidle (~20-30s).
       // For unauthenticated bots: networkidle as before.
       const isSsoBot = !!GLOBAL.get().meet_sso_config
-      const response = await page.goto(link, {
-        waitUntil: isSsoBot ? "domcontentloaded" : "networkidle",
-        timeout: 30000
-      })
+      let response: Awaited<ReturnType<typeof page.goto>> = null
+      try {
+        response = await page.goto(link, {
+          waitUntil: isSsoBot ? "domcontentloaded" : "networkidle",
+          timeout: 30000
+        })
+      } catch (navError) {
+        // page.goto rejects on timeout / nav failure. For SSO bots fall through
+        // to the in-process retry loop below (which re-navigates up to 3×)
+        // instead of aborting the whole join to a full SQS requeue. Non-SSO
+        // bots keep the original behavior: rethrow → outer retryable handler.
+        if (!isSsoBot) throw navError
+        console.warn(
+          "[Meet][SSO] initial navigation failed (SSO retry loop will re-navigate):",
+          formatError(navError)
+        )
+      }
       console.log("Navigation completed")
 
       // Catch transient Google edge failures (503/502/504): the page resolves with

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -1,4 +1,5 @@
 import type { BrowserContext, Page } from "@playwright/test"
+import { Api } from "../api/methods"
 import { brandingReady } from "../branding"
 import { listenPage } from "../browser/page-logger"
 import { SimpleDialogObserver } from "../services/dialog-observer/simple-dialog-observer"
@@ -106,7 +107,9 @@ export class MeetProvider implements MeetingProviderInterface {
         // CreateMeetingDevice RPC). Must be installed before page.goto so the
         // response listener is in place when the join handshake fires.
         await setupBotDetectionRoute(page, (signal) => {
-          if (signal.detectedAsBot) {
+          if (!signal.decoded) {
+            console.warn("[Meet] ⚠️ Meet bot-detection response could not be decoded")
+          } else if (signal.detectedAsBot) {
             console.error(
               `[Meet] 🚨 Meet flagged this bot — detectedAsBot=${signal.detectedAsBot} (raw field 36 = ${signal.rawField})`
             )
@@ -115,6 +118,7 @@ export class MeetProvider implements MeetingProviderInterface {
               `[Meet] ✅ Meet did NOT flag this bot — detectedAsBot=${signal.detectedAsBot} (raw field 36 = ${signal.rawField})`
             )
           }
+          Api.instance?.reportMeetBotDetection(signal, attempts)
         })
       } catch (error) {
         console.warn(
@@ -153,11 +157,13 @@ export class MeetProvider implements MeetingProviderInterface {
         for (let attempt = 1; attempt <= 3; attempt++) {
           const landedUrl = page.url()
           if (landedUrl.includes("meet.google.com")) break
-          console.log(`[Meet][SSO] Landed on ${landedUrl} — navigating to meeting URL (attempt ${attempt}/3)`)
+          console.log(
+            `[Meet][SSO] Landed on ${landedUrl} — navigating to meeting URL (attempt ${attempt}/3)`
+          )
           await page.goto(link, { waitUntil: "domcontentloaded", timeout: 20_000 })
         }
         // Settled on Meet — wait for the page to fully load.
-        await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => { })
+        await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {})
       }
 
       // Check for page freeze after goto (same as Teams)
@@ -381,10 +387,7 @@ export class MeetProvider implements MeetingProviderInterface {
     }
   }
 
-  async findEndMeeting(
-    page: Page,
-    opts?: { ignoreAloneSignals?: boolean }
-  ): Promise<boolean> {
+  async findEndMeeting(page: Page, opts?: { ignoreAloneSignals?: boolean }): Promise<boolean> {
     try {
       try {
         await Promise.race([

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -160,7 +160,17 @@ export class MeetProvider implements MeetingProviderInterface {
           console.log(
             `[Meet][SSO] Landed on ${landedUrl} — navigating to meeting URL (attempt ${attempt}/3)`
           )
-          await page.goto(link, { waitUntil: "domcontentloaded", timeout: 20_000 })
+          try {
+            await page.goto(link, { waitUntil: "domcontentloaded", timeout: 20_000 })
+          } catch (navError) {
+            // page.goto rejects on timeout / navigation failure. Don't let a
+            // single failed attempt abort the whole SSO landing sequence — log
+            // and keep trying; a later attempt often lands on meet.google.com.
+            console.warn(
+              `[Meet][SSO] navigation attempt ${attempt}/3 failed (continuing):`,
+              formatError(navError)
+            )
+          }
         }
       }
 

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -162,8 +162,6 @@ export class MeetProvider implements MeetingProviderInterface {
           )
           await page.goto(link, { waitUntil: "domcontentloaded", timeout: 20_000 })
         }
-        // Settled on Meet — wait for the page to fully load.
-        await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {})
       }
 
       // Check for page freeze after goto (same as Teams)

--- a/src/meeting/meet/network-interception/index.ts
+++ b/src/meeting/meet/network-interception/index.ts
@@ -25,6 +25,7 @@ import type { ChatMessage, NetworkPayload } from "./types"
 // the bot as suspected.
 export type MeetBotDetectionSignal = {
   detectedAsBot: boolean
+  decoded: boolean
   rawField: number | string | null
   timestamp: number
 }
@@ -191,10 +192,11 @@ export async function setupBotDetectionRoute(
       const text = await response.text()
       // Response body is base64-encoded protobuf.
       const bytes = Uint8Array.from(Buffer.from(text, "base64"))
-      const raw = decodeDetectedAsBotField(bytes)
+      const decoded = decodeDetectedAsBotField(bytes)
       onSignal({
-        detectedAsBot: Boolean(raw),
-        rawField: raw,
+        detectedAsBot: decoded.decoded && Boolean(decoded.rawField),
+        decoded: decoded.decoded,
+        rawField: decoded.rawField,
         timestamp: Date.now()
       })
     } catch (err) {
@@ -208,14 +210,17 @@ export async function setupBotDetectionRoute(
   return true
 }
 
-function decodeDetectedAsBotField(bytes: Uint8Array): number | null {
+function decodeDetectedAsBotField(bytes: Uint8Array): {
+  decoded: boolean
+  rawField: number | null
+} {
   try {
     const msg = CreateMeetingDeviceResponseType.decode(bytes) as unknown as {
       detectedAsBot?: number
     }
-    return msg.detectedAsBot ?? null
+    return { decoded: true, rawField: msg.detectedAsBot ?? null }
   } catch {
-    return null
+    return { decoded: false, rawField: null }
   }
 }
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -85,16 +85,22 @@ export function markProxyDisabledReason(reason: string): void {
 
 export function getProxyTelemetry(): ProxyTelemetry {
   const configured = Boolean(envVars.RESIDENTIAL_PROXY_TEMPLATE)
+  // Report UPSTREAM routing state, not local-server existence. The local proxy
+  // server stays alive after setDirectMode() (useUpstream=false) so it can be
+  // flipped back on — but while direct, traffic does NOT go through the exit,
+  // so enabled/mode/exit_* must reflect useUpstream or the detection telemetry
+  // records a proxied join that was actually direct.
+  const upstreamEnabled = server !== null && useUpstream
   return {
-    enabled: server !== null,
-    mode: server !== null ? "selective" : "none",
+    enabled: upstreamEnabled,
+    mode: upstreamEnabled ? "selective" : "none",
     provider: configured ? inferProxyProvider() : null,
     type: configured ? "residential" : null,
-    exit_ip: server !== null ? exitIp : null,
-    exit_country: server !== null ? (exitGeo?.country ?? null) : null,
-    exit_timezone: server !== null ? (exitGeo?.timezone ?? null) : null,
+    exit_ip: upstreamEnabled ? exitIp : null,
+    exit_country: upstreamEnabled ? (exitGeo?.country ?? null) : null,
+    exit_timezone: upstreamEnabled ? (exitGeo?.timezone ?? null) : null,
     session_id: currentSessionId,
-    disabled_reason: server === null ? proxyDisabledReason : null
+    disabled_reason: upstreamEnabled ? null : proxyDisabledReason
   }
 }
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -5,8 +5,8 @@ import axios from "axios"
 // the codebase moves to moduleResolution: "bundler" or "node16".
 // @ts-expect-error - see comment above; remove this once tsconfig moves on.
 import { HttpsProxyAgent } from "https-proxy-agent"
-import { Server } from "proxy-chain"
 import type { ConnectionStats } from "proxy-chain"
+import { Server } from "proxy-chain"
 import { envVars } from "../config/env-vars"
 
 // Allowlist of hosts that route through the residential upstream. Everything
@@ -55,14 +55,57 @@ let server: Server | null = null
 // window. setDirectMode() flips it off post-admission.
 let useUpstream = true
 let exitIp: string | null = null
+let currentSessionId: string | null = null
+let proxyDisabledReason: string | null = null
 // Country code + IANA timezone of the current exit IP (set by logExitIp), so the
 // browser can align its locale/timezone with the proxied egress geo instead of a
 // hardcoded en-US/UTC. Null until the exit-IP probe runs.
 let exitGeo: { country: string | null; timezone: string | null } | null = null
 
+export type ProxyTelemetry = {
+  enabled: boolean
+  mode: "selective" | "none"
+  provider: string | null
+  type: "residential" | null
+  exit_ip: string | null
+  exit_country: string | null
+  exit_timezone: string | null
+  session_id: string | null
+  disabled_reason: string | null
+}
+
 /** Country code + IANA timezone of the current exit IP, or null until probed. */
 export function getExitGeo(): { country: string | null; timezone: string | null } | null {
   return exitGeo
+}
+
+export function markProxyDisabledReason(reason: string): void {
+  proxyDisabledReason = reason
+}
+
+export function getProxyTelemetry(): ProxyTelemetry {
+  const configured = Boolean(envVars.RESIDENTIAL_PROXY_TEMPLATE)
+  return {
+    enabled: server !== null,
+    mode: server !== null ? "selective" : "none",
+    provider: configured ? inferProxyProvider() : null,
+    type: configured ? "residential" : null,
+    exit_ip: server !== null ? exitIp : null,
+    exit_country: server !== null ? (exitGeo?.country ?? null) : null,
+    exit_timezone: server !== null ? (exitGeo?.timezone ?? null) : null,
+    session_id: currentSessionId,
+    disabled_reason: server === null ? proxyDisabledReason : null
+  }
+}
+
+function inferProxyProvider(): string {
+  try {
+    const host = new URL(envVars.RESIDENTIAL_PROXY_TEMPLATE).hostname
+    if (host.includes("decodo")) return "decodo"
+    return "unknown"
+  } catch {
+    return "unknown"
+  }
 }
 
 // Set of connectionIds that were routed through the residential upstream.
@@ -120,6 +163,8 @@ export async function startToggleProxy(
   sessionSuffix = ""
 ): Promise<string | null> {
   if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
+    currentSessionId = null
+    proxyDisabledReason = "template_missing"
     console.log("[ToggleProxy] No RESIDENTIAL_PROXY_TEMPLATE configured, skipping proxy")
     return null
   }
@@ -129,6 +174,9 @@ export async function startToggleProxy(
   // in-process retry within the SAME pod without touching retry_count.
   const session = `${sessionId.replace(/-/g, "")}${retryCount}${sessionSuffix}`
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
+  currentSessionId = session
+  proxyDisabledReason = null
+  useUpstream = true
 
   // Reset stats, proxied-connection tracking, and exit IP for this new session
   stats.trgTxBytes = 0
@@ -164,13 +212,16 @@ export async function startToggleProxy(
     // The local proxy server must stay running after joining (Chrome was launched
     // with --proxy-server pointing here), but setDirectMode() stops routing through
     // the upstream residential proxy — so stats at that point reflect residential usage.
-    server.on("connectionClosed", ({ connectionId, stats: cs }: { connectionId: number; stats: ConnectionStats }) => {
-      if (!proxiedConnectionIds.has(connectionId)) return
-      proxiedConnectionIds.delete(connectionId)
-      stats.connectionCount++
-      stats.trgTxBytes += cs.trgTxBytes ?? 0
-      stats.trgRxBytes += cs.trgRxBytes ?? 0
-    })
+    server.on(
+      "connectionClosed",
+      ({ connectionId, stats: cs }: { connectionId: number; stats: ConnectionStats }) => {
+        if (!proxiedConnectionIds.has(connectionId)) return
+        proxiedConnectionIds.delete(connectionId)
+        stats.connectionCount++
+        stats.trgTxBytes += cs.trgTxBytes ?? 0
+        stats.trgRxBytes += cs.trgRxBytes ?? 0
+      }
+    )
 
     await server.listen()
     const port = server.port
@@ -180,8 +231,9 @@ export async function startToggleProxy(
     // down, etc.), tear down and let the bot run direct.
     const upstreamOk = await logExitIp(upstreamUrl)
     if (!upstreamOk) {
-      await server.close(true).catch(() => { })
+      await server.close(true).catch(() => {})
       server = null
+      proxyDisabledReason = "upstream_unreachable"
       return null
     }
     return proxyUrl
@@ -190,6 +242,7 @@ export async function startToggleProxy(
       `[ToggleProxy] ❌ Failed to start, proceeding without proxy: ${error instanceof Error ? error.message : String(error)}`
     )
     server = null
+    proxyDisabledReason = "start_failed"
     return null
   }
 }
@@ -218,12 +271,12 @@ async function logExitIp(upstreamProxyUrl: string): Promise<boolean> {
       timeout: 5000
     })
     const d = res.data
-    const ip = d.proxy?.ip ?? "unknown"
+    const ip = d.proxy?.ip ?? null
     exitIp = ip
     exitGeo = { country: d.country?.code ?? null, timezone: d.city?.time_zone ?? null }
     const geo = `${d.country?.code ?? "?"}/${d.city?.name ?? "?"}`
     const isp = `${d.isp?.isp ?? "?"} (AS${d.isp?.asn ?? "?"})`
-    console.log(`[ToggleProxy] 🌍 Exit IP: ${ip} | ${geo} | ${isp}`)
+    console.log(`[ToggleProxy] 🌍 Exit IP: ${ip ?? "unknown"} | ${geo} | ${isp}`)
     return true
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)


### PR DESCRIPTION
Bot half of the Meet detection dashboard (api-server side = meeting-baas-v2 **#311**, on preprod). Rebased onto current `v2-improvements` — supersedes #195.

Today the `detectedAsBot` signal from Meet's `CreateMeetingDevice` RPC is only logged. This POSTs it to the api-server so it's stored and shown in-product.

## What it does
- `api/methods.ts`: POST `/bot-process/meet-bot-detection` with the signal + proxy context (exit IP / session / country) for the per-team/per-user/per-proxy breakdowns
- `meet.ts`: wire the existing bot-detection callback to send it
- `network-interception/index.ts`: surface decoded/raw field + source
- `toggle-proxy.ts`: capture the proxy exit metadata that rides along

## Rebase note
`v2-improvements` refactored browser setup into `establishBrowserSession`; the old telemetry commit still patched the pre-refactor inline proxy block in `initialization-state.ts`. Resolved by taking the `establishBrowserSession` path — the proxy telemetry still runs because `establishBrowserSession` calls `startToggleProxy` (where the capture now lives). `tsc` clean.

## Sequencing
Merge #311 (storage + admin API) first or together; this is what populates the table. Frontend admin panel is a separate PR on `preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)