### PR TITLE
Feat/teams authenticated bots

### DIFF
--- a/src/meeting/teams-state-config.ts
+++ b/src/meeting/teams-state-config.ts
@@ -42,5 +42,36 @@ export const TEAMS_STATE_CONFIG: StateDetectionConfig = {
     ],
     threshold: 3,
     checkVisibility: false
+  },
+  // Launcher screen: teams(.microsoft.com|.cloud.microsoft)/dl/launcher/... offers to
+  // open the desktop app; the bot stays on the web by clicking one of these. Several
+  // label/markup variants across tenants and the old/new domains, so match any.
+  continueOnBrowserPattern: {
+    selectors: [
+      'button:has-text("Continue on this browser")',
+      'a:has-text("Continue on this browser")',
+      '[data-tid="joinOnWeb"]',
+      'button:has-text("Join on the web instead")',
+      'a:has-text("Join on the web instead")',
+      'button:has-text("Watch on the web instead")',
+      'button:has-text("Use the web app instead")'
+    ],
+    threshold: 2,
+    checkVisibility: true
+  },
+  // Pre-join screen: where the (signed-in or guest) participant commits to joining.
+  // "Join now" is the common label; the data-tid / id are stable fallbacks if the
+  // visible text is localized or changes.
+  preJoinPattern: {
+    selectors: [
+      'button:has-text("Join now")',
+      'button[data-tid="prejoin-join-button"]',
+      "#prejoin-join-button",
+      'button[aria-label*="Join now" i]',
+      'button[title*="Join now" i]',
+      'button:has-text("Join")'
+    ],
+    threshold: 2,
+    checkVisibility: true
   }
 }

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -5,7 +5,7 @@ import { MeetingEndReason } from "../state-machine/types"
 import type { MeetingProviderInterface } from "../types"
 import { parseMeetingUrlFromJoinInfos } from "../urlParser/teamsUrlParser"
 import { formatError } from "../utils/Logger"
-import { createStateDetector } from "../utils/meeting-state-detector"
+import { createStateDetector, patternLocator } from "../utils/meeting-state-detector"
 import { sleep } from "../utils/sleep"
 import { enableTeamsAudioCapture, verifyTeamsAudioCapture } from "./teams/audio-capture"
 import { TEAMS_STATE_CONFIG } from "./teams-state-config"
