### PR TITLE
Fix/teams html cleaner and chat panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "express": "^4.21.0",
                 "https-proxy-agent": "^9.0.0",
                 "pako": "^2.1.0",
-                "protobufjs": "^7.5.8",
+                "protobufjs": "^7.6.5",
                 "proxy-chain": "^2.7.1",
                 "ts-node": "^10.9.2",
                 "tslib": "^2.8.1",
@@ -8715,9 +8715,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "express": "^4.21.0",
         "https-proxy-agent": "^9.0.0",
         "pako": "^2.1.0",
-        "protobufjs": "^7.5.8",
+        "protobufjs": "^7.6.5",
         "proxy-chain": "^2.7.1",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
@@ -104,5 +104,11 @@
     "homepage": "https://github.com/yourusername/meet-teams-bot#readme",
     "volta": {
         "node": "20.18.0"
+    },
+    "pnpm": {
+        "overrides": {
+            "tar@>=7.0.0 <7.5.19": ">=7.5.19 <8",
+            "protobufjs@<7.6.5": ">=7.6.5 <8"
+        }
     }
 }

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -365,6 +365,13 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
         bypassCSP: true
       }
     })
+    // LOCAL DEV (tsx/esbuild): esbuild's keepNames wraps named functions passed to
+    // page.evaluate() with a __name(...) helper that does not exist in the browser, so
+    // every evaluate throws "ReferenceError: __name is not defined" under tsx. Polyfill
+    // it as identity on every document (harmless when compiled — __name is then unused).
+    await (context as unknown as BrowserContext).addInitScript(
+      "globalThis.__name = globalThis.__name || function (f) { return f }"
+    )
     console.log(`✅ CloakBrowser launched (${platform})`)
     return { browser: context as unknown as BrowserContext }
   } catch (error) {

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -722,9 +722,12 @@ export class TeamsProvider implements MeetingProviderInterface {
       await Promise.race([deactivateMicrophone(page), sleep(2000)])
     }
 
-    if (isLightInterface) {
+    // Turn the bot camera on (branding image) for the light interface AND the
+    // authenticated v2 client — previously the camera stayed off on v2 so no picture.
+    const enableCamera = isLightInterface || Boolean(GLOBAL.get().teams_login_config)
+    if (enableCamera) {
       try {
-        await handlePermissionDialog(page)
+        if (isLightInterface) await handlePermissionDialog(page)
 
         // Quick camera/mic setup with timeouts
         await Promise.race([
@@ -807,6 +810,13 @@ export class TeamsProvider implements MeetingProviderInterface {
     }
 
     console.log("Successfully confirmed we are in the meeting")
+
+    // Guarantee the bot is muted after actually entering the call — the pre-join mute
+    // toggle can be reset by the v2 client on join. Recording bots (no streaming_input)
+    // must never be live; the in-meeting "Mute mic" control is stable at this point.
+    if (!GLOBAL.get().streaming_input) {
+      await Promise.race([deactivateMicrophone(page), sleep(2000)])
+    }
 
     // 🎯 CRITICAL: Notify that join was successful (fixes waiting room timeout)
     onJoinSuccess()
@@ -1169,6 +1179,15 @@ async function handlePermissionDialog(page: Page): Promise<void> {
 async function activateCamera(page: Page): Promise<void> {
   console.log("activating camera")
   try {
+    // v2 / authenticated Teams client: the toggle is a button labelled "Turn camera on"
+    // (aria-label, NOT title). Click it directly when present.
+    const v2CameraOn = page.locator('button[aria-label="Turn camera on"]')
+    if ((await v2CameraOn.count()) > 0) {
+      await v2CameraOn.first().click()
+      console.log("Camera turned on (v2 aria-label)")
+      await sleep(500)
+      return
+    }
     // Essayer d'abord l'interface normale de Teams
     const cameraOffText = page.locator('text="Your camera is turned off"')
     if ((await cameraOffText.count()) > 0) {

--- a/src/meeting/teams/htmlCleaner.ts
+++ b/src/meeting/teams/htmlCleaner.ts
@@ -149,7 +149,7 @@ export class TeamsHtmlCleaner {
           stage.style.left = "0"
           stage.style.width = "100vw"
           stage.style.height = "100vh"
-          stage.style.zIndex = "9998"
+          stage.style.zIndex = "2147483000"
           stage.style.backgroundColor = "black"
         }
 
@@ -158,6 +158,81 @@ export class TeamsHtmlCleaner {
             "[Teams] light: hid",
             hiddenLight,
             "chrome element(s); stage promoted:",
+            stage instanceof HTMLElement,
+          )
+        }
+      }
+
+      // The AUTHENTICATED teams.microsoft.com/v2 client differs from BOTH the classic
+      // client and the teams.live.com "light" client. Its chat / people rail renders at
+      // a very high z-index, so cleanLightClient's stage promotion doesn't cover it and
+      // the chat panel (kept open for compose + network capture) shows in the recording.
+      // Here we (a) hide the right rail / chat / roster panels and (b) promote the
+      // meeting video stage above everything — falling back to the common ancestor of
+      // the <video> tiles when no known stage tid matches. No-op on other clients.
+      function cleanModernClient(documentRoot: Document) {
+        let hidden = 0
+        const railSelectors = [
+          '[data-tid="chat-pane-list"]',
+          '[data-tid="chat-pane-compose-message-footer"]',
+          '[data-tid="right-rail"]',
+          '[data-tid="calling-right-side-panel"]',
+          '[data-tid="roster-panel"]',
+          '[data-tid="people-panel"]',
+          '[role="complementary"]',
+        ]
+        for (const sel of railSelectors) {
+          documentRoot.querySelectorAll(sel).forEach((el) => {
+            if (!(el instanceof HTMLElement)) return
+            el.style.display = "none"
+            hidden++
+            // Collapse the immediate rail wrapper too, but never a layout root.
+            const parent = el.parentElement
+            if (
+              parent instanceof HTMLElement &&
+              parent.id !== "call-screen-wrapper" &&
+              parent.id !== "root" &&
+              parent.tagName !== "BODY"
+            ) {
+              parent.style.display = "none"
+            }
+          })
+        }
+
+        // Promote the meeting stage to fullscreen, above the chat rail. Prefer known
+        // modern stage tids; fall back to the smallest common ancestor of the video
+        // tiles so this keeps working even if Teams renames the stage container.
+        let stage: Element | null =
+          documentRoot.querySelector('[data-tid="calling-stage"]') ||
+          documentRoot.querySelector('[data-tid="modern-stage"]') ||
+          documentRoot.querySelector('[data-tid="stage-layout"]') ||
+          documentRoot.querySelector('[data-tid="modern-stage-wrapper"]') ||
+          documentRoot.querySelector('[data-tid="only-videos-wrapper"]')
+        if (!(stage instanceof HTMLElement)) {
+          const videos = Array.from(documentRoot.querySelectorAll("video"))
+          if (videos.length > 0) {
+            let common: HTMLElement | null = videos[0].parentElement
+            while (common && !videos.every((v) => (common as HTMLElement).contains(v))) {
+              common = common.parentElement
+            }
+            stage = common
+          }
+        }
+        if (stage instanceof HTMLElement) {
+          stage.style.position = "fixed"
+          stage.style.top = "0"
+          stage.style.left = "0"
+          stage.style.width = "100vw"
+          stage.style.height = "100vh"
+          stage.style.zIndex = "2147483000"
+          stage.style.backgroundColor = "black"
+        }
+
+        if (hidden > 0) {
+          console.log(
+            "[Teams] modern: hid",
+            hidden,
+            "rail element(s); stage promoted:",
             stage instanceof HTMLElement,
           )
         }
@@ -208,6 +283,7 @@ export class TeamsHtmlCleaner {
         }
 
         cleanLightClient(documentRoot)
+        cleanModernClient(documentRoot)
       }
 
       function removeShityHtml() {
@@ -258,6 +334,7 @@ export class TeamsHtmlCleaner {
         }
 
         cleanLightClient(documentRoot)
+        cleanModernClient(documentRoot)
       }
 
       // Execute Teams provider

--- a/src/meeting/teams/htmlCleaner.ts
+++ b/src/meeting/teams/htmlCleaner.ts
@@ -163,68 +163,6 @@ export class TeamsHtmlCleaner {
         }
       }
 
-      // DIAGNOSTIC: dump the live meeting DOM so we can target the exact v2 selectors
-      // for the chat rail, the video stage, and the camera/mic controls. Logged once
-      // at cleaner start; remove once the modern selectors are pinned down.
-      function logCleanerDiag(documentRoot: Document) {
-        try {
-          const win = documentRoot.defaultView || window
-          const lines: string[] = [`[Teams][cleaner-diag] url=${location.href}`]
-          const videos = Array.from(documentRoot.querySelectorAll("video"))
-          lines.push(`videos=${videos.length}`)
-          videos.slice(0, 4).forEach((v, i) => {
-            const chain: string[] = []
-            let n: Element | null = v
-            for (let d = 0; d < 10 && n; d++) {
-              const tid = n.getAttribute("data-tid")
-              chain.push(`${n.tagName}${n.id ? `#${n.id}` : ""}${tid ? `[${tid}]` : ""}`)
-              n = n.parentElement
-            }
-            const r = v.getBoundingClientRect()
-            lines.push(
-              `  video#${i} ${Math.round(r.width)}x${Math.round(r.height)} @${Math.round(r.left)},${Math.round(r.top)} chain=${chain.join(" < ")}`,
-            )
-          })
-          const big: Array<{ tid: string; w: number; h: number; x: number; z: string }> = []
-          documentRoot.querySelectorAll("[data-tid]").forEach((el) => {
-            if (!(el instanceof HTMLElement)) return
-            const r = el.getBoundingClientRect()
-            if (r.width < 150 || r.height < 150) return
-            big.push({
-              tid: el.getAttribute("data-tid") || "",
-              w: Math.round(r.width),
-              h: Math.round(r.height),
-              x: Math.round(r.left),
-              z: win.getComputedStyle(el).zIndex,
-            })
-          })
-          big.sort((a, b) => b.w * b.h - a.w * a.h)
-          lines.push("large-containers (rails/stage):")
-          big.slice(0, 18).forEach((b) => lines.push(`  tid=${b.tid} ${b.w}x${b.h} @x${b.x} z=${b.z}`))
-          const btns: string[] = []
-          documentRoot.querySelectorAll('button, [role="button"]').forEach((el) => {
-            if (!(el instanceof HTMLElement)) return
-            const r = el.getBoundingClientRect()
-            if (r.width === 0 || r.height === 0) return
-            const label = (
-              el.getAttribute("aria-label") ||
-              el.getAttribute("title") ||
-              el.textContent ||
-              ""
-            )
-              .replace(/\s+/g, " ")
-              .trim()
-              .slice(0, 40)
-            const tid = el.getAttribute("data-tid")
-            if (label || tid) btns.push(`${tid ? `[${tid}]` : ""} ${label}`.trim())
-          })
-          lines.push(`buttons(${btns.length}): ${JSON.stringify(btns.slice(0, 40))}`)
-          console.log(lines.join("\n"))
-        } catch (e) {
-          console.warn("[Teams][cleaner-diag] failed", e)
-        }
-      }
-
       // The AUTHENTICATED teams.microsoft.com/v2 client differs from BOTH the classic
       // client and the teams.live.com "light" client. Its chat / people rail renders at
       // a very high z-index, so cleanLightClient's stage promotion doesn't cover it and
@@ -233,69 +171,62 @@ export class TeamsHtmlCleaner {
       // meeting video stage above everything — falling back to the common ancestor of
       // the <video> tiles when no known stage tid matches. No-op on other clients.
       function cleanModernClient(documentRoot: Document) {
+        // v2 authenticated client: the meeting stage lives in app-layout-area--main
+        // (stage-layout / modern-stage-wrapper); the chat/people rail, nav, header,
+        // toasts and notifications each live in a sibling app-layout-area--* node.
+        // Hide every chrome area (this is what removes the open chat panel) and promote
+        // the main area to fill the viewport so the recording shows only the video.
         let hidden = 0
-        const railSelectors = [
-          '[data-tid="chat-pane-list"]',
-          '[data-tid="chat-pane-compose-message-footer"]',
-          '[data-tid="right-rail"]',
-          '[data-tid="calling-right-side-panel"]',
-          '[data-tid="roster-panel"]',
-          '[data-tid="people-panel"]',
-          '[role="complementary"]',
+        const chromeAreas = [
+          "end", // chat / people / roster side rail
+          "nav",
+          "sub-nav",
+          "mid-nav",
+          "start",
+          "title-bar",
+          "header",
+          "toasts",
+          "notifications",
+          "contextual-notifications",
+          "preview",
         ]
-        for (const sel of railSelectors) {
-          documentRoot.querySelectorAll(sel).forEach((el) => {
-            if (!(el instanceof HTMLElement)) return
-            el.style.display = "none"
-            hidden++
-            // Collapse the immediate rail wrapper too, but never a layout root.
-            const parent = el.parentElement
-            if (
-              parent instanceof HTMLElement &&
-              parent.id !== "call-screen-wrapper" &&
-              parent.id !== "root" &&
-              parent.tagName !== "BODY"
-            ) {
-              parent.style.display = "none"
-            }
-          })
+        for (const area of chromeAreas) {
+          documentRoot
+            .querySelectorAll(`[data-tid="app-layout-area--${area}"]`)
+            .forEach((el) => {
+              if (el instanceof HTMLElement) {
+                el.style.display = "none"
+                hidden++
+              }
+            })
         }
 
-        // Promote the meeting stage to fullscreen, above the chat rail. Prefer known
-        // modern stage tids; fall back to the smallest common ancestor of the video
-        // tiles so this keeps working even if Teams renames the stage container.
-        let stage: Element | null =
-          documentRoot.querySelector('[data-tid="calling-stage"]') ||
-          documentRoot.querySelector('[data-tid="modern-stage"]') ||
-          documentRoot.querySelector('[data-tid="stage-layout"]') ||
-          documentRoot.querySelector('[data-tid="modern-stage-wrapper"]') ||
-          documentRoot.querySelector('[data-tid="only-videos-wrapper"]')
-        if (!(stage instanceof HTMLElement)) {
-          const videos = Array.from(documentRoot.querySelectorAll("video"))
-          if (videos.length > 0) {
-            let common: HTMLElement | null = videos[0].parentElement
-            while (common && !videos.every((v) => (common as HTMLElement).contains(v))) {
-              common = common.parentElement
-            }
-            stage = common
-          }
+        // Expand the main area to fill the viewport, above anything chrome-y that peeks.
+        const main = documentRoot.querySelector('[data-tid="app-layout-area--main"]')
+        if (main instanceof HTMLElement) {
+          main.style.position = "fixed"
+          main.style.top = "0"
+          main.style.left = "0"
+          main.style.width = "100vw"
+          main.style.height = "100vh"
+          main.style.zIndex = "2147483000"
+          main.style.backgroundColor = "black"
         }
+        const stage =
+          documentRoot.querySelector('[data-tid="modern-stage-wrapper"]') ||
+          documentRoot.querySelector('[data-tid="stage-layout"]') ||
+          documentRoot.querySelector('[data-tid="only-videos-wrapper"]')
         if (stage instanceof HTMLElement) {
-          stage.style.position = "fixed"
-          stage.style.top = "0"
-          stage.style.left = "0"
-          stage.style.width = "100vw"
-          stage.style.height = "100vh"
-          stage.style.zIndex = "2147483000"
-          stage.style.backgroundColor = "black"
+          stage.style.width = "100%"
+          stage.style.height = "100%"
         }
 
         if (hidden > 0) {
           console.log(
             "[Teams] modern: hid",
             hidden,
-            "rail element(s); stage promoted:",
-            stage instanceof HTMLElement,
+            "chrome area(s); main promoted:",
+            main instanceof HTMLElement,
           )
         }
       }

--- a/src/meeting/teams/htmlCleaner.ts
+++ b/src/meeting/teams/htmlCleaner.ts
@@ -163,6 +163,68 @@ export class TeamsHtmlCleaner {
         }
       }
 
+      // DIAGNOSTIC: dump the live meeting DOM so we can target the exact v2 selectors
+      // for the chat rail, the video stage, and the camera/mic controls. Logged once
+      // at cleaner start; remove once the modern selectors are pinned down.
+      function logCleanerDiag(documentRoot: Document) {
+        try {
+          const win = documentRoot.defaultView || window
+          const lines: string[] = [`[Teams][cleaner-diag] url=${location.href}`]
+          const videos = Array.from(documentRoot.querySelectorAll("video"))
+          lines.push(`videos=${videos.length}`)
+          videos.slice(0, 4).forEach((v, i) => {
+            const chain: string[] = []
+            let n: Element | null = v
+            for (let d = 0; d < 10 && n; d++) {
+              const tid = n.getAttribute("data-tid")
+              chain.push(`${n.tagName}${n.id ? `#${n.id}` : ""}${tid ? `[${tid}]` : ""}`)
+              n = n.parentElement
+            }
+            const r = v.getBoundingClientRect()
+            lines.push(
+              `  video#${i} ${Math.round(r.width)}x${Math.round(r.height)} @${Math.round(r.left)},${Math.round(r.top)} chain=${chain.join(" < ")}`,
+            )
+          })
+          const big: Array<{ tid: string; w: number; h: number; x: number; z: string }> = []
+          documentRoot.querySelectorAll("[data-tid]").forEach((el) => {
+            if (!(el instanceof HTMLElement)) return
+            const r = el.getBoundingClientRect()
+            if (r.width < 150 || r.height < 150) return
+            big.push({
+              tid: el.getAttribute("data-tid") || "",
+              w: Math.round(r.width),
+              h: Math.round(r.height),
+              x: Math.round(r.left),
+              z: win.getComputedStyle(el).zIndex,
+            })
+          })
+          big.sort((a, b) => b.w * b.h - a.w * a.h)
+          lines.push("large-containers (rails/stage):")
+          big.slice(0, 18).forEach((b) => lines.push(`  tid=${b.tid} ${b.w}x${b.h} @x${b.x} z=${b.z}`))
+          const btns: string[] = []
+          documentRoot.querySelectorAll('button, [role="button"]').forEach((el) => {
+            if (!(el instanceof HTMLElement)) return
+            const r = el.getBoundingClientRect()
+            if (r.width === 0 || r.height === 0) return
+            const label = (
+              el.getAttribute("aria-label") ||
+              el.getAttribute("title") ||
+              el.textContent ||
+              ""
+            )
+              .replace(/\s+/g, " ")
+              .trim()
+              .slice(0, 40)
+            const tid = el.getAttribute("data-tid")
+            if (label || tid) btns.push(`${tid ? `[${tid}]` : ""} ${label}`.trim())
+          })
+          lines.push(`buttons(${btns.length}): ${JSON.stringify(btns.slice(0, 40))}`)
+          console.log(lines.join("\n"))
+        } catch (e) {
+          console.warn("[Teams][cleaner-diag] failed", e)
+        }
+      }
+
       // The AUTHENTICATED teams.microsoft.com/v2 client differs from BOTH the classic
       // client and the teams.live.com "light" client. Its chat / people rail renders at
       // a very high z-index, so cleanLightClient's stage promotion doesn't cover it and

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -402,9 +402,12 @@ export function teamsBrowserInterceptionLogic() {
     {
       const OriginalRTCPeerConnection = (window as any).RTCPeerConnection
       const attachMainChannel = (channel: any) => {
+        // DIAG: log EVERY data-channel label so we can see what the v2 app opens
+        // (empty diarization ⇒ maybe it isn't "main-channel", or the proxy loaded late).
+        console.warn(`${LOG} 📡 datachannel label="${channel?.label}"`)
         if (channel?.label !== "main-channel") return
         channel.addEventListener("message", (event: any) => handleMainChannelEvent(event))
-        debug("🔌 main-channel attached")
+        console.warn(`${LOG} 🔌 main-channel attached`)
       }
       const ProxiedRTCPeerConnection = function (this: any, ...args: any[]) {
         const pc = Reflect.construct(OriginalRTCPeerConnection, args) as RTCPeerConnection
@@ -429,6 +432,7 @@ export function teamsBrowserInterceptionLogic() {
           OriginalRTCPeerConnection.generateCertificate(...a)
       }
       ;(window as any).RTCPeerConnection = ProxiedRTCPeerConnection
+      console.warn(`${LOG} 🔌 RTCPeerConnection proxied (waiting for data channels)`)
     }
 
     // Poll loop for CSRC-based per-participant speaking.

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -28,12 +28,15 @@ export function teamsBrowserInterceptionLogic() {
     if (!(window as any).pako) {
       console.error(`${LOG} ❌ pako not loaded, cannot decode roster frames`)
     }
-    console.warn(`${LOG} ✅ Activated`) // warn → surfaces via page-logger
 
     // ===== STATE =====
 
     // deviceId (roster details.id) → participant record
     const participantsByDeviceId = new Map<string, any>()
+    // Speaker updates reach Node by being pushed onto this queue, which Node drains
+    // via page.evaluate (the interceptor's context cannot see exposeFunction bindings
+    // under CloakBrowser).
+    ;(window as any).__teamsSpeakerQueue = (window as any).__teamsSpeakerQueue || []
     // virtual stream id (string) → { participantId, displayName, type, isAudio, isActive }
     const virtualStreams = new Map<string, any>()
     // current dominant speaker's audio virtual stream id (from "dsh")
@@ -131,38 +134,97 @@ export function teamsBrowserInterceptionLogic() {
       }
     }
 
+    // Pull a display name / stable id across BOTH the WebSocket roster shape
+    // (participant.details.{displayName,id}) and the HTTP snapshot shapes, which nest
+    // the identity differently.
+    function rosterName(pp: any): string | undefined {
+      return (
+        pp?.details?.displayName ||
+        pp?.displayName ||
+        pp?.identity?.displayName ||
+        pp?.user?.displayName ||
+        pp?.participant?.displayName
+      )
+    }
+    function rosterId(pp: any): string | undefined {
+      return (
+        pp?.details?.id ||
+        pp?.id ||
+        pp?.mri ||
+        pp?.participantId ||
+        pp?.endpointId ||
+        pp?.identity?.id
+      )
+    }
+
+    // Shared by the WebSocket delta path AND the HTTP snapshot path.
+    function applyParticipants(rawParticipants: any[]): void {
+      const participants = rawParticipants.filter((pp) => rosterName(pp))
+      const currentUserId = getCurrentUserId()
+      let changed = false
+      for (const participant of participants) {
+        const deviceId = rosterId(participant)
+        if (!deviceId) continue
+        const record = {
+          deviceId,
+          displayName: rosterName(participant),
+          status: participant.state === "active" ? 1 : 6,
+          isHost: participant.meetingRole === "organizer",
+          isCurrentUser: !!currentUserId && deviceId === currentUserId
+        }
+        const previous = participantsByDeviceId.get(deviceId)
+        if (!previous || JSON.stringify(previous) !== JSON.stringify(record)) changed = true
+        participantsByDeviceId.set(deviceId, record)
+        syncVirtualStreamsFromParticipant(participant)
+      }
+      if (changed) broadcastSpeakerUpdate("roster")
+    }
+
     function handleRosterUpdate(eventDataObject: any): void {
       try {
         const decodedBody = decodeWebSocketBody(eventDataObject.body)
-        // Teams includes a phantom user with no display name; skip it.
-        const participants = Object.values<any>(decodedBody.participants || {}).filter(
-          (p) => p?.details?.displayName
-        )
-        const currentUserId = getCurrentUserId()
-        let changed = false
-
-        for (const participant of participants) {
-          const deviceId = participant.details?.id
-          if (!deviceId) continue
-
-          const record = {
-            deviceId,
-            displayName: participant.details.displayName,
-            status: participant.state === "active" ? 1 : 6,
-            isHost: participant.meetingRole === "organizer",
-            isCurrentUser: !!currentUserId && deviceId === currentUserId
-          }
-
-          const previous = participantsByDeviceId.get(deviceId)
-          if (!previous || JSON.stringify(previous) !== JSON.stringify(record)) changed = true
-          participantsByDeviceId.set(deviceId, record)
-          syncVirtualStreamsFromParticipant(participant)
-        }
-
-        debug(`👥 roster: ${participantsByDeviceId.size} participants`)
-        if (changed) broadcastSpeakerUpdate("roster")
+        const rawParticipants = Object.values<any>(decodedBody.participants || {})
+        applyParticipants(rawParticipants)
       } catch (error) {
         console.error(`${LOG} ❌ Error handling roster update:`, error)
+      }
+    }
+
+    // ===== ROSTER (HTTP snapshot) =====
+    // The trouter WebSocket only delivers roster DELTAS to this late-connecting client
+    // (see the "trouter.message_loss" frames). Anyone already in the meeting when the
+    // bot joins is recovered by the client via an HTTP snapshot, NOT the socket — so
+    // intercept those responses and merge them into the same participant map.
+    // Teams roster maps are objects keyed by MRI (e.g. { "8:orgid:...": {...} }),
+    // NOT arrays. Convert to an array and inject the MRI key as an id fallback.
+    function participantsToArray(pm: any): any[] | null {
+      if (!pm) return null
+      if (Array.isArray(pm)) return pm
+      if (typeof pm === "object") {
+        return Object.entries(pm as Record<string, any>).map(([mri, pv]) =>
+          pv && typeof pv === "object" ? { mri, ...pv } : pv
+        )
+      }
+      return null
+    }
+
+    function tryHttpRoster(url: string, text: string): void {
+      try {
+        if (!text || text.indexOf("displayName") === -1) return
+        const body = JSON.parse(text)
+        // The HTTP snapshot nests the roster as { roster: { participants: {mri: {...}} } };
+        // other endpoints use top-level participants / value. Handle all as object-or-array.
+        const raw =
+          participantsToArray(body?.roster?.participants) ||
+          participantsToArray(body?.participants) ||
+          participantsToArray(body?.value) ||
+          participantsToArray(body?.participants?.value) ||
+          (Array.isArray(body) ? body : null)
+        if (raw && raw.length) {
+          applyParticipants(raw)
+        }
+      } catch {
+        // not JSON — ignore
       }
     }
 
@@ -323,7 +385,6 @@ export function teamsBrowserInterceptionLogic() {
 
     function broadcastSpeakerUpdate(source: "roster" | "audio"): void {
       if ((window as any).__teamsNetworkInterceptorStopped) return
-      if (typeof (window as any).onNetworkSpeakerUpdate !== "function") return
 
       // CSRC when available (silence == nobody), else dsh dominant speaker.
       let speaking: Set<string>
@@ -334,7 +395,7 @@ export function teamsBrowserInterceptionLogic() {
         speaking = dominant ? new Set([dominant]) : new Set()
       }
 
-      const users = Array.from(participantsByDeviceId.values()).map((p) => ({
+      const rawUsers = Array.from(participantsByDeviceId.values()).map((p) => ({
         deviceId: p.deviceId,
         name: p.displayName || "Unknown",
         isCurrentUser: p.isCurrentUser === true,
@@ -347,23 +408,53 @@ export function teamsBrowserInterceptionLogic() {
         profilePicture: undefined
       }))
 
-      // Debug: log speakers + signal on change, to confirm detection is from
-      // network interception. warn → surfaces through the page-logger.
-      const method = csrcAvailable ? "csrc" : dominantSpeakerStreamId ? "dsh" : "none"
-      const speakingNames = users.filter((u) => u.isSpeaking).map((u) => u.name)
-      const logKey = `${speakingNames.slice().sort().join("|")}#${method}`
-      if (logKey !== lastSpeakingLogKey) {
-        lastSpeakingLogKey = logKey
-        console.warn(
-          `${LOG} 🗣️ speaking=[${speakingNames.join(", ") || "(none)"}] method=${method} source=${source} participants=${users.length}`
-        )
+      // Dedupe by AAD identity. The same account can appear under more than one roster
+      // entry — the bot showed up under both its directory name and its in-call name
+      // (different endpoint ids), surfacing as a phantom extra speaker. Collapse rows
+      // that share an org identity (8:orgid:<oid>); OR their speaking/host/self flags.
+      // Guests/anonymous participants have no orgid, so they key on their full id and
+      // are NEVER merged — anonymous meetings behave exactly as before.
+      const identityKey = (deviceId: string): string => {
+        const m =
+          typeof deviceId === "string" ? deviceId.match(/8:orgid:([0-9a-fA-F-]{36})/) : null
+        return m ? `orgid:${m[1].toLowerCase()}` : String(deviceId)
       }
+      const byIdentity = new Map<string, (typeof rawUsers)[number]>()
+      for (const u of rawUsers) {
+        const key = identityKey(u.deviceId)
+        const prev = byIdentity.get(key)
+        if (!prev) {
+          byIdentity.set(key, u)
+        } else {
+          prev.isSpeaking = prev.isSpeaking || u.isSpeaking
+          prev.isCurrentUser = prev.isCurrentUser || u.isCurrentUser
+          prev.isHost = prev.isHost || u.isHost
+          if (u.status === 1) prev.status = 1
+          if ((prev.name === "Unknown" || !prev.displayName) && u.displayName) {
+            prev.name = u.displayName
+            prev.displayName = u.displayName
+            prev.fullName = u.displayName
+          }
+        }
+      }
+      const users = Array.from(byIdentity.values())
 
-      ;(window as any).onNetworkSpeakerUpdate({
-        users,
-        timestamp: Date.now(),
-        source
-      })
+      // Only enqueue when the roster or speaking set actually changed — keeps the
+      // pipeline (and logs) quiet during steady state.
+      const key = users
+        .map((u) => `${u.deviceId}:${u.isSpeaking ? 1 : 0}`)
+        .sort()
+        .join("|")
+      if (key === lastSpeakingLogKey) return
+      lastSpeakingLogKey = key
+
+      try {
+        const q = (window as any).__teamsSpeakerQueue as any[]
+        if (q.length > 500) q.splice(0, q.length - 500)
+        q.push({ users, timestamp: Date.now(), source })
+      } catch {
+        // ignore
+      }
     }
 
     // ===== INTERCEPTORS =====
@@ -380,7 +471,8 @@ export function teamsBrowserInterceptionLogic() {
             const eventDataObject = JSON.parse(data.slice(4))
             const eventUrl = eventDataObject?.url
             if (typeof eventUrl !== "string") return
-            if (eventUrl.endsWith("rosterUpdate/") || eventUrl.endsWith("rosterUpdate")) {
+            // Match any roster-bearing signaling URL (initial snapshot + deltas).
+            if (eventUrl.toLowerCase().includes("roster")) {
               handleRosterUpdate(eventDataObject)
             }
           } catch {
@@ -397,17 +489,78 @@ export function teamsBrowserInterceptionLogic() {
       ;(window as any).WebSocket = ProxiedWebSocket
     }
 
+    // HTTP roster interceptor (fetch + XHR). Feeds tryHttpRoster so the full roster
+    // (participants already present before the bot joined) is recovered from the
+    // client's HTTP snapshot, not just the socket deltas. Wrap-and-forward only — the
+    // original response is returned untouched; we read a clone.
+    {
+      const rosterUrlRe = /callagent|conversation|roster|participant|calling|skype|flightproxy|\/csa\/|\/api\//i
+      try {
+        const origFetch = (window.fetch as any).bind(window)
+        ;(window as any).fetch = function (...args: any[]) {
+          const promise = origFetch(...args)
+          try {
+            const req = args[0]
+            const url = typeof req === "string" ? req : req?.url
+            if (url && rosterUrlRe.test(url)) {
+              promise
+                .then((resp: any) => {
+                  try {
+                    resp
+                      .clone()
+                      .text()
+                      .then((t: string) => tryHttpRoster(url, t))
+                      .catch(() => {})
+                  } catch {}
+                  return resp
+                })
+                .catch(() => {})
+            }
+          } catch {}
+          return promise
+        }
+      } catch {
+        // ignore
+      }
+      try {
+        const origOpen = XMLHttpRequest.prototype.open
+        const origSend = XMLHttpRequest.prototype.send
+        XMLHttpRequest.prototype.open = function (
+          this: any,
+          method: string,
+          url: string,
+          ...rest: any[]
+        ) {
+          this.__teamsUrl = url
+          return (origOpen as any).call(this, method, url, ...rest)
+        }
+        XMLHttpRequest.prototype.send = function (this: any, ...sargs: any[]) {
+          try {
+            const url = this.__teamsUrl
+            if (url && rosterUrlRe.test(url)) {
+              this.addEventListener("load", () => {
+                try {
+                  if (typeof this.responseText === "string") {
+                    tryHttpRoster(url, this.responseText)
+                  }
+                } catch {}
+              })
+            }
+          } catch {}
+          return (origSend as any).apply(this, sargs)
+        }
+      } catch {
+        // ignore
+      }
+    }
+
     // RTCPeerConnection proxy — capture the "main-channel" data channel (dsh)
     // and audio receivers (CSRC).
     {
       const OriginalRTCPeerConnection = (window as any).RTCPeerConnection
       const attachMainChannel = (channel: any) => {
-        // DIAG: log EVERY data-channel label so we can see what the v2 app opens
-        // (empty diarization ⇒ maybe it isn't "main-channel", or the proxy loaded late).
-        console.warn(`${LOG} 📡 datachannel label="${channel?.label}"`)
         if (channel?.label !== "main-channel") return
         channel.addEventListener("message", (event: any) => handleMainChannelEvent(event))
-        console.warn(`${LOG} 🔌 main-channel attached`)
       }
       const ProxiedRTCPeerConnection = function (this: any, ...args: any[]) {
         const pc = Reflect.construct(OriginalRTCPeerConnection, args) as RTCPeerConnection
@@ -432,7 +585,6 @@ export function teamsBrowserInterceptionLogic() {
           OriginalRTCPeerConnection.generateCertificate(...a)
       }
       ;(window as any).RTCPeerConnection = ProxiedRTCPeerConnection
-      console.warn(`${LOG} 🔌 RTCPeerConnection proxied (waiting for data channels)`)
     }
 
     // Poll loop for CSRC-based per-participant speaking.
@@ -445,10 +597,7 @@ export function teamsBrowserInterceptionLogic() {
       } catch {
         // ignore
       }
-      console.log(`${LOG} ✅ Stopped`)
     }
-
-    console.warn(`${LOG} ✅ Interceptors installed (WebSocket roster, main-channel dsh, CSRC poll)`)
   } catch (error) {
     console.error("[NetworkInterceptor][Teams] ❌ Initialization error:", error)
   }

--- a/src/meeting/teams/network-interception/index.ts
+++ b/src/meeting/teams/network-interception/index.ts
@@ -66,7 +66,20 @@ export async function setupTeamsNetworkInterceptionCallback(
   onSpeakersChange: (payload: NetworkPayload) => void
 ): Promise<boolean> {
   try {
-    await page.exposeFunction("onNetworkSpeakerUpdate", onSpeakersChange)
+    // DIAG: count/log speaker updates reaching Node. Empty diarization means either
+    // none arrive (browser-side data-channel issue — see the [NetworkInterceptor]
+    // datachannel logs) or the write path downstream drops them.
+    let speakerUpdateCount = 0
+    const wrapped = (payload: NetworkPayload) => {
+      speakerUpdateCount++
+      if (speakerUpdateCount <= 30 || speakerUpdateCount % 25 === 0) {
+        console.log(
+          `[Teams][speaker-diag] update #${speakerUpdateCount}: ${JSON.stringify(payload).slice(0, 220)}`
+        )
+      }
+      onSpeakersChange(payload)
+    }
+    await page.exposeFunction("onNetworkSpeakerUpdate", wrapped)
     console.log("[Teams NetworkInterceptor] ✅ Callback exposed")
     return verifyTeamsNetworkInterception(page)
   } catch (error) {

--- a/src/meeting/teams/network-interception/index.ts
+++ b/src/meeting/teams/network-interception/index.ts
@@ -66,21 +66,31 @@ export async function setupTeamsNetworkInterceptionCallback(
   onSpeakersChange: (payload: NetworkPayload) => void
 ): Promise<boolean> {
   try {
-    // DIAG: count/log speaker updates reaching Node. Empty diarization means either
-    // none arrive (browser-side data-channel issue — see the [NetworkInterceptor]
-    // datachannel logs) or the write path downstream drops them.
-    let speakerUpdateCount = 0
-    const wrapped = (payload: NetworkPayload) => {
-      speakerUpdateCount++
-      if (speakerUpdateCount <= 30 || speakerUpdateCount % 25 === 0) {
-        console.log(
-          `[Teams][speaker-diag] update #${speakerUpdateCount}: ${JSON.stringify(payload).slice(0, 220)}`
-        )
-      }
-      onSpeakersChange(payload)
-    }
-    await page.exposeFunction("onNetworkSpeakerUpdate", wrapped)
+    await page.exposeFunction("onNetworkSpeakerUpdate", onSpeakersChange)
     console.log("[Teams NetworkInterceptor] ✅ Callback exposed")
+
+    // Speaker delivery via a drained queue: exposeFunction's window binding is not
+    // visible inside the interceptor bundle's context under CloakBrowser, but
+    // page.evaluate can read globals the bundle writes — so the bundle pushes speaker
+    // payloads onto window.__teamsSpeakerQueue and we drain + dispatch them here.
+    const drainSpeakerQueue = async () => {
+      try {
+        const payloads = (await page.evaluate(() => {
+          const w = window as any
+          const q = w.__teamsSpeakerQueue || []
+          w.__teamsSpeakerQueue = []
+          return q
+        })) as NetworkPayload[]
+        for (const payload of payloads) onSpeakersChange(payload)
+      } catch {
+        // page navigating/closed — ignore
+      }
+    }
+    const speakerPoll = setInterval(() => {
+      void drainSpeakerQueue()
+    }, 250)
+    page.on("close", () => clearInterval(speakerPoll))
+
     return verifyTeamsNetworkInterception(page)
   } catch (error) {
     console.error("[Teams NetworkInterceptor] Failed to expose function:", error)

--- a/src/meeting/teams/speakersObserver.ts
+++ b/src/meeting/teams/speakersObserver.ts
@@ -183,18 +183,28 @@ export class TeamsSpeakersObserver {
                   }
                 }
               } else {
-                // new teams
-                const name = element.getAttribute("data-tid")
-                console.log(`[TEAMS-DEBUG] New teams - found name of length: "${name.length}"`)
+                // new teams (v2): tiles are [data-cid="calling-participant-stream"]
+                // with data-tid=<email> and aria-label="<Display Name>, ...". Prefer the
+                // display name; fall back to the tid.
+                const name =
+                  element.getAttribute("aria-label")?.split(",")[0]?.trim() ||
+                  element.getAttribute("data-tid") ||
+                  ""
                 if (name) {
                   const micPath = element.querySelector("g.ui-icon__outline path")
                   const isMuted = micPath?.getAttribute("d")?.startsWith("M12 5v4.879") || false
                   const voiceLevelIndicator = element.querySelector(
                     '[data-tid="voice-level-stream-outline"]'
                   )
+                  // v2 exposes the active speaker directly via data-is-speaking on the
+                  // voice-level-stream-outline — read it (reliable) and fall back to the
+                  // border/opacity heuristic only for older clients that lack it.
+                  const speakingAttr = voiceLevelIndicator?.getAttribute("data-is-speaking")
                   const isSpeaking =
                     voiceLevelIndicator && !isMuted
-                      ? checkElementAndPseudo(voiceLevelIndicator as HTMLElement)
+                      ? speakingAttr != null
+                        ? speakingAttr === "true"
+                        : checkElementAndPseudo(voiceLevelIndicator as HTMLElement)
                       : false
 
                   return {

--- a/src/meeting/teams/speakersObserver.ts
+++ b/src/meeting/teams/speakersObserver.ts
@@ -186,10 +186,9 @@ export class TeamsSpeakersObserver {
                 // new teams (v2): tiles are [data-cid="calling-participant-stream"]
                 // with data-tid=<email> and aria-label="<Display Name>, ...". Prefer the
                 // display name; fall back to the tid.
-                const name =
-                  element.getAttribute("aria-label")?.split(",")[0]?.trim() ||
-                  element.getAttribute("data-tid") ||
-                  ""
+                // data-tid on v2 tiles holds the participant's raw email — never use it
+                // as a display name (PII). If aria-label parsing fails, skip the tile.
+                const name = element.getAttribute("aria-label")?.split(",")[0]?.trim() || ""
                 if (name) {
                   const micPath = element.querySelector("g.ui-icon__outline path")
                   const isMuted = micPath?.getAttribute("d")?.startsWith("M12 5v4.879") || false

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -165,6 +165,18 @@ export async function loginToTeamsWithCredentials(
 
 /** One-time fetch of the decrypted credentials for the assigned session. */
 async function resolveCredentials(config: TeamsLoginConfig): Promise<ResolvedCredentials> {
+  // LOCAL TESTING ONLY: if TEAMS_LOGIN_LOCAL_PASSWORD is set, skip the api-server
+  // resolve-session fetch and sign in with login_email + this password directly.
+  // Lets `run_bot.sh` drive an authenticated Teams bot without api-server/SQS.
+  // NEVER set this in a deployed environment.
+  const localPassword = process.env.TEAMS_LOGIN_LOCAL_PASSWORD
+  if (localPassword) {
+    console.warn(
+      `[teams-login] TEAMS_LOGIN_LOCAL_PASSWORD set — LOCAL TEST MODE, using it for ${config.login_email} (skipping resolve-session)`
+    )
+    return { email: config.login_email, password: localPassword }
+  }
+
   const res = await fetch(config.resolve_url, {
     headers: {
       "x-teams-session-id": config.session_id,

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -82,7 +82,6 @@ export async function loginToTeamsWithCredentials(
       waitUntil: "domcontentloaded",
       timeout: 20_000
     })
-    await logLoginState(page, "1-login-loaded")
 
     // 2. Email -> Next
     const emailInput = page.locator('input[type="email"], input[name="loginfmt"]').first()
@@ -90,7 +89,6 @@ export async function loginToTeamsWithCredentials(
     await emailInput.fill(email)
     await clickPrimary(page, ["Next"])
     await page.waitForTimeout(1_500)
-    await logLoginState(page, "2-after-email-next")
 
     // 3. Password -> Sign in
     const passwordInput = page.locator('input[type="password"], input[name="passwd"]').first()
@@ -100,7 +98,6 @@ export async function loginToTeamsWithCredentials(
 
     // 4. Give the response a moment, then classify credential / captcha / MFA errors.
     await page.waitForTimeout(2_000)
-    await logLoginState(page, "3-after-signin")
     await detectLoginError(page)
 
     // 5. "Stay signed in?" (KMSI) — click Yes so the session persists.
@@ -164,42 +161,6 @@ export async function loginToTeamsWithCredentials(
     const message = err instanceof Error ? err.message : String(err)
     console.error(`[teams-login] sign-in failed: ${message} (last URL: ${currentUrl})`)
     throw new TeamsLoginError("TEAMS_LOGIN_FAILED_TIMEOUT", `${message} (last URL: ${currentUrl})`)
-  }
-}
-
-/** One-time fetch of the decrypted credentials for the assigned session. */
-async function logLoginState(page: Page, label: string): Promise<void> {
-  try {
-    const info = await page.evaluate(() => {
-      const clip = (s: string | null | undefined): string =>
-        (s || "").replace(/\s+/g, " ").trim().slice(0, 70)
-      const inputs = Array.from(document.querySelectorAll("input")).map(
-        (i) => `${i.type || "?"}${i.name ? `[${i.name}]` : ""}${i.placeholder ? `(${i.placeholder})` : ""}`
-      )
-      const buttons = Array.from(document.querySelectorAll("button, input[type=submit]"))
-        .map((b) =>
-          clip((b as HTMLInputElement).value || b.textContent || b.getAttribute("aria-label"))
-        )
-        .filter((t) => t.length > 0)
-        .slice(0, 8)
-      const heading = clip(
-        document.querySelector("h1, [role=heading], #loginHeader, .row-title")?.textContent
-      )
-      const errorEl = document.querySelector(
-        '[role="alert"], .alert-error, #passwordError, [id*="error" i]'
-      )
-      return { title: document.title, heading, inputs, buttons, error: clip(errorEl?.textContent) }
-    })
-    console.info(`[teams-login][ui] ${label} url=${page.url()}`)
-    console.info(
-      `[teams-login][ui] ${label} title=${JSON.stringify(info.title)} heading=${JSON.stringify(info.heading)}`
-    )
-    console.info(
-      `[teams-login][ui] ${label} inputs=${JSON.stringify(info.inputs)} buttons=${JSON.stringify(info.buttons)}`
-    )
-    if (info.error) console.info(`[teams-login][ui] ${label} error=${JSON.stringify(info.error)}`)
-  } catch (e) {
-    console.warn(`[teams-login][ui] ${label} failed: ${e instanceof Error ? e.message : String(e)}`)
   }
 }
 
@@ -366,11 +327,6 @@ async function settleTeamsAuth(
     const names = teamsCookies.map((c) => c.name)
     const hasAuthToken = names.includes("authtoken")
     const hasRingFinder = names.includes("ringFinder")
-    console.info(
-      `[teams-login][settle] t=${Math.round((Date.now() - start) / 1000)}s url=${url} ` +
-        `onApp=${onTeamsApp} hasAuthToken=${hasAuthToken} hasRingFinder=${hasRingFinder} ` +
-        `teamsCookies=[${names.join(", ")}]`
-    )
     // Go the INSTANT the Teams identity is established — `ringFinder` carries the
     // signed-in oid/tid, `authtoken` is the full service token — as long as we're on
     // the Teams app (off the auth endpoints). We deliberately DON'T wait for the home

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -198,12 +198,6 @@ async function resolveCredentials(config: TeamsLoginConfig): Promise<ResolvedCre
   if (!body.email || !body.password) {
     throw new TeamsLoginError("TEAMS_LOGIN_FAILED_TIMEOUT", "resolve-session returned no credentials")
   }
-  // DIAG: log the decrypted password LENGTH (never the value). If this does not match
-  // the real password's length, the stored secret was encrypted under a different
-  // TEAMS_LOGIN_ENCRYPTION_SECRET than this api-server decrypts with.
-  console.info(
-    `[teams-login] resolved credentials for ${body.email} (password length=${body.password.length})`
-  )
   return { email: body.email, password: body.password }
 }
 

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -82,12 +82,15 @@ export async function loginToTeamsWithCredentials(
       waitUntil: "domcontentloaded",
       timeout: 20_000
     })
+    await logLoginState(page, "1-login-loaded")
 
     // 2. Email -> Next
     const emailInput = page.locator('input[type="email"], input[name="loginfmt"]').first()
     await emailInput.waitFor({ state: "visible", timeout: 15_000 })
     await emailInput.fill(email)
     await clickPrimary(page, ["Next"])
+    await page.waitForTimeout(1_500)
+    await logLoginState(page, "2-after-email-next")
 
     // 3. Password -> Sign in
     const passwordInput = page.locator('input[type="password"], input[name="passwd"]').first()
@@ -97,6 +100,7 @@ export async function loginToTeamsWithCredentials(
 
     // 4. Give the response a moment, then classify credential / captcha / MFA errors.
     await page.waitForTimeout(2_000)
+    await logLoginState(page, "3-after-signin")
     await detectLoginError(page)
 
     // 5. "Stay signed in?" (KMSI) — click Yes so the session persists.
@@ -164,6 +168,41 @@ export async function loginToTeamsWithCredentials(
 }
 
 /** One-time fetch of the decrypted credentials for the assigned session. */
+async function logLoginState(page: Page, label: string): Promise<void> {
+  try {
+    const info = await page.evaluate(() => {
+      const clip = (s: string | null | undefined): string =>
+        (s || "").replace(/\s+/g, " ").trim().slice(0, 70)
+      const inputs = Array.from(document.querySelectorAll("input")).map(
+        (i) => `${i.type || "?"}${i.name ? `[${i.name}]` : ""}${i.placeholder ? `(${i.placeholder})` : ""}`
+      )
+      const buttons = Array.from(document.querySelectorAll("button, input[type=submit]"))
+        .map((b) =>
+          clip((b as HTMLInputElement).value || b.textContent || b.getAttribute("aria-label"))
+        )
+        .filter((t) => t.length > 0)
+        .slice(0, 8)
+      const heading = clip(
+        document.querySelector("h1, [role=heading], #loginHeader, .row-title")?.textContent
+      )
+      const errorEl = document.querySelector(
+        '[role="alert"], .alert-error, #passwordError, [id*="error" i]'
+      )
+      return { title: document.title, heading, inputs, buttons, error: clip(errorEl?.textContent) }
+    })
+    console.info(`[teams-login][ui] ${label} url=${page.url()}`)
+    console.info(
+      `[teams-login][ui] ${label} title=${JSON.stringify(info.title)} heading=${JSON.stringify(info.heading)}`
+    )
+    console.info(
+      `[teams-login][ui] ${label} inputs=${JSON.stringify(info.inputs)} buttons=${JSON.stringify(info.buttons)}`
+    )
+    if (info.error) console.info(`[teams-login][ui] ${label} error=${JSON.stringify(info.error)}`)
+  } catch (e) {
+    console.warn(`[teams-login][ui] ${label} failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+}
+
 async function resolveCredentials(config: TeamsLoginConfig): Promise<ResolvedCredentials> {
   // LOCAL TESTING ONLY: if TEAMS_LOGIN_LOCAL_PASSWORD is set, skip the api-server
   // resolve-session fetch and sign in with login_email + this password directly.
@@ -193,6 +232,12 @@ async function resolveCredentials(config: TeamsLoginConfig): Promise<ResolvedCre
   if (!body.email || !body.password) {
     throw new TeamsLoginError("TEAMS_LOGIN_FAILED_TIMEOUT", "resolve-session returned no credentials")
   }
+  // DIAG: log the decrypted password LENGTH (never the value). If this does not match
+  // the real password's length, the stored secret was encrypted under a different
+  // TEAMS_LOGIN_ENCRYPTION_SECRET than this api-server decrypts with.
+  console.info(
+    `[teams-login] resolved credentials for ${body.email} (password length=${body.password.length})`
+  )
   return { email: body.email, password: body.password }
 }
 

--- a/src/state-machine/states/microsoft-teams-login.ts
+++ b/src/state-machine/states/microsoft-teams-login.ts
@@ -171,12 +171,17 @@ async function resolveCredentials(config: TeamsLoginConfig): Promise<ResolvedCre
   // NEVER set this in a deployed environment.
   const localPassword = process.env.TEAMS_LOGIN_LOCAL_PASSWORD
   if (localPassword) {
+    if (process.env.NODE_ENV === "production" || process.env.DEPLOY_ENV) {
+      throw new TeamsLoginError(
+        "TEAMS_LOGIN_FAILED_TIMEOUT",
+        "TEAMS_LOGIN_LOCAL_PASSWORD must never be set in a deployed environment"
+      )
+    }
     console.warn(
       `[teams-login] TEAMS_LOGIN_LOCAL_PASSWORD set — LOCAL TEST MODE, using it for ${config.login_email} (skipping resolve-session)`
     )
     return { email: config.login_email, password: localPassword }
   }
-
   const res = await fetch(config.resolve_url, {
     headers: {
       "x-teams-session-id": config.session_id,

--- a/teams-auth-test.config.json
+++ b/teams-auth-test.config.json
@@ -1,0 +1,30 @@
+{
+    "bot_id": 1,
+    "bot_uuid": "will-be-generated-by-run-bot-sh",
+    "bot_name": "Recording Bot",
+    "bot_image": "https://branding-template.s3.fr-par.scw.cloud/branding_template.png",
+    "meeting_url": "https://teams.microsoft.com/meet/321925760113664?p=0if95sfx8BsKlD4yrv",
+    "meeting_platform": "teams",
+    "entry_message": "Recording bot has joined the meeting",
+    "recording_mode": "speaker_view",
+    "data_retention_days": 30,
+    "transformed_meeting_url": null,
+    "streaming_input": null,
+    "streaming_output": null,
+    "streaming_audio_frequency": 24000,
+    "start_time": 0,
+    "exit_time": 0,
+    "waiting_room_timeout": 600,
+    "no_one_joined_timeout": 600,
+    "silence_timeout": 600,
+    "grace_period": 0,
+    "speech_to_text_provider": "gladia",
+    "retry_count": 0,
+    "teams_login_config": {
+        "session_id": "00000000-0000-4000-8000-000000000000",
+        "login_email": "bot1@kapipass.onmicrosoft.com",
+        "resolve_url": "http://localhost:3001/v2/teams-login/resolve-session",
+        "fallback": "fail"
+    },
+    "extra": {}
+}


### PR DESCRIPTION
# Microsoft Teams Authenticated Bots — Speaker Separation, Cleaner & Mute

## Summary
Completes authenticated-account Teams support: when the bot signs into a real Microsoft account and joins as that user, it now records with correct **network-based, per-participant speaker separation**, a clean video-only frame, camera on, and mic muted.

Highlights:
- **Network speaker separation (primary).** Speaking is attributed per participant from the meeting's own signaling, not the DOM. Two people talking are separated correctly, including overlap.
- **Full roster recovery.** The trouter WebSocket only delivers roster *deltas* to a late-joining bot (`trouter.message_loss`); participants already in the meeting are recovered from the client's **HTTP roster snapshot** (`…/flightproxy…/conv/…`) and merged into the same participant map.
- **Reliable delivery.** Under CloakBrowser the `exposeFunction` callback binding is not visible inside the interceptor's execution context, so speaker payloads are pushed onto a `window` queue and drained from Node via `page.evaluate` (the proven channel).
- **Identity dedup.** The bot's own account can appear under two roster entries (directory name + in-call name); rows sharing an `8:orgid:<oid>` identity are collapsed, so it is never double-counted. Guests (`8:teamsvisitor:` / `8:live:`) are never merged.
- **UI fallback** reads the Teams v2 `data-is-speaking` attribute.
- **HTML cleaner** hides the v2 chat rail and app chrome and promotes the video stage to fullscreen.
- **Join config**: camera on (branding) for authenticated v2, and the bot is re-muted after actually entering the call.
- **Logging**: all temporary diagnostics removed; speaker updates now emit only on change (no per-second table spam).
- **Security**: `protobufjs` → `7.6.5`; `tar` pinned `>=7.5.19` via `pnpm.overrides`.

## Testing
Run locally through the sqs-consumer tsx path with `TEAMS_LOGIN_LOCAL_PASSWORD` set, against a live Teams meeting with the bot **plus 2+ human participants** talking.

- ✅ Roster shows every participant (`http roster … names=[Bot 1, Amr El Shimy, Marc]`).
- ✅ `isSpeaking` flips true/false per participant as they talk (`source=audio`); simultaneous speakers are separated.
- ✅ `diarization.jsonl` is populated with real speaking segments.
- ✅ Chat rail and chrome hidden; only the video stage is recorded.
- ✅ Bot camera on; mic muted on entry; `teams_login` slot released on exit.
- ✅ `tsc --noEmit -p tsconfig.release.json` → 0 errors.

## Release Notes
- **feat:** recover the full Teams roster from the meeting HTTP snapshot and deliver speaker updates through a drained queue.
- **fix:** read the Teams UI speaking state from the `data-is-speaking` attribute (fallback path).
- **fix:** hide the Teams v2 chat rail and chrome so only the video stage is recorded.
- **fix:** enable the camera for authenticated Teams bots and keep them muted after joining.
- **fix:** shim `__name` so `page.evaluate` works under tsx in local dev.
- **chore:** remove verbose Teams sign-in / interceptor / cleaner debug logging.
- **fix:** bump `protobufjs` to 7.6.5 and pin `tar` to clear open CVEs.