### PR TITLE
fix(proxy): (ASN, country) burned keying + verify unpinned fallback exit

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -16,6 +16,8 @@ import axios from "./axios-instance"
 export interface BurnedNetworks {
   asns: number[]
   pairs: Set<string>
+  /** ASNs that have at least one (ASN, country) pair entry. */
+  pairAsns: Set<number>
 }
 
 export function isBurnedExit(
@@ -24,8 +26,14 @@ export function isBurnedExit(
   country: string | null
 ): boolean {
   if (asn === null) return false
-  if (country && burned.pairs.size > 0) {
-    return burned.pairs.has(`${asn}:${country.toUpperCase()}`)
+  const cc = country?.trim().toUpperCase()
+  if (cc && /^[A-Z]{2}$/.test(cc) && burned.pairs.size > 0) {
+    if (burned.pairs.has(`${asn}:${cc}`)) return true
+    // An ASN in the global list WITHOUT any pair entry is blended-burned
+    // (its flags are spread too thin per country to form a pair) — treat it
+    // as burned everywhere. An ASN WITH pair entries is pair-scoped: its
+    // non-burned countries are usable, which is the point of pair keying.
+    return !burned.pairAsns.has(asn) && burned.asns.includes(asn)
   }
   return burned.asns.includes(asn)
 }
@@ -47,24 +55,28 @@ export async function fetchBurnedAsns(): Promise<BurnedNetworks> {
     const asns = Array.isArray(data?.asns)
       ? data.asns.filter((n): n is number => typeof n === "number")
       : []
-    const pairs = new Set<string>(
-      Array.isArray(data?.asn_countries)
-        ? data.asn_countries
-            .filter(
-              (p): p is { asn: number; country: string } =>
-                typeof (p as { asn?: unknown })?.asn === "number" &&
-                typeof (p as { country?: unknown })?.country === "string"
-            )
-            .map((p) => `${p.asn}:${p.country.toUpperCase()}`)
-        : []
-    )
-    return { asns, pairs }
+    // Only well-formed entries (numeric ASN + alpha-2 country) may form pair
+    // keys: a malformed entry (e.g. empty country) would make `pairs`
+    // nonempty and wrongly disable the legacy global-ASN fallback in
+    // isBurnedExit for every geolocated exit.
+    const validPairs = (
+      Array.isArray(data?.asn_countries) ? data.asn_countries : []
+    ).flatMap((p) => {
+      const asn = (p as { asn?: unknown })?.asn
+      const rawCountry = (p as { country?: unknown })?.country
+      if (typeof asn !== "number" || typeof rawCountry !== "string") return []
+      const cc = rawCountry.trim().toUpperCase()
+      return /^[A-Z]{2}$/.test(cc) ? [{ asn, cc }] : []
+    })
+    const pairs = new Set<string>(validPairs.map((p) => `${p.asn}:${p.cc}`))
+    const pairAsns = new Set<number>(validPairs.map((p) => p.asn))
+    return { asns, pairs, pairAsns }
   } catch (error) {
     console.warn(
       "[BurnedAsns] fetch failed (avoiding nothing):",
       error instanceof Error ? error.message : error
     )
-    return { asns: [], pairs: new Set() }
+    return { asns: [], pairs: new Set(), pairAsns: new Set() }
   }
 }
 

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -7,22 +7,64 @@ import type { BotMetricsPayload } from "../services/metrics-collector"
 import axios from "./axios-instance"
 
 /**
- * Fetch the set of Google-Meet-"burned" exit ASNs (high flagged rate) from the
- * api-server. Used by the pre-join proxy rotation to avoid landing on a burned
- * network. Fail-soft: any error returns [] (avoid nothing) rather than blocking
- * the join.
+ * Networks currently "burned" on Google Meet (high flagged rate).
+ * `pairs` is the precise unit — "ASN:COUNTRY" (e.g. "10753:SG") — because a
+ * multi-country carrier can be burned in one country and clean in another.
+ * `asns` is the coarse global list, used only when the exit's country is
+ * unknown (geo probe failed) or the api-server predates the pair field.
  */
-export async function fetchBurnedAsns(): Promise<number[]> {
+export interface BurnedNetworks {
+  asns: number[]
+  pairs: Set<string>
+}
+
+export function isBurnedExit(
+  burned: BurnedNetworks,
+  asn: number | null,
+  country: string | null
+): boolean {
+  if (asn === null) return false
+  if (country && burned.pairs.size > 0) {
+    return burned.pairs.has(`${asn}:${country.toUpperCase()}`)
+  }
+  return burned.asns.includes(asn)
+}
+
+/**
+ * Fetch the set of Google-Meet-"burned" exit networks (high flagged rate)
+ * from the api-server. Used by the pre-join proxy rotation to avoid landing
+ * on a burned network. Fail-soft: any error returns empty lists (avoid
+ * nothing) rather than blocking the join.
+ */
+export async function fetchBurnedAsns(): Promise<BurnedNetworks> {
   try {
     const resp = await axios.get("/bot-process/meet-burned-asns", { timeout: 5000 })
-    const asns = (resp.data as { data?: { asns?: unknown } })?.data?.asns
-    return Array.isArray(asns) ? asns.filter((n): n is number => typeof n === "number") : []
+    const data = (
+      resp.data as {
+        data?: { asns?: unknown; asn_countries?: unknown }
+      }
+    )?.data
+    const asns = Array.isArray(data?.asns)
+      ? data.asns.filter((n): n is number => typeof n === "number")
+      : []
+    const pairs = new Set<string>(
+      Array.isArray(data?.asn_countries)
+        ? data.asn_countries
+            .filter(
+              (p): p is { asn: number; country: string } =>
+                typeof (p as { asn?: unknown })?.asn === "number" &&
+                typeof (p as { country?: unknown })?.country === "string"
+            )
+            .map((p) => `${p.asn}:${p.country.toUpperCase()}`)
+        : []
+    )
+    return { asns, pairs }
   } catch (error) {
     console.warn(
       "[BurnedAsns] fetch failed (avoiding nothing):",
       error instanceof Error ? error.message : error
     )
-    return []
+    return { asns: [], pairs: new Set() }
   }
 }
 

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,8 +1,9 @@
 import { execFile } from "child_process"
 import type { BrowserContext } from "@playwright/test"
-import { fetchBurnedAsns } from "../api/methods"
+import { fetchBurnedAsns, isBurnedExit } from "../api/methods"
 import {
   getExitAsn,
+  getExitGeo,
   resolveProxyCountries,
   startToggleProxy,
   stopToggleProxy
@@ -90,7 +91,12 @@ export async function establishBrowserSession(
       // (an empty burned list or exhausted rotations just proceeds).
       if (session.proxyUrl && platform === "meet") {
         const burned = await fetchBurnedAsns()
-        if (burned.length > 0) {
+        if (burned.asns.length > 0 || burned.pairs.size > 0) {
+          // Burned is keyed on (ASN, country) when the exit's country is
+          // known — a carrier can be burned in SG and clean in BR, so the
+          // pair check avoids over-rotating off usable routes. Falls back
+          // to the global ASN list when the geo probe didn't resolve.
+          const exitIsBurned = () => isBurnedExit(burned, getExitAsn(), getExitGeo()?.country ?? null)
           const ROTATIONS_PER_REGION = 3
           // The team's selected regions, in order ([] = no pin / env default).
           // Try each region in turn; within a region, rotate the Decodo session
@@ -110,7 +116,7 @@ export async function establishBrowserSession(
             let lastAsn: number | null = null
             for (let rot = 1; rot <= ROTATIONS_PER_REGION; rot++) {
               const asn = getExitAsn()
-              if (asn === null || !burned.includes(asn)) {
+              if (!exitIsBurned()) {
                 cleared = true
                 break
               }
@@ -151,23 +157,39 @@ export async function establishBrowserSession(
           }
 
           // Every selected region was ASN-burned. Rather than launch on a
-          // known-burned pinned exit, drop the geo pin entirely for one random
+          // known-burned pinned exit, drop the geo pin entirely for a random
           // residential exit (a different ASN pool) — the same final degradation
           // the regional-outage path takes (skipGeoPin). Only when we still hold
           // a live proxy (a null rotation above already fell back to direct).
-          if (!cleared && session.proxyUrl) {
-            const asn = getExitAsn()
-            if (asn !== null && burned.includes(asn)) {
+          // The unpinned exit is VERIFIED too: a random rotation can land right
+          // back on a burned network (observed in prod: AS5511 serving at ~78%
+          // flagged despite being burned), so retry a bounded number of times
+          // rather than launching on the first unchecked exit.
+          if (!cleared && session.proxyUrl && exitIsBurned()) {
+            const NO_PIN_ROTATIONS = 3
+            for (let rot = 1; rot <= NO_PIN_ROTATIONS; rot++) {
               console.warn(
-                "[BrowserSession] all selected regions ASN-burned on Meet — dropping geo pin for a random exit"
+                `[BrowserSession] all selected regions ASN-burned on Meet — rotating without geo pin (${rot}/${NO_PIN_ROTATIONS})`
               )
               const rotated = await startToggleProxy(
                 GLOBAL.get().bot_uuid,
                 retryCount,
-                `${opts.sessionSuffix ?? ""}rNoPin`,
+                `${opts.sessionSuffix ?? ""}rNoPin${rot}`,
                 { skipGeoPin: true }
               )
-              session.proxyUrl = rotated ?? undefined
+              if (!rotated) {
+                // Rotation tore the proxy down without a replacement — same
+                // direct-join degradation as the in-region path above.
+                session.proxyUrl = undefined
+                break
+              }
+              session.proxyUrl = rotated
+              if (!exitIsBurned()) break
+              if (rot === NO_PIN_ROTATIONS) {
+                console.warn(
+                  `[BrowserSession] unpinned exit still burned after ${NO_PIN_ROTATIONS} rotations — launching anyway (fail-soft)`
+                )
+              }
             }
           }
         }


### PR DESCRIPTION
Companion to Meeting-BaaS/meeting-baas-v2#343 (api-server side). Two prod-observed gaps in Meet burned-network avoidance:

## 1. (ASN, country) keying — fixes threshold masking

Burned was a global-ASN list. A multi-country carrier blends its rates: AS10753 runs **59% flagged in SG / 43% in JP** but 18% in BR → 23% blended → under the 35% threshold → never burned, worst routes keep serving. Same shape hid AS2856 (GB).

- `fetchBurnedAsns()` now also parses `asn_countries` pairs from the api-server and exposes `isBurnedExit(burned, asn, country)`.
- Pair check when the exit country is known (from the existing geo probe); falls back to the global `asns` list when geo didn't resolve **or the api-server predates the pair field** — safe against either side deploying first.
- Bonus: stops over-rotating off usable routes (AS10753/BR stays usable while AS10753/SG burns).

## 2. Verified unpinned fallback — plugs the AS5511 leak

The "all selected regions burned → skipGeoPin" path did ONE random rotation and launched without re-checking the new exit. A random exit can land straight back on a burned network — prod showed AS5511 serving at **~78% flagged in the last 48h despite being long past the burned threshold**. The fallback now re-verifies and rotates up to 3×, then launches fail-soft with a loud log.

## Deploy notes

- Bot-first or api-first both safe (pair field absent → `pairs` empty → `isBurnedExit` uses the legacy global list, exactly today's behavior).
- Typecheck clean (tsc, Node 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)