### PR TITLE
fix: upload screenshots on failed runs

### DIFF
--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -356,8 +356,10 @@ export async function uploadLogsToS3(): Promise<void> {
       console.log("No speaker separation log file found at path:", speakerLogPath)
     }
 
-    // Upload screenshots if they are not already uploaded
-    if (GLOBAL.getArtifactKeys().some((artifact) => artifact.type !== "screenshots")) {
+    // Upload screenshots if they are not already uploaded. On failed runs the
+    // artifact-key list is empty, so this must not gate on other artifacts
+    // existing — failures are precisely when the on-disk frames matter most.
+    if (!GLOBAL.getArtifactKeys().some((artifact) => artifact.type === "screenshots")) {
       await uploadScreenshotsToS3()
     }
 


### PR DESCRIPTION
## Bug

`uploadLogsToS3` (the `finally`-path upload that runs for every bot, including failures) gates its screenshot upload with:

```ts
if (GLOBAL.getArtifactKeys().some((artifact) => artifact.type !== "screenshots")) {
```

This is wrong two ways versus its own comment ("Upload screenshots if they are not already uploaded"):

- **Failed runs**: artifact-key list is empty → `.some()` is `false` → screenshots never uploaded. Failures are exactly when the frames matter most — prod bot `72cabe30-37dd-4947-9ace-caa6597a062b` (support ticket: bot stuck "in waiting room") spent 10 minutes on a Google sign-in wall and we had no visual evidence, only DOM snapshots.
- **Successful runs**: screenshots are already uploaded by `handleSuccessfulRecording`, but any other artifact key matches `type !== "screenshots"` → double upload.

## Fix

Invert the gate to its intended meaning: upload only when no `screenshots` artifact key exists yet.

```ts
if (!GLOBAL.getArtifactKeys().some((artifact) => artifact.type === "screenshots")) {
```

Audio-only bots are unaffected: `uploadScreenshotsToS3` early-returns for `audio_only` (compliance opt-out of visual capture).

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)