### PR TITLE
feat(proxy): capture exit ASN + avoid burned Meet networks

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -5,6 +5,26 @@ import { GLOBAL } from "../singleton"
 import { getErrorMessageFromCode, type MeetingEndReason } from "../state-machine/types"
 import axios from "./axios-instance"
 
+/**
+ * Fetch the set of Google-Meet-"burned" exit ASNs (high flagged rate) from the
+ * api-server. Used by the pre-join proxy rotation to avoid landing on a burned
+ * network. Fail-soft: any error returns [] (avoid nothing) rather than blocking
+ * the join.
+ */
+export async function fetchBurnedAsns(): Promise<number[]> {
+  try {
+    const resp = await axios.get("/bot-process/meet-burned-asns", { timeout: 5000 })
+    const asns = (resp.data as { data?: { asns?: unknown } })?.data?.asns
+    return Array.isArray(asns) ? asns.filter((n): n is number => typeof n === "number") : []
+  } catch (error) {
+    console.warn(
+      "[BurnedAsns] fetch failed (avoiding nothing):",
+      error instanceof Error ? error.message : error
+    )
+    return []
+  }
+}
+
 export class Api {
   public static instance: Api | null = null // Singleton class
 

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process"
 import type { BrowserContext } from "@playwright/test"
-import { startToggleProxy, stopToggleProxy } from "../proxy/toggle-proxy"
+import { fetchBurnedAsns } from "../api/methods"
+import { getExitAsn, startToggleProxy, stopToggleProxy } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
 import { MAX_RETRY_COUNT } from "../config/retry-config"
 import { formatError } from "../utils/Logger"
@@ -66,6 +67,32 @@ export async function establishBrowserSession(
         opts.sessionSuffix
       )
       if (proxyUrl) session.proxyUrl = proxyUrl
+
+      // Burned-ASN avoidance (Meet only). startToggleProxy already probed the
+      // exit IP + ASN. If we landed on a network Google is currently flagging,
+      // rotate the Decodo session to a fresh IP BEFORE spending a browser launch
+      // + join on it — cheap because we're still pre-launch. Bounded; fail-soft
+      // (an empty burned list or exhausted rotations just proceeds).
+      if (session.proxyUrl && platform === "meet") {
+        const burned = await fetchBurnedAsns()
+        if (burned.length > 0) {
+          const MAX_ASN_ROTATIONS = 3
+          for (let rot = 1; rot <= MAX_ASN_ROTATIONS; rot++) {
+            const asn = getExitAsn()
+            if (asn === null || !burned.includes(asn)) break
+            console.warn(
+              `[BrowserSession] exit ASN ${asn} is burned on Meet — rotating Decodo session (${rot}/${MAX_ASN_ROTATIONS})`
+            )
+            const rotated = await startToggleProxy(
+              GLOBAL.get().bot_uuid,
+              retryCount,
+              `${opts.sessionSuffix ?? ""}r${rot}`
+            )
+            if (!rotated) break
+            session.proxyUrl = rotated
+          }
+        }
+      }
     }
   }
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -61,6 +61,9 @@ let proxyDisabledReason: string | null = null
 // browser can align its locale/timezone with the proxied egress geo instead of a
 // hardcoded en-US/UTC. Null until the exit-IP probe runs.
 let exitGeo: { country: string | null; timezone: string | null } | null = null
+// ASN of the current exit IP (set by logExitIp). The burned-network unit —
+// residential IPs rarely repeat but ASNs do. Null until the probe runs.
+let exitAsn: number | null = null
 
 export type ProxyTelemetry = {
   enabled: boolean
@@ -68,6 +71,7 @@ export type ProxyTelemetry = {
   provider: string | null
   type: "residential" | null
   exit_ip: string | null
+  exit_asn: number | null
   exit_country: string | null
   exit_timezone: string | null
   session_id: string | null
@@ -77,6 +81,11 @@ export type ProxyTelemetry = {
 /** Country code + IANA timezone of the current exit IP, or null until probed. */
 export function getExitGeo(): { country: string | null; timezone: string | null } | null {
   return exitGeo
+}
+
+/** ASN of the current exit IP, or null until the exit-IP probe runs. */
+export function getExitAsn(): number | null {
+  return exitAsn
 }
 
 export function markProxyDisabledReason(reason: string): void {
@@ -97,6 +106,7 @@ export function getProxyTelemetry(): ProxyTelemetry {
     provider: configured ? inferProxyProvider() : null,
     type: configured ? "residential" : null,
     exit_ip: upstreamEnabled ? exitIp : null,
+    exit_asn: upstreamEnabled ? exitAsn : null,
     exit_country: upstreamEnabled ? (exitGeo?.country ?? null) : null,
     exit_timezone: upstreamEnabled ? (exitGeo?.timezone ?? null) : null,
     session_id: currentSessionId,
@@ -190,6 +200,7 @@ export async function startToggleProxy(
   stats.connectionCount = 0
   proxiedConnectionIds.clear()
   exitIp = null
+  exitAsn = null
   exitGeo = null
 
   try {
@@ -279,6 +290,7 @@ async function logExitIp(upstreamProxyUrl: string): Promise<boolean> {
     const d = res.data
     const ip = d.proxy?.ip ?? null
     exitIp = ip
+    exitAsn = d.isp?.asn ?? null
     exitGeo = { country: d.country?.code ?? null, timezone: d.city?.time_zone ?? null }
     const geo = `${d.country?.code ?? "?"}/${d.city?.name ?? "?"}`
     const isp = `${d.isp?.isp ?? "?"} (AS${d.isp?.asn ?? "?"})`


### PR DESCRIPTION
Follow-up to #252 (merged before this ASN work was pushed) — carries the delta.

- toggle-proxy: capture exit-IP ASN in the pre-join probe, expose `getExitAsn()`, include `exit_asn` in `getProxyTelemetry` (detection signal now carries it)
- burned-ASN avoidance (Meet only): after the proxy probe, fetch the api-server burned-ASN set and, if we landed on a flagged network, rotate the Decodo session to a fresh IP before launching the browser — up to 3 rotations, all pre-launch (cheap). Fail-soft.

Rotate-until-clean (Decodo can't target a known-good IP), keyed on ASN not exact IP. Pairs with the api-server ASN PR. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)