### PR TITLE
fix(metrics): simplify bot-pushed payload to bot_info metric

### DIFF
--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -90,7 +90,9 @@ export const envVars = cleanEnv(process.env, {
   // disables in-process retry entirely (pure requeue behavior). Envalid-validated
   // here; consumed/re-exported via config/retry-config.ts, the single retry-count
   // source (total-budget math lives there).
-  IN_PROCESS_RETRY_MAX: num({ default: 2 })
+  IN_PROCESS_RETRY_MAX: num({ default: 2 }),
+  POD_NAME: str({ default: "" }),
+  NODE_NAME: str({ default: "" })
 })
 
 export type EnvVars = typeof envVars

--- a/src/main.ts
+++ b/src/main.ts
@@ -343,8 +343,7 @@ async function handleFailedRecording(): Promise<void> {
       try {
         const collector = GLOBAL.getMetricsCollector()
         if (collector.isRunning() && Api.instance) {
-          collector.stop()
-          const payload = collector.getPayload()
+          const payload = await collector.getPayload()
           await Promise.race([
             Api.instance.reportMetrics(payload),
             new Promise((_, reject) =>

--- a/src/services/metrics-collector.ts
+++ b/src/services/metrics-collector.ts
@@ -3,114 +3,47 @@ import { GLOBAL } from "../singleton"
 import { NORMAL_END_REASONS } from "../state-machine/constants"
 
 export interface BotMetricsPayload {
-  bot_id: number
   bot_uuid: string
   platform: "meet" | "teams" | "zoom"
-  bot_type: "meet-teams"
-  config: {
-    resolution: "720" | "1080"
-    recording_mode: "speaker_view" | "gallery_view" | "audio_only"
-  }
-  duration: {
-    total_sec: number
-    recording_sec: number
-    idle_sec: number
-    waiting_room_sec: number
-  }
-  resources: {
-    cpu_total_sec: number
-    mem_rss_start_mb: number
-    mem_rss_end_mb: number
-    mem_heap_start_mb: number
-    mem_heap_end_mb: number
-  }
-  meeting_info: {
-    participant_count: number
-    speaker_count: number
-  }
+  resolution: "720" | "1080"
   retry_count: number
   success: boolean
+  pod_name: string
+  node_name: string
 }
 
 export class MetricsCollector {
-  private cpuStart: NodeJS.CpuUsage | null = null
-  private memRssStartMb = 0
-  private memHeapStartMb = 0
-  private recordingStartTime = 0
-  private cpuDeltaSec = 0
-  private memRssEndMb = 0
-  private memHeapEndMb = 0
-  private stopped = false
+  private recording = false
 
   start(): void {
-    const mem = process.memoryUsage()
-    this.cpuStart = process.cpuUsage()
-    this.memRssStartMb = Math.round(mem.rss / 1024 / 1024)
-    this.memHeapStartMb = Math.round(mem.heapUsed / 1024 / 1024)
-    this.recordingStartTime = Date.now()
-    this.stopped = false
+    this.recording = true
   }
 
-  stop(): void {
-    const cpuEnd = process.cpuUsage(this.cpuStart ?? undefined)
-    const mem = process.memoryUsage()
-    this.cpuDeltaSec = (cpuEnd.user + cpuEnd.system) / 1e6
-    this.memRssEndMb = Math.round(mem.rss / 1024 / 1024)
-    this.memHeapEndMb = Math.round(mem.heapUsed / 1024 / 1024)
-    this.stopped = true
+  async stop(): Promise<void> {
+    this.recording = false
   }
 
   isRunning(): boolean {
-    return !this.stopped && this.cpuStart !== null
+    return this.recording
   }
 
-  getPayload(): BotMetricsPayload {
-    if (!this.stopped) {
-      this.stop()
+  async getPayload(): Promise<BotMetricsPayload> {
+    if (this.recording) {
+      await this.stop()
     }
 
-    const startTime = GLOBAL.get().start_time
-    const exitTime = GLOBAL.get().exit_time || Math.floor(Date.now() / 1000)
-    const totalSec = Math.max(0, exitTime - startTime)
-    const recordingSec = Math.max(0, (Date.now() - this.recordingStartTime) / 1000)
-    const idleSec = Math.max(0, totalSec - recordingSec)
-    const waitingRoomSec = Math.max(0, (this.recordingStartTime / 1000) - startTime)
     const endReason = GLOBAL.getEndReason()
     const success = endReason !== null && NORMAL_END_REASONS.includes(endReason)
-
     const platform = GLOBAL.get().meeting_platform
 
     return {
-      bot_id: GLOBAL.get().bot_id,
       bot_uuid: GLOBAL.get().bot_uuid,
       platform: (platform === "zoom" ? "zoom" : platform) as "meet" | "teams" | "zoom",
-      bot_type: "meet-teams",
-      config: {
-        resolution: envVars.RESOLUTION as "720" | "1080",
-        recording_mode: GLOBAL.get().recording_mode as
-          | "speaker_view"
-          | "gallery_view"
-          | "audio_only"
-      },
-      duration: {
-        total_sec: totalSec,
-        recording_sec: recordingSec,
-        idle_sec: idleSec,
-        waiting_room_sec: waitingRoomSec
-      },
-      resources: {
-        cpu_total_sec: this.cpuDeltaSec,
-        mem_rss_start_mb: this.memRssStartMb,
-        mem_rss_end_mb: this.memRssEndMb,
-        mem_heap_start_mb: this.memHeapStartMb,
-        mem_heap_end_mb: this.memHeapEndMb
-      },
-      meeting_info: {
-        participant_count: GLOBAL.getParticipants().length,
-        speaker_count: GLOBAL.getSpeakers().length
-      },
+      resolution: envVars.RESOLUTION as "720" | "1080",
       retry_count: GLOBAL.getRetryCount(),
-      success
+      success,
+      pod_name: envVars.POD_NAME || process.env.HOSTNAME || "",
+      node_name: envVars.NODE_NAME || ""
     }
   }
 }


### PR DESCRIPTION
- Remove metrics already collected by cAdvidsor (cpu, mem, duration..etc)
- Add `pod_name` and `node_name` to be correlated with usage metrics in grafana
- Attempt to fix the "5 metrics push in a row" issue, but I'm clueless on the reason it append