### PR TITLE
feat(proxy): geo-pin residential exit by country (Decodo {GEO} param)

### DIFF
--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -56,6 +56,11 @@ export const envVars = cleanEnv(process.env, {
   //   http://user-<USER>-continent-eu-session-{SESSION}:<PASS>@gate.decodo.com:7000
   // Leave empty to disable residential proxy.
   RESIDENTIAL_PROXY_TEMPLATE: str({ default: "" }),
+  // Optional ISO-3166 alpha-2 country to pin the residential exit to (e.g.
+  // "us"). Injected into the Decodo username at the {GEO} placeholder as
+  // `-country-<cc>`. Empty = no pinning (current behaviour). A per-bot region
+  // (set by the user in settings) overrides this default when present.
+  RESIDENTIAL_PROXY_COUNTRY: str({ default: "" }),
   // Read-only diagnostic gate. When true, the fingerprint probe dumps the
   // runtime navigator / WebGL / font-list / geometry the page's JS actually
   // sees (into html_snapshots/, uploaded to the log bucket) so we can measure

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -8,6 +8,7 @@ import { HttpsProxyAgent } from "https-proxy-agent"
 import type { ConnectionStats } from "proxy-chain"
 import { Server } from "proxy-chain"
 import { envVars } from "../config/env-vars"
+import { GLOBAL } from "../singleton"
 
 // Allowlist of hosts that route through the residential upstream. Everything
 // else goes direct from the pod IP. Default-direct is intentional: if Google
@@ -104,6 +105,18 @@ export function getProxyTelemetry(): ProxyTelemetry {
   }
 }
 
+/**
+ * Country to pin the residential exit to. Per-bot region (set by the user in
+ * settings) takes precedence over the RESIDENTIAL_PROXY_COUNTRY env default.
+ * Returns "" for no pinning. The per-bot value is fed via GLOBAL once the
+ * settings field ships; until then this resolves to the env default.
+ */
+function resolveProxyCountry(): string {
+  const perBot = GLOBAL.get().proxy_country
+  if (typeof perBot === "string" && perBot.trim()) return perBot.trim()
+  return envVars.RESIDENTIAL_PROXY_COUNTRY
+}
+
 function inferProxyProvider(): string {
   try {
     const host = new URL(envVars.RESIDENTIAL_PROXY_TEMPLATE).hostname
@@ -179,7 +192,26 @@ export async function startToggleProxy(
   // residential IP; sessionSuffix (e.g. "x1") advances the IP again for an
   // in-process retry within the SAME pod without touching retry_count.
   const session = `${sessionId.replace(/-/g, "")}${retryCount}${sessionSuffix}`
-  const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session)
+
+  // Optional geo pinning. Decodo username params are dash-appended and go
+  // BEFORE `-session-`, so the template must carry a `{GEO}` placeholder there
+  // (e.g. `user-<u>{GEO}-session-{SESSION}`). Resolve the country from the
+  // per-bot region the user picked in settings, falling back to the env
+  // default; empty → no pinning (backward compatible). Only alpha-2 letters
+  // are accepted so a bad value can't corrupt the auth string.
+  const rawCountry = resolveProxyCountry()
+  const country = /^[a-z]{2}$/i.test(rawCountry) ? rawCountry.toLowerCase() : ""
+  const geoParam = country ? `-country-${country}` : ""
+  if (country && !envVars.RESIDENTIAL_PROXY_TEMPLATE.includes("{GEO}")) {
+    console.warn(
+      `[ToggleProxy] country=${country} requested but template has no {GEO} placeholder — proceeding without geo pinning`
+    )
+  }
+  const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session).replaceAll(
+    "{GEO}",
+    geoParam
+  )
+  if (country) console.log(`[ToggleProxy] 🌍 Pinning residential exit to country: ${country}`)
   currentSessionId = session
   proxyDisabledReason = null
   useUpstream = true

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -56,6 +56,11 @@ export const BotMessageSchema = object({
   speech_to_text_provider: SpeechToTextProviderSchema.default("none"),
   retry_count: number().int().nonnegative().default(0),
 
+  // Optional ISO-3166 alpha-2 country to pin the residential proxy exit to,
+  // chosen by the user in settings (api-server passes it through). Overrides the
+  // RESIDENTIAL_PROXY_COUNTRY env default; null/absent = no per-bot pinning.
+  proxy_country: optional(nullable(string())).default(null),
+
   // Meet SSO authenticated bot config — present when api-server assigned a meet_login.
   // Bot uses these to sign in to Google before joining the meeting.
   meet_sso_config: optional(


### PR DESCRIPTION
Adds optional **country pinning** for the Decodo residential exit — the foundation for consistent geo and the user-facing region picker.

## How
Decodo username params are dash-appended and go before `-session-`, so the template carries a `{GEO}` placeholder (e.g. `user-<u>{GEO}-session-{SESSION}`) that we fill with `-country-<cc>` when a country is set.

Resolution order: per-bot `proxy_country` (user setting, passed through by api-server) → `RESIDENTIAL_PROXY_COUNTRY` env default → none. Alpha-2 validated so a bad value can't corrupt the auth string.

## Backward compatible
No `{GEO}` in the template / no country → **current behaviour unchanged**. If a country is requested but the template lacks `{GEO}`, it logs a warning and proceeds without pinning.

## Activation (ops, separate)
- add `{GEO}` to the `RESIDENTIAL_PROXY_TEMPLATE` secret
- confirm Decodo country coverage on our **ISP** plan (`isp.decodo.com` — narrower geo than the rotating residential gateway)

## Notes
- `proxy_country` added to the bot message schema (optional/nullable) so api-server can pass a user-picked region through. The settings UI + api-server field are the next PRs.
- Independent of the ASN work (#253); different code paths.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)