### PR TITLE
fix(proxy): burned-ASN region skip + 5 attempts + last retry stays residential

### DIFF
--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -97,12 +97,24 @@ export async function establishBrowserSession(
             // same exclusion is reused for that region's rotations so they stay
             // in-region and only advance the exit IP.
             const triedCountries = regions.slice(0, r)
+            let lastAsn: number | null = null
             for (let rot = 1; rot <= ROTATIONS_PER_REGION; rot++) {
               const asn = getExitAsn()
               if (asn === null || !burned.includes(asn)) {
                 cleared = true
                 break
               }
+              // A rotation that hands back the SAME burned ASN means this region's
+              // pool won't diversify — a country served by one dominant ISP (e.g.
+              // FR ≈ Orange AS5511). Don't waste the remaining rotations here;
+              // advance to the next selected region instead.
+              if (asn === lastAsn) {
+                console.warn(
+                  `[BrowserSession] ${regions[r] ? `region ${regions[r]}` : "current region"} keeps returning burned ASN ${asn} — skipping to next region`
+                )
+                break
+              }
+              lastAsn = asn
               const where = regions[r] ? `region ${regions[r]}` : "current region"
               console.warn(
                 `[BrowserSession] exit ASN ${asn} is burned on Meet — rotating Decodo session → ${where} (${rot}/${ROTATIONS_PER_REGION})`

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -59,12 +59,22 @@ export async function establishBrowserSession(
   const retryCount = GLOBAL.getRetryCount()
 
   if (!session.proxyUrl && (platform === "meet" || platform === "zoom")) {
-    // Meet's "last retry runs without proxy" fallback does NOT apply to Zoom:
-    // the browser-join wall blocks datacenter/pod IPs outright, so every Zoom
-    // attempt must egress through the proxy — its retry value comes from cycling
-    // to a fresh exit IP, not from dropping the proxy.
+    // On the last retry, Meet used to run WITHOUT a proxy — but a datacenter/pod
+    // IP is the single strongest bot signal and gets flagged on sight (verified
+    // in prod: the no-proxy attempt is the one that flags). So even the last
+    // attempt egresses through the proxy; it just drops the geo pin for a random
+    // residential exit (skipGeoPin) — a fresh network to shake things up, minus
+    // the datacenter IP. (Zoom never went proxy-less either — its browser-join
+    // wall blocks datacenter IPs outright.)
     if (platform === "meet" && retryCount >= MAX_RETRY_COUNT) {
-      console.log("[BrowserSession] Last retry attempt — running without proxy")
+      console.log("[BrowserSession] Last retry — random residential exit (skipGeoPin)")
+      const proxyUrl = await startToggleProxy(
+        GLOBAL.get().bot_uuid,
+        retryCount,
+        opts.sessionSuffix,
+        { skipGeoPin: true }
+      )
+      if (proxyUrl) session.proxyUrl = proxyUrl
     } else {
       const proxyUrl = await startToggleProxy(
         GLOBAL.get().bot_uuid,

--- a/src/config/retry-config.ts
+++ b/src/config/retry-config.ts
@@ -16,8 +16,10 @@ import { envVars } from "./env-vars"
  * deliberately separate cap in a different app. Keep the two independent.
  */
 
-// SQS pod-requeue cap (Meet/Teams default).
-export const MAX_RETRY_COUNT = 2
+// SQS pod-requeue cap (Meet/Teams default). 4 requeues = 5 total attempts, so a
+// bot has several chances to cycle its residential exit IP past a burned network
+// / Meet flag before giving up (same reasoning as the Zoom web cap below).
+export const MAX_RETRY_COUNT = 4
 
 // SQS pod-requeue cap for Zoom web — higher to cycle exit IPs past the
 // probabilistic anti-bot / RTMS wall, which keys on the exit IP's reputation.


### PR DESCRIPTION
Three related fixes to the Meet burned-ASN / retry path, all verified against prod bot logs.

### 1. Skip to next region when a burned ASN won't diversify
A bot pinned to FR rotates 3× in-region but every rotation returns Orange **AS5511** (France's residential pool is nearly all Orange), wasting all 3 before falling through to DE. Now: if a rotation returns the *same* burned ASN, advance to the next selected region immediately. Multi-ASN countries are unaffected.

### 2. 5 attempts (was 3)
`MAX_RETRY_COUNT` 2→4 (Meet/Teams) = 5 total attempts, so a bot has several chances to cycle its residential exit IP off a burned network / past a flag before giving up. (Zoom web already uses a higher cap for the same reason.)

### 3. Last retry no longer runs proxy-less
Meet's last retry used to run **without a proxy** — but a datacenter/pod IP is the single strongest bot signal and flags on sight. Verified in prod: the no-proxy attempt is exactly the one that gets flagged (null country/ASN/IP in the detection signal). The final attempt now drops the geo pin for a **random residential exit** (`skipGeoPin`) instead of dropping the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)