### PR TITLE
feat(metrics): add bot resource metrics reporting

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -194,8 +194,8 @@ export class Api {
       })
   }
 
-  public reportMetrics(payload: BotMetricsPayload): void {
-    axios({
+  public async reportMetrics(payload: BotMetricsPayload): Promise<void> {
+    await axios({
       method: "POST",
       url: "/bot-process/metrics",
       data: payload,

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -3,6 +3,7 @@ import type { MeetBotDetectionSignal } from "../meeting/meet/network-interceptio
 import { getProxyTelemetry } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
 import { getErrorMessageFromCode, type MeetingEndReason } from "../state-machine/types"
+import type { BotMetricsPayload } from "../services/metrics-collector"
 import axios from "./axios-instance"
 
 /**
@@ -191,6 +192,18 @@ export class Api {
           error instanceof Error ? error.message : error
         )
       })
+  }
+
+  public reportMetrics(payload: BotMetricsPayload): void {
+    axios({
+      method: "POST",
+      url: "/bot-process/metrics",
+      data: payload,
+      "axios-retry": { retries: 0 },
+      timeout: 5000
+    }).catch((error) => {
+      console.warn("Failed to report bot metrics (continuing):", error.message)
+    })
   }
 
   // Handle end meeting with retry logic

--- a/src/main.ts
+++ b/src/main.ts
@@ -339,6 +339,16 @@ async function handleFailedRecording(): Promise<void> {
       } catch (error) {
         console.error("Failed to upload logs to S3:", formatError(error))
       }
+
+      try {
+        const collector = GLOBAL.getMetricsCollector()
+        if (collector.isRunning() && Api.instance) {
+          collector.stop()
+          Api.instance.reportMetrics(collector.getPayload())
+        }
+      } catch {
+        // metrics report is best-effort, never block exit
+      }
     }
     console.log("exiting instance")
     exit(0)

--- a/src/main.ts
+++ b/src/main.ts
@@ -344,7 +344,13 @@ async function handleFailedRecording(): Promise<void> {
         const collector = GLOBAL.getMetricsCollector()
         if (collector.isRunning() && Api.instance) {
           collector.stop()
-          Api.instance.reportMetrics(collector.getPayload())
+          const payload = collector.getPayload()
+          await Promise.race([
+            Api.instance.reportMetrics(payload),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("metrics shutdown timeout")), 3000)
+            )
+          ]).catch(() => {})
         }
       } catch {
         // metrics report is best-effort, never block exit

--- a/src/services/metrics-collector.ts
+++ b/src/services/metrics-collector.ts
@@ -1,0 +1,106 @@
+import { envVars } from "../config/env-vars"
+import { GLOBAL } from "../singleton"
+
+export interface BotMetricsPayload {
+  bot_id: number
+  bot_uuid: string
+  platform: "meet" | "teams" | "zoom"
+  bot_type: "meet-teams"
+  config: {
+    resolution: "720" | "1080"
+    recording_mode: "speaker_view" | "gallery_view" | "audio_only"
+  }
+  duration: {
+    total_sec: number
+    recording_sec: number
+    idle_sec: number
+  }
+  resources: {
+    cpu_total_sec: number
+    mem_rss_start_mb: number
+    mem_rss_end_mb: number
+    mem_heap_start_mb: number
+    mem_heap_end_mb: number
+  }
+  meeting_info: {
+    participant_count: number
+    speaker_count: number
+  }
+}
+
+export class MetricsCollector {
+  private cpuStart: NodeJS.CpuUsage | null = null
+  private memRssStartMb = 0
+  private memHeapStartMb = 0
+  private recordingStartTime = 0
+  private cpuDeltaSec = 0
+  private memRssEndMb = 0
+  private memHeapEndMb = 0
+  private stopped = false
+
+  start(): void {
+    const mem = process.memoryUsage()
+    this.cpuStart = process.cpuUsage()
+    this.memRssStartMb = Math.round(mem.rss / 1024 / 1024)
+    this.memHeapStartMb = Math.round(mem.heapUsed / 1024 / 1024)
+    this.recordingStartTime = Date.now()
+    this.stopped = false
+  }
+
+  stop(): void {
+    const cpuEnd = process.cpuUsage(this.cpuStart ?? undefined)
+    const mem = process.memoryUsage()
+    this.cpuDeltaSec = (cpuEnd.user + cpuEnd.system) / 1e6
+    this.memRssEndMb = Math.round(mem.rss / 1024 / 1024)
+    this.memHeapEndMb = Math.round(mem.heapUsed / 1024 / 1024)
+    this.stopped = true
+  }
+
+  isRunning(): boolean {
+    return !this.stopped && this.cpuStart !== null
+  }
+
+  getPayload(): BotMetricsPayload {
+    if (!this.stopped) {
+      this.stop()
+    }
+
+    const startTime = GLOBAL.get().start_time
+    const exitTime = GLOBAL.get().exit_time || Math.floor(Date.now() / 1000)
+    const totalSec = Math.max(0, exitTime - startTime)
+    const recordingSec = Math.max(0, (Date.now() - this.recordingStartTime) / 1000)
+    const idleSec = Math.max(0, totalSec - recordingSec)
+
+    const platform = GLOBAL.get().meeting_platform
+
+    return {
+      bot_id: GLOBAL.get().bot_id,
+      bot_uuid: GLOBAL.get().bot_uuid,
+      platform: (platform === "zoom" ? "zoom" : platform) as "meet" | "teams" | "zoom",
+      bot_type: "meet-teams",
+      config: {
+        resolution: envVars.RESOLUTION as "720" | "1080",
+        recording_mode: GLOBAL.get().recording_mode as
+          | "speaker_view"
+          | "gallery_view"
+          | "audio_only"
+      },
+      duration: {
+        total_sec: totalSec,
+        recording_sec: recordingSec,
+        idle_sec: idleSec
+      },
+      resources: {
+        cpu_total_sec: this.cpuDeltaSec,
+        mem_rss_start_mb: this.memRssStartMb,
+        mem_rss_end_mb: this.memRssEndMb,
+        mem_heap_start_mb: this.memHeapStartMb,
+        mem_heap_end_mb: this.memHeapEndMb
+      },
+      meeting_info: {
+        participant_count: GLOBAL.getParticipants().length,
+        speaker_count: GLOBAL.getSpeakers().length
+      }
+    }
+  }
+}

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -1,4 +1,5 @@
 import { envVars } from "./config/env-vars"
+import { MetricsCollector } from "./services/metrics-collector"
 import { NORMAL_END_REASONS } from "./state-machine/constants"
 import { getErrorMessageFromCode, MeetingEndReason } from "./state-machine/types"
 import type { ArtifactKey, MeetingParams, Participant, RecordingMode } from "./types"
@@ -393,6 +394,15 @@ class Global {
    */
   public hasDiarizationFallbackTriggered(): boolean {
     return this.hasTriggeredDiarizationFallback
+  }
+
+  private metricsCollector: MetricsCollector | null = null
+
+  public getMetricsCollector(): MetricsCollector {
+    if (!this.metricsCollector) {
+      this.metricsCollector = new MetricsCollector()
+    }
+    return this.metricsCollector
   }
 }
 

--- a/src/state-machine/states/cleanup-state.ts
+++ b/src/state-machine/states/cleanup-state.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs"
+import { Api } from "../../api/methods"
 import { ChatManager } from "../../chat-manager"
 import { envVars } from "../../config/env-vars"
 import { SoundContext, VideoContext } from "../../media_context"
@@ -39,6 +40,8 @@ export class CleanupState extends BaseState {
         await this.mirrorRecordingsToEFS()
         // Continue to Terminated even if cleanup fails
       }
+      this.reportMetrics()
+
       console.info("🧹 Transitioning to Terminated state")
       return this.transition(MeetingStateType.Terminated)
     } catch (error) {
@@ -225,6 +228,21 @@ export class CleanupState extends BaseState {
       this.context.dialogObserver.stopGlobalDialogObserver()
     } else {
       console.warn(`Global dialog observer not available in state ${this.constructor.name}`)
+    }
+  }
+
+  private reportMetrics(): void {
+    try {
+      const collector = GLOBAL.getMetricsCollector()
+      if (!collector.isRunning()) return
+
+      collector.stop()
+      const payload = collector.getPayload()
+      if (Api.instance) {
+        Api.instance.reportMetrics(payload)
+      }
+    } catch (error) {
+      console.warn("Failed to report bot metrics (continuing):", error)
     }
   }
 

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -80,6 +80,8 @@ export class RecordingState extends BaseState {
       // Initialize recording
       await this.initializeRecording()
 
+      GLOBAL.getMetricsCollector().start()
+
       // Set a global timeout for the recording state
       const startTime = Date.now()
       // Note: startTime is already set in in-call state to prevent race conditions


### PR DESCRIPTION
Adds a `MetricsCollector` that captures CPU time (cpuUsage diff), memory snapshots (RSS/heap), and state durations (total, recording, idle) at recording boundaries.
At cleanup, the bot POSTs the payload to `POST /bot-process/metrics` as a fire-and-forget call with a 5s timeout