@@ -84,7 +84,29 @@ export class TeamsProvider implements MeetingProviderInterface {
     attempts = 0
   ): Promise<Page> {
     const url = new URL(link)
-    const page = await browserContext.newPage()
+
+    // Authenticated Teams bots: reuse the page the sign-in flow left open on
+    // teams.microsoft.com (it holds the live MSAL session). Opening a FRESH page
+    // forces a silent re-auth that loses the race to the meeting redirect and lands
+    // on the anonymous /light-meetings launcher (anon=true → guest/name prompt).
+    // Reusing the already-signed-in tab is how a human joins. Anonymous bots (no
+    // teams_login_config) open a fresh page exactly as before.
+    // Match every Teams host: the signed-in page is bounced from teams.microsoft.com
+    // to teams.cloud.microsoft (the ocdiRedirect migration), so a teams.microsoft.com-
+    // only filter misses the authenticated tab entirely and we fall back to a fresh
+    // page — which re-auths, loses the race, and joins anonymously.
+    const isAuthenticatedTeams = Boolean(GLOBAL.get().teams_login_config)
+    const reusablePage = isAuthenticatedTeams
+      ? browserContext
+          .pages()
+          .find((p) =>
+            /(teams\.microsoft\.com|teams\.cloud\.microsoft|teams\.live\.com)/i.test(p.url())
+          )
+      : undefined
+    const page = reusablePage ?? (await browserContext.newPage())
+    if (reusablePage) {
+      console.log("[teams] reusing the authenticated sign-in page for the meeting join")
+    }
 
     page.setDefaultTimeout(30000)
     page.setDefaultNavigationTimeout(30000)
@@ -218,7 +240,8 @@ export class TeamsProvider implements MeetingProviderInterface {
         Element.prototype.setAttribute = function (name: string, value: string): void {
           const n = typeof name === "string" ? name.toLowerCase() : ""
           if (
-            ((n === "src" && this.tagName === "IFRAME") || (n === "href" && this.tagName === "A")) &&
+            ((n === "src" && this.tagName === "IFRAME") ||
+              (n === "href" && this.tagName === "A")) &&
             isExternal(value)
           ) {
             log(`setAttribute:${n}`, String(value))
@@ -247,6 +270,53 @@ export class TeamsProvider implements MeetingProviderInterface {
         },
         true
       )
+
+      // Statically-parsed <iframe src="scheme:…"> / <a href="scheme:…"> from the
+      // SERVER HTML never hit the JS src/href setters or setAttribute above — the
+      // parser sets them natively. The Teams launcher ships exactly this: a static
+      // <iframe id="teamsLauncher" src="msteams:…"> that fires Chromium's tab-modal
+      // "Open Microsoft Teams?" dialog and freezes the join. Neutralise such nodes
+      // the instant they're inserted (MutationObserver microtask fires before the
+      // browser processes the pending subframe navigation), and sweep any already
+      // present. Kept scoped to external (non-http) schemes via isExternal().
+      const neutralise = (el: Element): void => {
+        try {
+          if (el.tagName === "IFRAME" && isExternal(el.getAttribute("src"))) {
+            log("static-iframe.src", String(el.getAttribute("src")))
+            ;(el as HTMLIFrameElement).src = "about:blank"
+            el.remove()
+          } else if (el.tagName === "A" && isExternal(el.getAttribute("href"))) {
+            log("static-anchor.href", String(el.getAttribute("href")))
+            el.removeAttribute("href")
+          }
+        } catch (_e) {
+          /* best-effort */
+        }
+      }
+      const sweep = (root: ParentNode | null): void => {
+        try {
+          root?.querySelectorAll?.("iframe[src], a[href]").forEach(neutralise)
+        } catch (_e) {
+          /* best-effort */
+        }
+      }
+      const mo = new MutationObserver((records: MutationRecord[]) => {
+        for (const rec of records) {
+          rec.addedNodes.forEach((node: Node) => {
+            if (node instanceof Element) {
+              neutralise(node)
+              sweep(node)
+            }
+          })
+        }
+      })
+      try {
+        mo.observe(document, { childList: true, subtree: true })
+      } catch (_e) {
+        /* document not observable yet — retry when the tree exists */
+        document.addEventListener("DOMContentLoaded", () => sweep(document))
+      }
+      sweep(document)
     })
 
     // Audio track layer for track detection
@@ -297,9 +367,11 @@ export class TeamsProvider implements MeetingProviderInterface {
                   const text = stripHtml(message.content)
                   if (!text) continue
 
-
                   // Filter out Teams system/metadata messages
-                  if (text.includes("\n") && (text.includes("callEnded") || text.includes("api.flightproxy"))) {
+                  if (
+                    text.includes("\n") &&
+                    (text.includes("callEnded") || text.includes("api.flightproxy"))
+                  ) {
                     continue
                   }
 
@@ -462,6 +534,12 @@ export class TeamsProvider implements MeetingProviderInterface {
     const htmlSnapshot = HtmlSnapshotService.getInstance()
     await htmlSnapshot.captureSnapshot(page, "teams_join_meeting_start")
 
+    // Authenticated bots go through the FULL Teams web pre-join (Continue on this
+    // browser → Join now). The "Continue without audio or video" button is a
+    // light/anonymous-interface prompt that never appears there, so its extra retry
+    // loops below are skipped for authenticated bots (they were pure dead wait).
+    const isAuthenticatedTeams = Boolean(GLOBAL.get().teams_login_config)
+
     try {
       await ensurePageLoaded(page)
     } catch (error) {
@@ -470,8 +548,54 @@ export class TeamsProvider implements MeetingProviderInterface {
     }
 
     try {
-      // Try multiple approaches to handle Teams button scenarios
-      const maxAttempts = 15 // Increased for better reliability
+      // Authenticated bots: page-based pre-join driven by TEAMS_STATE_CONFIG's
+      // multi-selector patterns (launcher "Continue on this browser" → pre-join
+      // "Join now"). Wait for the indicator to be visible, then click through
+      // Playwright so CloakBrowser's humanized click applies — no blind retry loop.
+      // (Anonymous/other interfaces fall through to the generic button loop below.)
+      if (isAuthenticatedTeams) {
+        const continuePat = TEAMS_STATE_CONFIG.continueOnBrowserPattern
+        const preJoinPat = TEAMS_STATE_CONFIG.preJoinPattern
+
+        // This link may open the launcher OR land straight on the pre-join.
+        if (continuePat && preJoinPat) {
+          await patternLocator(page, continuePat)
+            .or(patternLocator(page, preJoinPat))
+            .first()
+            .waitFor({ state: "visible", timeout: 30_000 })
+            .catch(() => {})
+        }
+        if (await isOnMicrosoftLoginPage(page)) throw new Error("LoginRequired")
+
+        // On the launcher, click through to the web pre-join, then wait for it.
+        const onLauncher =
+          !!continuePat &&
+          (await patternLocator(page, continuePat)
+            .first()
+            .isVisible()
+            .catch(() => false))
+        if (onLauncher && continuePat) {
+          await patternLocator(page, continuePat)
+            .first()
+            .click({ timeout: 3_000 })
+            .then(() => console.log('✅ [teams] clicked "Continue on this browser"'))
+            .catch((e) =>
+              console.warn(`[teams] continue-on-browser click failed: ${formatError(e)}`)
+            )
+          if (preJoinPat) {
+            await patternLocator(page, preJoinPat)
+              .first()
+              .waitFor({ state: "visible", timeout: 30_000 })
+              .catch(() => {})
+          }
+        } else {
+          console.log("✅ [teams] already at the pre-join (Join now) screen")
+        }
+      }
+
+      // Try multiple approaches to handle Teams button scenarios (anonymous/other
+      // interfaces). Authenticated bots handled the pre-join page-based above, so skip.
+      const maxAttempts = isAuthenticatedTeams ? 0 : 15
 
       for (let i = 0; i < maxAttempts; i++) {
         if (cancelCheck?.()) break
@@ -510,29 +634,32 @@ export class TeamsProvider implements MeetingProviderInterface {
         await sleep(300) // Slightly reduced wait time
       }
 
-      // Extra attempts for "Continue without audio" in light interface
-      console.log('🔄 Extra attempts for "Continue without audio or video"...')
-      for (let i = 0; i < 5; i++) {
-        if (cancelCheck?.()) break
+      // Extra attempts for "Continue without audio" in light interface (skip for
+      // authenticated bots — that button isn't part of the authenticated pre-join).
+      if (!isAuthenticatedTeams) {
+        console.log('🔄 Extra attempts for "Continue without audio or video"...')
+        for (let i = 0; i < 5; i++) {
+          if (cancelCheck?.()) break
 
-        // Check if we've been redirected to a login page
-        if (await isOnMicrosoftLoginPage(page)) {
-          throw new Error("LoginRequired")
-        }
+          // Check if we've been redirected to a login page
+          if (await isOnMicrosoftLoginPage(page)) {
+            throw new Error("LoginRequired")
+          }
 
-        const found = await clickWithInnerText(
-          page,
-          "button",
-          "Continue without audio or video",
-          3,
-          true
-        )
-        if (found) {
-          console.log('✅ Successfully clicked "Continue without audio" (extra attempt)')
-          await sleep(1000)
-          break
+          const found = await clickWithInnerText(
+            page,
+            "button",
+            "Continue without audio or video",
+            3,
+            true
+          )
+          if (found) {
+            console.log('✅ Successfully clicked "Continue without audio" (extra attempt)')
+            await sleep(1000)
+            break
+          }
+          await sleep(500)
         }
-        await sleep(500)
       }
     } catch (e) {
       if (e instanceof Error && e.message === "LoginRequired") {
@@ -553,33 +680,39 @@ export class TeamsProvider implements MeetingProviderInterface {
     )
 
     try {
-      await clickWithInnerText(page, "button", "Join now", 100, false)
+      // Wait for the pre-join "Join now" to render (detection barrier; the real click
+      // happens below). 12 attempts with the capped backoff is up to ~6s if it's slow,
+      // and returns the instant it appears — the old count of 100 could wait minutes.
+      await clickWithInnerText(page, "button", "Join now", 12, false)
     } catch (e) {
       console.warn('Failed to find "Join now" button (first attempt):', e)
     }
 
-    // Additional attempt for "Continue without audio" in case it appears later
-    try {
-      console.log('🔄 Additional attempt for "Continue without audio or video"...')
-      for (let i = 0; i < 3; i++) {
-        if (cancelCheck?.()) break
+    // Additional attempt for "Continue without audio" in case it appears later (skip
+    // for authenticated bots — not part of the authenticated pre-join).
+    if (!isAuthenticatedTeams) {
+      try {
+        console.log('🔄 Additional attempt for "Continue without audio or video"...')
+        for (let i = 0; i < 3; i++) {
+          if (cancelCheck?.()) break
 
-        const found = await clickWithInnerText(
-          page,
-          "button",
-          "Continue without audio or video",
-          2,
-          true
-        )
-        if (found) {
-          console.log('✅ Successfully clicked "Continue without audio" (delayed attempt)')
-          await sleep(1000)
-          break
+          const found = await clickWithInnerText(
+            page,
+            "button",
+            "Continue without audio or video",
+            2,
+            true
+          )
+          if (found) {
+            console.log('✅ Successfully clicked "Continue without audio" (delayed attempt)')
+            await sleep(1000)
+            break
+          }
+          await sleep(500)
         }
-        await sleep(500)
+      } catch (e) {
+        console.warn('Additional "Continue without audio" attempt failed:', e)
       }
-    } catch (e) {
-      console.warn('Additional "Continue without audio" attempt failed:', e)
     }
 
     const streaming_input = GLOBAL.get().streaming_input
@@ -610,14 +743,35 @@ export class TeamsProvider implements MeetingProviderInterface {
 
     // Final stop check before the irreversible "Join now" click
     if (cancelCheck()) {
-      console.log('Stop request detected before clicking Join now — aborting')
+      console.log("Stop request detected before clicking Join now — aborting")
       GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
       throw new Error("Bot stopped before joining meeting")
     }
 
     try {
-      await typeBotName(page, GLOBAL.get().bot_name, 20)
-      await clickWithInnerText(page, "button", "Join now", 20)
+      // Authenticated bots join AS the signed-in user — the name comes from the
+      // Microsoft account, and the authenticated pre-join has no guest-name field.
+      // Only type a guest name on the anonymous path; the waiting-room clears
+      // teams_login_config when it falls back to anonymous, so its presence here
+      // means sign-in succeeded and we must NOT type a name (doing so is the "types
+      // the name / joins as guest" bug). Respects the fallback config by construction.
+      if (isAuthenticatedTeams) {
+        // Join AS the signed-in user (no guest-name field). Click via the multi-selector
+        // pre-join pattern; fall back to the exact-text click if it didn't resolve.
+        console.log("[teams] authenticated bot — joining as signed-in user (no guest name)")
+        const preJoinPat = TEAMS_STATE_CONFIG.preJoinPattern
+        const clicked = preJoinPat
+          ? await patternLocator(page, preJoinPat)
+              .first()
+              .click({ timeout: 5_000 })
+              .then(() => true)
+              .catch(() => false)
+          : false
+        if (!clicked) await clickWithInnerText(page, "button", "Join now", 20)
+      } else {
+        await typeBotName(page, GLOBAL.get().bot_name, 20)
+        await clickWithInnerText(page, "button", "Join now", 20)
+      }
     } catch (e) {
       console.error('Error during bot name typing or second "Join now" click:', e)
       throw new Error("RetryableError")
@@ -710,10 +864,7 @@ export class TeamsProvider implements MeetingProviderInterface {
     }
   }
 
-  async findEndMeeting(
-    page: Page,
-    _opts?: { ignoreAloneSignals?: boolean }
-  ): Promise<boolean> {
+  async findEndMeeting(page: Page, _opts?: { ignoreAloneSignals?: boolean }): Promise<boolean> {
     // Teams end-detection (login page / freeze / removed) has no "alone" signal,
     // so _opts.ignoreAloneSignals is not applicable here.
     // Check if we're on a Microsoft login page
@@ -851,8 +1002,7 @@ async function clickWithInnerText(
       // can't land during the join.
       if (continueButton && click) {
         const humanizeActive = Boolean((page as unknown as { _original?: unknown })._original)
-        const humanized =
-          humanizeActive && (await clickButtonHumanized(page, htmlType, innerText))
+        const humanized = humanizeActive && (await clickButtonHumanized(page, htmlType, innerText))
         if (!humanized) {
           await page.evaluate(
             ({ innerText, htmlType }) => {
@@ -873,7 +1023,10 @@ async function clickWithInnerText(
     }
 
     if (!continueButton) {
-      await page.waitForTimeout(100 + i * 100)
+      // Cap the backoff: the old `100 + i * 100` grew unbounded, so a high iteration
+      // count (e.g. 100) waited minutes for a button that was slow or absent. Capped at
+      // 500ms per attempt it stays responsive while still yielding between polls.
+      await page.waitForTimeout(Math.min(100 + i * 100, 500))
     }
 
     // Only log if found or on final attempt

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -187,6 +187,12 @@ class Global {
     }
   }
 
+  public clearTeamsLoginConfig(): void {
+    if (this.meetingParams) {
+      this.meetingParams.teams_login_config = null
+    }
+  }
+
   // NEW: Retry flag methods
   public setShouldRetry(value: boolean): void {
     this.shouldRetry = value

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -1,0 +1,229 @@
+import type { BrowserContext, Page } from "@playwright/test"
+
+/**
+ * Microsoft Teams username/password login — runs before joining a Teams meeting
+ * when an authenticated bot is configured (teams_login_config present in the SQS
+ * message).
+ *
+ * Unlike Meet (SAML SSO with MeetingBaaS as IdP), Teams has no IdP path without
+ * federation, so — like Recall/Attendee — the bot signs in with real credentials:
+ *   1. Fetch the assigned account { email, password } once from api-server's
+ *      /v2/teams-sso/resolve-session (keyed by the short-lived session id).
+ *   2. Type them into login.microsoftonline.com (email -> Next, password -> Sign in).
+ *   3. Handle the "Stay signed in?" (KMSI) prompt; detect bad creds / captcha / MFA.
+ *   4. Confirm Microsoft auth cookies (ESTSAUTH*) are set on the browser context so
+ *      the subsequent teams.microsoft.com navigation is authenticated.
+ *
+ * See docs/MICROSOFT_TEAMS_AUTHENTICATED_BOTS.md for full design context.
+ */
+
+const MICROSOFT_AUTH_COOKIE_NAMES = new Set([
+  "ESTSAUTH",
+  "ESTSAUTHPERSISTENT",
+  "ESTSAUTHLIGHT",
+  "SignInStateCookie"
+])
+
+/**
+ * Codes the bot can produce. Mapped by the caller to a MeetingEndReason reported
+ * back to api-server, which flips the teams_login to state=invalid for the
+ * credential/MFA/captcha buckets (per-account, not shared like Meet's cert) and
+ * treats TIMEOUT as transient (no auto-disable).
+ */
+export type TeamsLoginFailureCode =
+  | "TEAMS_LOGIN_FAILED_INVALID_CREDENTIALS"
+  | "TEAMS_LOGIN_FAILED_CAPTCHA"
+  | "TEAMS_LOGIN_FAILED_MFA_REQUIRED"
+  | "TEAMS_LOGIN_FAILED_TIMEOUT"
+
+export class TeamsLoginError extends Error {
+  constructor(
+    public readonly code: TeamsLoginFailureCode,
+    message: string
+  ) {
+    super(message)
+    this.name = "TeamsLoginError"
+  }
+}
+
+export interface TeamsLoginConfig {
+  session_id: string
+  login_email: string
+  resolve_url: string // api-server endpoint returning { email, password } for this session
+  fallback: "fail" | "anonymous"
+}
+
+interface ResolvedCredentials {
+  email: string
+  password: string
+}
+
+/**
+ * Sign in to the assigned Microsoft account. Sets Microsoft auth cookies on the
+ * browserContext; subsequent teams.microsoft.com navigations are authenticated.
+ * Throws TeamsLoginError on any failure.
+ */
+export async function loginToTeamsWithCredentials(
+  browserContext: BrowserContext,
+  config: TeamsLoginConfig
+): Promise<void> {
+  const { email, password } = await resolveCredentials(config)
+  const page = await browserContext.newPage()
+
+  try {
+    console.info(`[teams-login] starting sign-in for ${config.login_email}`)
+
+    // Force English so Microsoft serves sign-in pages in a predictable language.
+    await page.setExtraHTTPHeaders({ "Accept-Language": "en-US,en;q=0.9" })
+
+    // 1. Microsoft identity sign-in entry.
+    await page.goto("https://login.microsoftonline.com/", {
+      waitUntil: "domcontentloaded",
+      timeout: 20_000
+    })
+
+    // 2. Email -> Next
+    const emailInput = page.locator('input[type="email"], input[name="loginfmt"]').first()
+    await emailInput.waitFor({ state: "visible", timeout: 15_000 })
+    await emailInput.fill(email)
+    await clickPrimary(page, ["Next"])
+
+    // 3. Password -> Sign in
+    const passwordInput = page.locator('input[type="password"], input[name="passwd"]').first()
+    await passwordInput.waitFor({ state: "visible", timeout: 20_000 })
+    await passwordInput.fill(password)
+    await clickPrimary(page, ["Sign in", "Sign In"])
+
+    // 4. Give the response a moment, then classify credential / captcha / MFA errors.
+    await page.waitForTimeout(2_000)
+    await detectLoginError(page)
+
+    // 5. "Stay signed in?" (KMSI) — click Yes so the session persists.
+    await dismissStaySignedIn(page)
+
+    // 6. Confirm Microsoft auth cookies are present.
+    await waitForMicrosoftAuthCookies(browserContext, page, 45_000)
+
+    console.info(`[teams-login] sign-in successful for ${config.login_email}`)
+  } catch (err) {
+    if (err instanceof TeamsLoginError) throw err
+    const message = err instanceof Error ? err.message : String(err)
+    const currentUrl = page.url()
+    console.error(`[teams-login] sign-in failed: ${message} (last URL: ${currentUrl})`)
+    throw new TeamsLoginError("TEAMS_LOGIN_FAILED_TIMEOUT", `${message} (last URL: ${currentUrl})`)
+  } finally {
+    await page.close().catch(() => {})
+  }
+}
+
+/** One-time fetch of the decrypted credentials for the assigned session. */
+async function resolveCredentials(config: TeamsLoginConfig): Promise<ResolvedCredentials> {
+  const res = await fetch(config.resolve_url, {
+    headers: {
+      "x-teams-session-id": config.session_id,
+      "ngrok-skip-browser-warning": "true"
+    }
+  })
+  if (!res.ok) {
+    throw new TeamsLoginError(
+      "TEAMS_LOGIN_FAILED_TIMEOUT",
+      `resolve-session endpoint returned ${res.status} — session may be expired or invalid`
+    )
+  }
+  const body = (await res.json()) as { email?: string; password?: string }
+  if (!body.email || !body.password) {
+    throw new TeamsLoginError("TEAMS_LOGIN_FAILED_TIMEOUT", "resolve-session returned no credentials")
+  }
+  return { email: body.email, password: body.password }
+}
+
+/** Click the primary submit button (Microsoft uses #idSIButton9) or a labelled fallback. */
+async function clickPrimary(page: Page, labels: string[]): Promise<void> {
+  const labelSelector = labels.map((l) => `button:has-text("${l}")`).join(", ")
+  await page
+    .locator(`#idSIButton9, input[type="submit"], ${labelSelector}`)
+    .first()
+    .click({ timeout: 10_000 })
+}
+
+/** Classify a login failure from the current page (bad creds, captcha, MFA). */
+async function detectLoginError(page: Page): Promise<void> {
+  const bodyText = await page
+    .locator("body")
+    .innerText()
+    .catch(() => "")
+
+  if (
+    /your account or password is incorrect|that account doesn't exist|password is incorrect|couldn't (?:find|verify) your account/i.test(
+      bodyText
+    )
+  ) {
+    throw new TeamsLoginError(
+      "TEAMS_LOGIN_FAILED_INVALID_CREDENTIALS",
+      "Microsoft rejected the account email/password. Update the teams_login credentials."
+    )
+  }
+
+  const captchaPresent = await page
+    .locator('iframe[src*="hip"], iframe[title*="captcha" i], #arkoseFrame, [data-testid*="captcha" i]')
+    .first()
+    .isVisible()
+    .catch(() => false)
+  if (captchaPresent) {
+    throw new TeamsLoginError(
+      "TEAMS_LOGIN_FAILED_CAPTCHA",
+      "Microsoft presented a captcha the bot cannot auto-solve. Provision the account so it is not challenged, or wire a captcha solver."
+    )
+  }
+
+  if (/verify your identity|enter (?:the )?code|approve.*request|authenticator app/i.test(bodyText)) {
+    throw new TeamsLoginError(
+      "TEAMS_LOGIN_FAILED_MFA_REQUIRED",
+      "Microsoft requested MFA/identity verification. The bot account must be provisioned without MFA."
+    )
+  }
+}
+
+/** "Stay signed in?" speedbump — click Yes so the session cookies persist. */
+async function dismissStaySignedIn(page: Page): Promise<void> {
+  try {
+    const bodyText = await page
+      .locator("body")
+      .innerText()
+      .catch(() => "")
+    if (!/stay signed in|kmsi/i.test(bodyText)) return
+    await page
+      .locator('#idSIButton9, button:has-text("Yes")')
+      .first()
+      .click({ timeout: 8_000 })
+  } catch {
+    // Non-fatal.
+  }
+}
+
+async function waitForMicrosoftAuthCookies(
+  browserContext: BrowserContext,
+  page: Page,
+  timeoutMs: number
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    // Re-check for a decisive failure so we don't silently wait out the full timeout.
+    await detectLoginError(page)
+
+    const cookies = await browserContext.cookies([
+      "https://login.microsoftonline.com",
+      "https://teams.microsoft.com"
+    ])
+    const present = new Set(cookies.map((c) => c.name))
+    for (const name of MICROSOFT_AUTH_COOKIE_NAMES) {
+      if (present.has(name)) return
+    }
+    await new Promise((r) => setTimeout(r, 500))
+  }
+
+  throw new TeamsLoginError(
+    "TEAMS_LOGIN_FAILED_TIMEOUT",
+    `Microsoft auth cookies did not appear within ${timeoutMs}ms — sign-in likely failed`
+  )
+}

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -24,6 +24,7 @@ const MICROSOFT_AUTH_COOKIE_NAMES = new Set([
   "SignInStateCookie"
 ])
 
+
 /**
  * Codes the bot can produce. Mapped by the caller to a MeetingEndReason reported
  * back to api-server, which flips the teams_login to state=invalid for the
@@ -104,15 +105,61 @@ export async function loginToTeamsWithCredentials(
     // 6. Confirm Microsoft auth cookies are present.
     await waitForMicrosoftAuthCookies(browserContext, page, 45_000)
 
+    // Sign-in itself is DONE here (identity cookies present). Everything below is a
+    // best-effort warm-up of the Teams v2 app session and MUST NOT fail the login.
     console.info(`[teams-login] sign-in successful for ${config.login_email}`)
+
+    // 7. Bootstrap the Teams v2 (MSAL) app session — NON-FATAL. teams.microsoft.com
+    // does a silent-SSO handoff via /v2/authv2 that stores MSAL tokens in localStorage;
+    // warming it here means the later /meet/<code> join is authenticated instead of
+    // anonymous. Wrapped in try/catch so a bootstrap failure never fails the sign-in.
+    // Note: right after "Sign in"/KMSI the page is still auto-redirecting toward
+    // m365.cloud.microsoft (OfficeHome); issuing page.goto() mid-redirect aborts with
+    // net::ERR_ABORTED, so we settle first and retry on abort.
+    try {
+      console.info(`[teams-login] bootstrap: post-signin URL = ${page.url()}`)
+      let navigated = false
+      for (let attempt = 1; attempt <= 3 && !navigated; attempt++) {
+        // Let the in-flight post-sign-in redirect chain settle before we navigate.
+        await page.waitForLoadState("domcontentloaded", { timeout: 10_000 }).catch(() => {})
+        console.info(
+          `[teams-login] bootstrap: nav attempt ${attempt}, settled URL = ${page.url()}`
+        )
+        try {
+          await page.goto("https://teams.microsoft.com/", {
+            waitUntil: "domcontentloaded",
+            timeout: 30_000
+          })
+          navigated = true
+          console.info(`[teams-login] bootstrap: reached teams.com, URL = ${page.url()}`)
+        } catch (navErr) {
+          const m = navErr instanceof Error ? navErr.message : String(navErr)
+          console.warn(`[teams-login] bootstrap: nav attempt ${attempt} failed — ${m}`)
+          await page.waitForTimeout(2_000)
+        }
+      }
+      if (navigated) {
+        await settleTeamsAuth(browserContext, page, config, 30_000)
+      } else {
+        console.warn("[teams-login] bootstrap: could not reach teams.com after 3 attempts")
+      }
+    } catch (bootstrapErr) {
+      const m = bootstrapErr instanceof Error ? bootstrapErr.message : String(bootstrapErr)
+      console.warn(
+        `[teams-login] Teams session bootstrap failed (non-fatal, sign-in still OK): ${m}`
+      )
+    }
   } catch (err) {
+    // On failure, close the login page. On SUCCESS we deliberately DO NOT close it —
+    // the meeting join reuses this authenticated page (see openMeetingPage) so it
+    // inherits the live MSAL session instead of re-authenticating on a fresh page
+    // (which loses the race and lands on the anonymous /light-meetings launcher).
+    const currentUrl = page.url()
+    await page.close().catch(() => {})
     if (err instanceof TeamsLoginError) throw err
     const message = err instanceof Error ? err.message : String(err)
-    const currentUrl = page.url()
     console.error(`[teams-login] sign-in failed: ${message} (last URL: ${currentUrl})`)
     throw new TeamsLoginError("TEAMS_LOGIN_FAILED_TIMEOUT", `${message} (last URL: ${currentUrl})`)
-  } finally {
-    await page.close().catch(() => {})
   }
 }
 
@@ -225,5 +272,82 @@ async function waitForMicrosoftAuthCookies(
   throw new TeamsLoginError(
     "TEAMS_LOGIN_FAILED_TIMEOUT",
     `Microsoft auth cookies did not appear within ${timeoutMs}ms — sign-in likely failed`
+  )
+}
+
+/**
+ * Wait for the Teams v2 (MSAL) silent-SSO handoff to complete after navigating to
+ * teams.microsoft.com. Teams v2 keeps tokens in localStorage; the observable signals
+ * are (a) the URL leaving the /v2/authv2 auth endpoint into the app, and (b) the
+ * MSAL cookies (msal.cache.encryption / ringFinder) appearing. While waiting we
+ * best-effort clear a "Stay signed in?" prompt and click our own account tile if an
+ * account picker stalls /authv2. Non-fatal: if it doesn't settle we warn and proceed
+ * (the meeting may then join anonymously per the fallback config).
+ */
+async function settleTeamsAuth(
+  browserContext: BrowserContext,
+  page: Page,
+  config: TeamsLoginConfig,
+  timeoutMs: number
+): Promise<void> {
+  // The signed-in app no longer lives only on teams.microsoft.com: the ocdiRedirect
+  // migration bounces it to teams.cloud.microsoft. Match EVERY teams host — hardcoding
+  // teams.microsoft.com made this loop wait forever on the new domain (observed: 60s
+  // stuck on teams.cloud.microsoft/, authtoken never "seen" because it lived elsewhere).
+  const TEAMS_APP_HOST = /(teams\.microsoft\.com|teams\.cloud\.microsoft|teams\.live\.com)/i
+  const ON_AUTH = /\/authv2|login\.microsoftonline\.com|login\.live\.com/i
+  const isTeamsCookieDomain = (domain: string): boolean =>
+    /(teams\.microsoft\.com|teams\.cloud\.microsoft|cloud\.microsoft|teams\.live\.com)/i.test(domain)
+
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const url = page.url()
+    const onAuthEndpoint = ON_AUTH.test(url)
+    const onTeamsApp = TEAMS_APP_HOST.test(url) && !onAuthEndpoint
+    const cookies = await browserContext.cookies()
+    const teamsCookies = cookies.filter((c) => isTeamsCookieDomain(c.domain))
+    const names = teamsCookies.map((c) => c.name)
+    const hasAuthToken = names.includes("authtoken")
+    const hasRingFinder = names.includes("ringFinder")
+    console.info(
+      `[teams-login][settle] t=${Math.round((Date.now() - start) / 1000)}s url=${url} ` +
+        `onApp=${onTeamsApp} hasAuthToken=${hasAuthToken} hasRingFinder=${hasRingFinder} ` +
+        `teamsCookies=[${names.join(", ")}]`
+    )
+    // Go the INSTANT the Teams identity is established — `ringFinder` carries the
+    // signed-in oid/tid, `authtoken` is the full service token — as long as we're on
+    // the Teams app (off the auth endpoints). We deliberately DON'T wait for the home
+    // page to finish loading/settling: we navigate straight to the meeting next, so
+    // any extra home-page time is pure latency the user sees as "stuck after sign-in".
+    // The meeting page does its own silent SSO from the identity cookies set at sign-in.
+    if ((hasAuthToken || hasRingFinder) && onTeamsApp) {
+      console.info(
+        `[teams-login] Teams identity established (${hasAuthToken ? "authtoken" : "ringFinder"}) — ` +
+          "handing off to meeting join"
+      )
+      return
+    }
+
+    // Best-effort: progress an account picker or KMSI that can stall /authv2.
+    await dismissStaySignedIn(page).catch(() => {})
+    try {
+      const tile = page
+        .locator(
+          `[aria-label*="${config.login_email}"], div[role="button"]:has-text("${config.login_email}")`
+        )
+        .first()
+      if (await tile.isVisible({ timeout: 300 }).catch(() => false)) {
+        console.info("[teams-login] account picker on /authv2 — selecting our account")
+        await tile.click({ timeout: 2_000 }).catch(() => {})
+      }
+    } catch (_e) {
+      /* no picker present */
+    }
+
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  console.warn(
+    `[teams-login] session did not fully settle within ${timeoutMs}ms — ` +
+      "proceeding to the meeting join anyway (may fall back to anonymous)"
   )
 }

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -17,6 +17,7 @@ import { handleTimingControl } from "../../utils/timing-control"
 import { MeetingEndReason, MeetingStateType, type StateExecuteResult } from "../types"
 import { BaseState } from "./base-state"
 import { loginToGoogleMeetWithSso, MeetSsoLoginError } from "./google-meet-sso-login"
+import { loginToTeamsWithCredentials, TeamsLoginError } from "./microsoft-teams-login"
 
 export class WaitingRoomState extends BaseState {
   async execute(): StateExecuteResult {
@@ -81,6 +82,46 @@ export class WaitingRoomState extends BaseState {
                 err.code === "MEET_LOGIN_FAILED_SAML_REJECTED"
                   ? MeetingEndReason.MeetLoginFailedSamlRejected
                   : MeetingEndReason.MeetLoginFailedTimeout
+              GLOBAL.setError(reason)
+              throw err
+            }
+          } else {
+            throw err
+          }
+        }
+      }
+
+      // Authenticated Teams bot: sign in with the assigned Microsoft account BEFORE
+      // opening the meeting page. Microsoft auth cookies persist for the
+      // teams.microsoft.com navigation that follows.
+      const teamsLoginConfig = GLOBAL.get().teams_login_config
+      const isTeams = GLOBAL.get().meeting_platform === "teams"
+      if (isTeams && teamsLoginConfig) {
+        if (!this.context.browserContext) {
+          throw new Error("Browser context not initialized for Teams login")
+        }
+        try {
+          await loginToTeamsWithCredentials(this.context.browserContext, teamsLoginConfig)
+        } catch (err) {
+          if (err instanceof TeamsLoginError) {
+            if (teamsLoginConfig.fallback === "anonymous") {
+              console.warn(
+                `[teams-login] login failed (${err.code}): ${err.message}. Falling back to anonymous join.`
+              )
+              GLOBAL.clearTeamsLoginConfig()
+              // Continue — openMeetingPage runs next as an unauthenticated bot.
+            } else {
+              console.error(
+                `[teams-login] login failed (${err.code}): ${err.message}. Reporting failure to api-server.`
+              )
+              const reason =
+                err.code === "TEAMS_LOGIN_FAILED_INVALID_CREDENTIALS"
+                  ? MeetingEndReason.TeamsLoginFailedInvalidCredentials
+                  : err.code === "TEAMS_LOGIN_FAILED_CAPTCHA"
+                    ? MeetingEndReason.TeamsLoginFailedCaptcha
+                    : err.code === "TEAMS_LOGIN_FAILED_MFA_REQUIRED"
+                      ? MeetingEndReason.TeamsLoginFailedMfaRequired
+                      : MeetingEndReason.TeamsLoginFailedTimeout
               GLOBAL.setError(reason)
               throw err
             }

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -123,6 +123,12 @@ export class WaitingRoomState extends BaseState {
                       ? MeetingEndReason.TeamsLoginFailedMfaRequired
                       : MeetingEndReason.TeamsLoginFailedTimeout
               GLOBAL.setError(reason)
+              // TIMEOUT is transient (network / Microsoft slowness) — let the SQS
+              // retry try again on a fresh attempt. Credential/captcha/MFA failures
+              // are terminal (the account is auto-disabled) and must NOT retry.
+              if (err.code === "TEAMS_LOGIN_FAILED_TIMEOUT") {
+                GLOBAL.setShouldRetry(true)
+              }
               throw err
             }
           } else {

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -46,6 +46,12 @@ export enum MeetingEndReason {
   // SDK. Maps to the api-server's ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED error code.
   ZoomAnonymousJoinNotAllowed = "zoomAnonymousJoinNotAllowed",
   ZoomPasscodeRequired = "zoomPasscodeRequired",
+  // Authenticated Teams bot (username/password) — failure modes the api-server distinguishes.
+  // Invalid/Captcha/Mfa flip the teams_login to invalid (per-account); Timeout is transient.
+  TeamsLoginFailedInvalidCredentials = "teamsLoginFailedInvalidCredentials",
+  TeamsLoginFailedCaptcha = "teamsLoginFailedCaptcha",
+  TeamsLoginFailedMfaRequired = "teamsLoginFailedMfaRequired",
+  TeamsLoginFailedTimeout = "teamsLoginFailedTimeout",
   Internal = "internalError"
 }
 
@@ -88,6 +94,14 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "This Zoom meeting rejected the recording bot because it joined anonymously — the host's account blocks anonymous/automated browser joins. We recommend recording it via Zoom RTMS (or the native SDK with a user-authorized credential)."
     case MeetingEndReason.ZoomPasscodeRequired:
       return "Zoom meeting requires a passcode that was not supplied in the meeting URL (?pwd=)."
+    case MeetingEndReason.TeamsLoginFailedInvalidCredentials:
+      return "Microsoft rejected the account email/password. Update the teams_login credentials."
+    case MeetingEndReason.TeamsLoginFailedCaptcha:
+      return "Microsoft presented a captcha the bot could not solve during sign-in."
+    case MeetingEndReason.TeamsLoginFailedMfaRequired:
+      return "Microsoft requested MFA during sign-in; the bot account must be MFA-free."
+    case MeetingEndReason.TeamsLoginFailedTimeout:
+      return "Microsoft sign-in did not complete in time."
     case MeetingEndReason.Internal:
       return "Internal error occurred during recording."
     default:

--- a/src/urlParser/teamsUrlParser.ts
+++ b/src/urlParser/teamsUrlParser.ts
@@ -31,7 +31,9 @@ function convertLightMeetingToStandard(url: URL): string {
       ...(organizerId ? { Oid: organizerId } : {})
     }
 
-    return `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${conversationId}/${messageId}?context=${encodeURIComponent(JSON.stringify(context))}&anon=true`
+    // Authenticated bots join as the signed-in user; only anonymous bots pass anon=true.
+    const anonSuffix = GLOBAL.get().teams_login_config ? "" : "&anon=true"
+    return `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${conversationId}/${messageId}?context=${encodeURIComponent(JSON.stringify(context))}${anonSuffix}`
   } catch (e) {
     console.error("🥕❌ Error converting light meeting URL:", formatError(e))
     GLOBAL.setError(MeetingEndReason.InvalidMeetingUrl)
@@ -47,6 +49,14 @@ function transformTeamsLink(originalLink: string): string {
     }
 
     const url = new URL(originalLink)
+
+    // NOTE on authenticated bots: teams.microsoft.com/meet/<code> server-redirects to
+    // the "anon=true" launcher even for a signed-in user — but that's just the launcher
+    // shell. A human signed into Teams who opens this exact raw link clicks "Continue on
+    // this browser" and joins AUTHENTICATED, because the browser session (login.micro-
+    // softonline.com + teams cookies) carries through. So we pass the raw /meet/ link
+    // UNCHANGED and let the signed-in page + "Continue on this browser" do the rest.
+    // (An earlier /v2/#/meet/<code> rewrite was unverified and did not help.)
 
     // Handle light-meetings format
     if (url.pathname.includes("/light-meetings/launch")) {
@@ -65,8 +75,10 @@ function transformTeamsLink(originalLink: string): string {
 
     const [_, threadId, timestamp, context] = match
 
-    // Build the working link format
-    return `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${threadId}/${timestamp}?context=${context}&anon=true`
+    // Build the working link format. Authenticated bots join as the signed-in user;
+    // only anonymous bots pass anon=true.
+    const anonSuffix = GLOBAL.get().teams_login_config ? "" : "&anon=true"
+    return `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${threadId}/${timestamp}?context=${context}${anonSuffix}`
   } catch (error) {
     console.error("Error transforming Teams link:", formatError(error))
     return originalLink

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -73,5 +73,18 @@ export const BotMessageSchema = object({
         fallback: zodEnum(["fail", "anonymous"]).default("anonymous")
       })
     )
+  ).default(null),
+
+  // Teams authenticated bot config — present when api-server assigned a teams_login.
+  // Bot fetches { email, password } from resolve_url and signs in before joining.
+  teams_login_config: optional(
+    nullable(
+      object({
+        session_id: uuid(),
+        login_email: string().email(),
+        resolve_url: url(),
+        fallback: zodEnum(["fail", "anonymous"]).default("anonymous")
+      })
+    )
   ).default(null)
 })

--- a/src/utils/meeting-state-detector.ts
+++ b/src/utils/meeting-state-detector.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 import type { MeetingEndReason } from "../state-machine/types"
 
 /**
@@ -30,6 +30,11 @@ export type StateDetectionConfig = {
   denialPatterns: DenialPattern[]
   waitingRoomPattern?: SelectorPattern
   inMeetingPattern: SelectorPattern
+  // Pre-join flow screens, each identified by any one of several selectors so a
+  // single label/markup change doesn't strand the join. Consumed page-based via
+  // patternLocator() (wait for the first match) rather than a blind retry loop.
+  continueOnBrowserPattern?: SelectorPattern
+  preJoinPattern?: SelectorPattern
 }
 
 export type StateDetectionResult = {
@@ -202,3 +207,13 @@ export const createStateDetector = (config: StateDetectionConfig): MeetingStateD
 
   return detector
 }
+
+/**
+ * Fold a SelectorPattern's selectors into ONE Playwright locator that matches ANY of
+ * them (`.or()` chain). Lets callers wait page-based on a whole pattern with
+ * `patternLocator(page, pattern).first().waitFor({ state: "visible" })` — multi-selector
+ * and event-driven (resolves the instant one matches), no polling/retry loop. Throws on
+ * an empty selector list (a pattern must have at least one selector).
+ */
+export const patternLocator = (page: Page, pattern: SelectorPattern): Locator =>
+  pattern.selectors.map((s) => page.locator(s)).reduce((a, b) => a.or(b))


### PR DESCRIPTION
# Microsoft Teams Authenticated Bots — Release

## Summary
Adds **authenticated Microsoft Teams bots**: a bot signs into a real Microsoft account (`teams_logins`, resolved per session) and joins a Teams meeting **as that user** instead of anonymously. Falls back to anonymous per the `fallback` config when sign-in fails.

This drop rebases every feature branch onto its current origin base, cleans up naming, and wires the missing deployment secret.

### What changed
- **Rebased + pushed** all feature branches (force-with-lease, feature branches only):
  - main repo (`meeting-baas-v2`) → **`origin/preprod`**
  - `meet-teams-bot` → **`origin/v2-improvements`**
  - `frontend` → **`origin/main`**
- **Route rename**: `teams-sso` → **`teams-login`** across routes, controllers, services, Redis key prefix, error codes, and docs (it is credential sign-in, not SSO).
- **Migration collision resolved**: my `0025_teams_authenticated_bots` collided with `0025_proxy_steering` on preprod → renumbered to **`0026_teams_authenticated_bots`**; journal rebuilt on top of preprod's.
- **Bot join reworked** to be page/indicator-driven via `TEAMS_STATE_CONFIG` (no blind retry loops); sign-in settles on the `ringFinder` identity cookie and handles the `teams.cloud.microsoft` redirect.
- **Deployment**: wired `TEAMS_LOGIN_ENCRYPTION_SECRET` (previously a hard-coded placeholder in every env — passwords were encrypting under a placeholder key).

## Testing
- **api-server** type-checks clean after the rebase + rename + conflict resolution (`tsc --noEmit`).
- **meet-teams-bot** type-checks clean.
- Rebase conflicts resolved and verified: 6 bot-dispatch paths now pass **both** `proxy_countries` (preprod) and `teams_login_config` (this feature); no `teams-sso` stragglers after the rename replayed.
- **End-to-end (manual, local via the API/SQS path)**: bot signs into `bot1@kapipass`, reaches `teams.cloud.microsoft`, and joins the meeting **authenticated** (not the guest/name prompt). macOS-only recording/virtual-device shims are kept in the working tree and were **not** committed.
- **To verify a deploy**: after merging the helm + deployment PRs, confirm `TEAMS_LOGIN_ENCRYPTION_SECRET` is populated (not the placeholder) in preprod, then create a Teams bot with a valid `teams_login` and confirm an authenticated join + that the session releases on exit.
- **DB**: run `pnpm db:migrate`; `0026_teams_authenticated_bots` applies after `0025_proxy_steering`.

## Release Notes
**User-facing**: Teams bots can now join meetings as a signed-in Microsoft user (authenticated capture) instead of anonymously, with an anonymous fallback.
