### PR TITLE
Fix/meet speaker attribution stuck

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,5 +15,9 @@ module.exports = {
     testMatch: ['**/src/**/*.test.ts', '**/src/**/*.spec.ts'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
+        // https-proxy-agent is ESM-only and node_modules is not transformed, so
+        // importing it aborts the whole suite at parse time. Nothing under test
+        // proxies anything — swap in a stub to keep the import graph loadable.
+        '^https-proxy-agent$': '<rootDir>/test/mocks/https-proxy-agent.ts',
     },
 }

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -591,14 +591,32 @@ export function browserInterceptionLogic(schema: any[]) {
         // network path on any meeting that opened with a quiet minute. Wait for
         // as long as the track is alive; only give up once it actually dies.
         const LIVENESS_POLL_MS = 15000
+
+        // Nothing to wait for if the track is already gone — don't open a read
+        // that will hang until the first poll tick.
+        if (abortSignal.aborted || track.readyState !== "live") {
+          console.error(
+            `[NetworkInterceptor] ❌ Track ${track.id} was not live before the first read: readyState=${track.readyState}, aborted=${abortSignal.aborted}`
+          )
+          trackAbortControllers.delete(track.id)
+          sendFailureSignal(track, "timeout")
+          return false
+        }
+
         const firstReadPromise = reader.read()
 
         let livenessTimer: ReturnType<typeof setInterval> | undefined
+        let onAbort: (() => void) | undefined
         let waitedMs = 0
         const trackDeath = new Promise<never>((_, reject) => {
+          const fail = () => reject(new Error("Track ended before producing audio"))
+          // Abort is edge-triggered: waiting for the next poll would leave the
+          // read pending for up to LIVENESS_POLL_MS after teardown started.
+          onAbort = fail
+          abortSignal.addEventListener("abort", fail, { once: true })
           livenessTimer = setInterval(() => {
-            if (abortSignal.aborted || track.readyState !== "live") {
-              reject(new Error("Track ended before producing audio"))
+            if (track.readyState !== "live") {
+              fail()
               return
             }
             waitedMs += LIVENESS_POLL_MS
@@ -615,6 +633,27 @@ export function browserInterceptionLogic(schema: any[]) {
           console.error(
             `[NetworkInterceptor] ❌ Track ${track.id} died before producing audio: readyState=${track.readyState}, muted=${track.muted}`
           )
+          // The first read is still pending and holds the stream lock. Cancel it
+          // (which settles the read) and release the lock, so a replacement
+          // track for this participant can be monitored instead of failing to
+          // acquire a reader. Release even if cancellation itself throws.
+          try {
+            await reader.cancel()
+          } catch (cancelError) {
+            console.error(
+              `[NetworkInterceptor] Error cancelling reader for track ${track.id}:`,
+              cancelError
+            )
+          } finally {
+            try {
+              reader.releaseLock()
+            } catch (releaseError) {
+              console.error(
+                `[NetworkInterceptor] Error releasing reader lock for track ${track.id}:`,
+                releaseError
+              )
+            }
+          }
           // Clean up AbortController since processing failed
           trackAbortControllers.delete(track.id)
           sendFailureSignal(track, "timeout")
@@ -622,6 +661,9 @@ export function browserInterceptionLogic(schema: any[]) {
         } finally {
           if (livenessTimer) {
             clearInterval(livenessTimer)
+          }
+          if (onAbort) {
+            abortSignal.removeEventListener("abort", onAbort)
           }
         }
 

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -582,31 +582,47 @@ export function browserInterceptionLogic(schema: any[]) {
           }
         }
 
-        // Read first frame to verify processing works before returning true
-        // Add 60-second timeout to detect hanging tracks
-        const TIMEOUT_MS = 60000 // 60 seconds
+        // Wait for the first frame before declaring the pipeline healthy.
+        //
+        // A live track that yields no frames is a SILENT participant, not a
+        // broken pipeline — Meet sends no RTP for someone who isn't talking.
+        // The previous code gave up after a flat 60s and reported the track as
+        // failed even while logging readyState=live, which retired the entire
+        // network path on any meeting that opened with a quiet minute. Wait for
+        // as long as the track is alive; only give up once it actually dies.
+        const LIVENESS_POLL_MS = 15000
         const firstReadPromise = reader.read()
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Timeout waiting for first frame")), TIMEOUT_MS)
-        )
+
+        let livenessTimer: ReturnType<typeof setInterval> | undefined
+        let waitedMs = 0
+        const trackDeath = new Promise<never>((_, reject) => {
+          livenessTimer = setInterval(() => {
+            if (abortSignal.aborted || track.readyState !== "live") {
+              reject(new Error("Track ended before producing audio"))
+              return
+            }
+            waitedMs += LIVENESS_POLL_MS
+            console.error(
+              `[NetworkInterceptor] ⏳ No audio yet on track ${track.id} after ${waitedMs / 1000}s — track is live, treating as a silent participant and continuing to wait`
+            )
+          }, LIVENESS_POLL_MS)
+        })
 
         let firstRead: any
         try {
-          firstRead = await Promise.race([firstReadPromise, timeoutPromise])
-        } catch (error: any) {
-          if (error?.message === "Timeout waiting for first frame") {
-            console.error(
-              `[NetworkInterceptor] ⏱️ Timeout: No frames received for track ${track.id} within ${TIMEOUT_MS}ms`
-            )
-            console.error(
-              `[NetworkInterceptor] 📊 Track state at timeout: id=${track.id}, readyState=${track.readyState}, muted=${track.muted}`
-            )
-            // Clean up AbortController since processing failed
-            trackAbortControllers.delete(track.id)
-            sendFailureSignal(track, "timeout")
-            return false
+          firstRead = await Promise.race([firstReadPromise, trackDeath])
+        } catch (_error) {
+          console.error(
+            `[NetworkInterceptor] ❌ Track ${track.id} died before producing audio: readyState=${track.readyState}, muted=${track.muted}`
+          )
+          // Clean up AbortController since processing failed
+          trackAbortControllers.delete(track.id)
+          sendFailureSignal(track, "timeout")
+          return false
+        } finally {
+          if (livenessTimer) {
+            clearInterval(livenessTimer)
           }
-          throw error
         }
 
         if (firstRead.done) {

--- a/src/meeting/meet/speakersObserver.ts
+++ b/src/meeting/meet/speakersObserver.ts
@@ -81,6 +81,13 @@ export class MeetSpeakersObserver {
         let lastValidSpeakerCheck = Date.now()
         const FREEZE_TIMEOUT_MS = 30000 // 30 seconds
 
+        // Which speaking signals this meeting's DOM actually produced. Meet has
+        // changed this markup before and silently zeroed out detection with no
+        // error anywhere; reporting it makes the next regression diagnosable
+        // from the bot log instead of requiring a DOM snapshot.
+        const signalsSeen = new Set<string>()
+        let signalsReported = ""
+
         // EXACT SAME getSpeakerRootToObserve as extension
         async function getSpeakerRootToObserve(
           recordingMode: string
@@ -300,7 +307,9 @@ export class MeetSpeakersObserver {
                   participant.isPresenting = true
                 }
 
-                // Check speaking indicators + NEW COLOR FIX
+                // SIGNAL A (legacy Meet): a mic-bar sprite tinted with one of
+                // Meet's accent blues, animated by shifting backgroundPositionX
+                // off its rest position.
                 const speakingIndicators = Array.from(item.querySelectorAll("*")).filter((elem) => {
                   const color = getComputedStyle(elem).backgroundColor
                   return (
@@ -318,9 +327,31 @@ export class MeetSpeakersObserver {
                       getComputedStyle(backgroundElement).backgroundPositionX
                     if (backgroundPosition !== "0px") {
                       participant.isSpeaking = true
+                      signalsSeen.add("sprite")
                     }
                   }
                 })
+
+                // SIGNAL B (current Meet): the mic-level bars sit in a wrapper
+                // whose opacity Meet drives 0 -> 1 while that person talks. The
+                // bar container is addressed by jsname, which survives Meet's
+                // class-name churn far better than the obfuscated class strings
+                // Signal A depends on.
+                //
+                // Both signals are OR'd rather than swapped: this can only add
+                // detections, never remove one that already works.
+                if (!participant.isSpeaking) {
+                  const bars = item.querySelector('[jsname="QgSmzd"]')
+                  const wrapper = bars?.parentElement
+                  if (wrapper) {
+                    signalsSeen.add("bars-present")
+                    const opacity = Number.parseFloat(getComputedStyle(wrapper).opacity || "0")
+                    if (opacity > 0.1) {
+                      participant.isSpeaking = true
+                      signalsSeen.add("opacity")
+                    }
+                  }
+                }
 
                 // Update the map with the potentially modified data
                 uniqueParticipants.set(uniqueKey, participant)
@@ -354,6 +385,12 @@ export class MeetSpeakersObserver {
               `[MEET-DEBUG] Found ${speakers.length} participants:`,
               speakers.map((s, index) => `Speaker ${index + 1} (speaking: ${s.isSpeaking})`)
             )
+
+            const signalSummary = Array.from(signalsSeen).sort().join(",") || "none"
+            if (signalSummary !== signalsReported) {
+              signalsReported = signalSummary
+              console.log(`[MEET-DEBUG-SIGNALS] speaking signals available: ${signalSummary}`)
+            }
 
             lastValidSpeakers = speakers
             lastValidSpeakerCheck = currentTime

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -32,7 +32,9 @@ export class SpeakerManager {
   // a later payload can omit a name that an earlier one carried; without this,
   // a participant flips back to "Unknown" mid-meeting.
   private deviceNames = new Map<string, string>()
-  private firstNetworkUpdateAt = Number.POSITIVE_INFINITY
+  // When each device was first seen, so the roster-race grace window below is
+  // scoped to that participant rather than to the start of the meeting.
+  private deviceFirstSeen = new Map<string, number>()
 
   private constructor() {}
 
@@ -58,6 +60,21 @@ export class SpeakerManager {
 
     const remembered = deviceId ? this.deviceNames.get(deviceId) : undefined
     return remembered ?? UNKNOWN_SPEAKER
+  }
+
+  /**
+   * Timestamp this device was first observed, recording it on first sight.
+   * Devices without an id share a single bucket — they cannot be told apart, so
+   * the best available behaviour is to grant the grace window once.
+   */
+  private firstSeenAt(deviceId: string | undefined, timestamp: number): number {
+    const key = deviceId || ""
+    const existing = this.deviceFirstSeen.get(key)
+    if (existing !== undefined) {
+      return existing
+    }
+    this.deviceFirstSeen.set(key, timestamp)
+    return timestamp
   }
 
   /**
@@ -134,10 +151,6 @@ export class SpeakerManager {
     timestamp: number
   ): Promise<void> {
     try {
-      if (this.firstNetworkUpdateAt === Number.POSITIVE_INFINITY) {
-        this.firstNetworkUpdateAt = timestamp
-      }
-
       // Convert network users to SpeakerData format
       const speakers: SpeakerData[] = networkUsers.map((user) => {
         // Use fullName as stable identifier, fallback to name (displayName)
@@ -168,12 +181,17 @@ export class SpeakerManager {
         // Audio can beat the roster: the first CSRC often resolves to a device
         // whose name has not been decoded yet, and attributing that speech to
         // the literal string "Unknown" burns it into the artifact permanently.
-        // Withhold the speaking flag while the name is still unresolved and
-        // early in the meeting — the roster lands within a second or two, and
+        // Withhold the speaking flag while the name is still unresolved and the
+        // device is newly seen — the roster lands within a second or two, and
         // the segment then opens under the correct name. After the grace window
         // an unresolved name is real (not a race), so stop suppressing.
+        //
+        // The window is per-device, not per-meeting: someone joining at minute
+        // 20 races their own roster entry exactly like the participants present
+        // at the start, and a meeting-wide anchor would have expired long ago.
         const nameResolved = stableName !== UNKNOWN_SPEAKER
-        const withinRosterGrace = timestamp - this.firstNetworkUpdateAt < ROSTER_GRACE_MS
+        const withinRosterGrace =
+          timestamp - this.firstSeenAt(user.deviceId, timestamp) < ROSTER_GRACE_MS
         return {
           name: stableName,
           id: sequentialId,

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -10,6 +10,15 @@ import type { Participant, SpeakerData } from "./types"
 import { PathManager } from "./utils/PathManager"
 import { createSequentialIdManager, generateStableUserId } from "./utils/speaker-id"
 
+/** The placeholder every platform's interceptor falls back to before a roster lands. */
+const UNKNOWN_SPEAKER = "Unknown"
+
+/**
+ * How long after the first network update an unresolved name is still assumed
+ * to be a roster race rather than a genuinely nameless participant.
+ */
+const ROSTER_GRACE_MS = 15000
+
 export class SpeakerManager {
   private static instance: SpeakerManager | null = null
   private currentSpeaker: SpeakerData | null = null
@@ -19,8 +28,37 @@ export class SpeakerManager {
   private lastCallbackTime: number | null = null // Track when we last received ANY callback
   // Sequential ID manager for network-detected speakers
   private sequentialIdManager = createSequentialIdManager()
+  // Best name seen so far per network device. Rosters arrive incrementally and
+  // a later payload can omit a name that an earlier one carried; without this,
+  // a participant flips back to "Unknown" mid-meeting.
+  private deviceNames = new Map<string, string>()
+  private firstNetworkUpdateAt = Number.POSITIVE_INFINITY
 
   private constructor() {}
+
+  /**
+   * Best available name for a network participant, never downgrading.
+   *
+   * Teams already repairs this inside its own interceptor (it upgrades an
+   * "Unknown" record once a displayName shows up). Meet and Zoom have no such
+   * path — Meet's decodeUserName and Zoom's `displayName || "Unknown"` both
+   * hand back the placeholder and nothing ever revisits it. Doing it here fixes
+   * all three platforms in one place.
+   */
+  private resolveNetworkName(user: NetworkUser): string {
+    const deviceId = user.deviceId
+    const incoming = (user.fullName || user.name || "").trim()
+
+    if (incoming && incoming !== UNKNOWN_SPEAKER) {
+      if (deviceId) {
+        this.deviceNames.set(deviceId, incoming)
+      }
+      return incoming
+    }
+
+    const remembered = deviceId ? this.deviceNames.get(deviceId) : undefined
+    return remembered ?? UNKNOWN_SPEAKER
+  }
 
   /**
    * Get the last time we received a speaker callback (regardless of speaking state)
@@ -96,10 +134,14 @@ export class SpeakerManager {
     timestamp: number
   ): Promise<void> {
     try {
+      if (this.firstNetworkUpdateAt === Number.POSITIVE_INFINITY) {
+        this.firstNetworkUpdateAt = timestamp
+      }
+
       // Convert network users to SpeakerData format
       const speakers: SpeakerData[] = networkUsers.map((user) => {
         // Use fullName as stable identifier, fallback to name (displayName)
-        const stableName = user.fullName || user.name || "Unknown"
+        const stableName = this.resolveNetworkName(user)
         const stableId = generateStableUserId(stableName, user.profilePicture)
         const sequentialId = this.sequentialIdManager.getSequentialId(stableId)
 
@@ -121,12 +163,22 @@ export class SpeakerManager {
           GLOBAL.addSpeakerIfNotExists(participant)
         }
 
-        // Return SpeakerData for diarization
+        // Return SpeakerData for diarization.
+        //
+        // Audio can beat the roster: the first CSRC often resolves to a device
+        // whose name has not been decoded yet, and attributing that speech to
+        // the literal string "Unknown" burns it into the artifact permanently.
+        // Withhold the speaking flag while the name is still unresolved and
+        // early in the meeting — the roster lands within a second or two, and
+        // the segment then opens under the correct name. After the grace window
+        // an unresolved name is real (not a race), so stop suppressing.
+        const nameResolved = stableName !== UNKNOWN_SPEAKER
+        const withinRosterGrace = timestamp - this.firstNetworkUpdateAt < ROSTER_GRACE_MS
         return {
           name: stableName,
           id: sequentialId,
           timestamp,
-          isSpeaking: user.isSpeaking === true
+          isSpeaking: user.isSpeaking === true && (nameResolved || !withinRosterGrace)
         }
       })
 

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -22,6 +22,9 @@ export class InCallState extends BaseState {
   // printing a name or id.
   private readonly maskedSpeakerIndices = new Map<string, number>()
   private lastNetworkSpeakingKey?: string // Dedup for network-speaker debug logging
+  // Tracks that stopped delivering audio. Recorded for diagnostics only — the
+  // diarization health monitor decides when the network path is beyond saving.
+  private readonly failedNetworkTracks = new Set<string>()
 
   async execute(): StateExecuteResult {
     const startTime = Date.now()
@@ -298,31 +301,24 @@ export class InCallState extends BaseState {
           // Handle network interception failure - trigger UI Observer fallback
           if (payload.source === "network_interception_failed" && payload.failure) {
             const { trackId, reason, trackState } = payload.failure
+            this.failedNetworkTracks.add(trackId)
             console.warn(
-              `[NetworkInterceptor] ❌ Network interception failed for track ${trackId}: ${reason} (state: ${trackState})`
+              `[NetworkInterceptor] ❌ Network interception failed for track ${trackId}: ${reason} (state: ${trackState}) — ${this.failedNetworkTracks.size} track(s) failed so far`
             )
 
-            // Mark network interception as failed to prevent further attempts
-            GLOBAL.setNetworkInterceptionSetupFailed()
-
-            // Trigger UI Observer fallback (only if not already started or starting)
-            if (!this.context.speakersObserver && !this.isStartingUIObserver) {
-              this.isStartingUIObserver = true
-              console.warn("[NetworkInterceptor] 🔄 Falling back to UI-based speaker detection")
-              try {
-                await this.startUIBasedObservation()
-              } finally {
-                this.isStartingUIObserver = false
-              }
-            } else {
-              if (this.context.speakersObserver) {
-                console.log("[NetworkInterceptor] ℹ️ UI Observer already running, skipping fallback")
-              } else {
-                console.log(
-                  "[NetworkInterceptor] ℹ️ UI Observer fallback already in progress, skipping duplicate"
-                )
-              }
-            }
+            // One dead track is not a dead pipeline. A participant who leaves,
+            // reconnects or replaces their audio track takes their track down
+            // with them; retiring the whole network path on the first such
+            // event handed the rest of the meeting to the UI observer even
+            // though the remaining tracks were still delivering audio.
+            //
+            // The stale-diarization monitor in RecordingState owns the fallback
+            // decision: it falls back within ~10s of sound activity when the
+            // network path has never produced a segment, which is both faster
+            // and better evidenced than reacting to a single track.
+            console.log(
+              "[NetworkInterceptor] ℹ️ Keeping network path active — diarization health monitor owns the fallback decision"
+            )
             return // Don't process as speaker update
           }
 

--- a/src/urlParser/meetUrlParser.test.ts
+++ b/src/urlParser/meetUrlParser.test.ts
@@ -92,33 +92,39 @@ describe("Meet URL Parser", () => {
   })
 
   describe("Invalid URLs", () => {
+    // The parser distinguishes two rejection reasons, and the message matters
+    // because they mean different things operationally: nothing that looks like
+    // a Meet link at all, versus a Meet link whose code is malformed.
     const invalidUrls = [
       {
         name: "empty URL",
-        url: ""
+        url: "",
+        error: "No Google Meet URL found"
       },
       {
         name: "wrong domain",
-        url: "https://google.com/abc-defg-hij"
+        url: "https://google.com/abc-defg-hij",
+        error: "No Google Meet URL found"
       },
       {
         name: "invalid code format",
-        url: "https://meet.google.com/abcd-efgh-ijkl"
+        url: "https://meet.google.com/abcd-efgh-ijkl",
+        error: "Invalid Google Meet URL format"
       },
       {
         name: "missing code parts",
-        url: "https://meet.google.com/abc-defg"
+        url: "https://meet.google.com/abc-defg",
+        error: "Invalid Google Meet URL format"
       },
       {
         name: "invalid characters in code",
-        url: "https://meet.google.com/123-4567-890"
+        url: "https://meet.google.com/123-4567-890",
+        error: "Invalid Google Meet URL format"
       }
     ]
 
-    test.each(invalidUrls)("should reject $name", async ({ url }) => {
-      await expect(parseMeetingUrlFromJoinInfos(url)).rejects.toThrow(
-        "Invalid Google Meet URL format"
-      )
+    test.each(invalidUrls)("should reject $name", async ({ url, error }) => {
+      await expect(parseMeetingUrlFromJoinInfos(url)).rejects.toThrow(error)
     })
   })
 })

--- a/src/urlParser/teamsUrlParser.test.ts
+++ b/src/urlParser/teamsUrlParser.test.ts
@@ -1,5 +1,23 @@
 import { parseMeetingUrlFromJoinInfos } from "./teamsUrlParser"
 
+// The parser consults GLOBAL to decide whether to append anon=true. With no
+// meeting configured GLOBAL.get() throws, transformTeamsLink swallows it and
+// returns the URL untransformed — so without this mock every assertion below
+// silently tested the error path instead of the parser.
+let mockTeamsLoginConfig: unknown = null
+jest.mock("../singleton", () => ({
+  GLOBAL: {
+    get: () => ({ teams_login_config: mockTeamsLoginConfig }),
+    setError: jest.fn()
+  }
+}))
+
+const V2_PREFIX = "https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/"
+
+beforeEach(() => {
+  mockTeamsLoginConfig = null // anonymous bot unless a test says otherwise
+})
+
 describe("Teams URL Parser", () => {
   describe("Standard Teams Microsoft URLs", () => {
     const standardUrls = [
@@ -8,21 +26,46 @@ describe("Teams URL Parser", () => {
       "https://teams.microsoft.com/l/meetup-join/19:meeting_MDYyNDgzMmQtODg2Ni00MjBmLTk4YTAtZjYwMTQ0MGNiMmNl@thread.v2/0?context=%7B%22Tid%22:%222dbdd394-741d-4914-9993-ea4584a95749%22%7D"
     ]
 
-    test.each(standardUrls)("should parse standard Teams URL: %s", (url) => {
+    test.each(standardUrls)("rewrites to the v2 join format: %s", (url) => {
       const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(url + "&anon=true")
+      const threadId = url.split("/l/meetup-join/")[1].split("/")[0]
+
+      expect(result.meetingId.startsWith(V2_PREFIX)).toBe(true)
+      expect(result.meetingId).toContain(threadId)
+      expect(result.meetingId.endsWith("&anon=true")).toBe(true)
       expect(result.password).toBe("")
     })
   })
 
-  describe("Teams urls standard", () => {
-    const standardUrls = [
-      "https://teams.microsoft.com/l/meetup-join/19%3aalTrvfJlXitdMLLxjio8rfnHDhKWaZ3_M-EwK5ewWHg1%40thread.tacv2/1740503107049?context=%7b%22Tid%22%3a%221eba988e-f725-4323-976e-38aaba6ee3a3%22%2c%22Oid%22%3a%222f8f4d50-3e1b-41ea-99fe-4361ba60ada5%22%7d"
+  describe("Authenticated bots", () => {
+    const url =
+      "https://teams.microsoft.com/l/meetup-join/19:meeting_123@thread.v2/0?context=123"
+
+    test("omits anon=true so the bot joins as the signed-in user", () => {
+      mockTeamsLoginConfig = { email: "bot@example.com" }
+      const result = parseMeetingUrlFromJoinInfos(url)
+
+      expect(result.meetingId.startsWith(V2_PREFIX)).toBe(true)
+      expect(result.meetingId).not.toContain("anon=true")
+    })
+
+    test("appends anon=true for anonymous bots", () => {
+      const result = parseMeetingUrlFromJoinInfos(url)
+      expect(result.meetingId.endsWith("&anon=true")).toBe(true)
+    })
+  })
+
+  describe("Teams TACV2 URLs", () => {
+    const tacv2Urls = [
+      "https://teams.microsoft.com/l/meetup-join/19%3aalTrvfJlXitdMLLxjio8rfnHDhKWaZ3_M-EwK5ewWHg1%40thread.tacv2/1740503107049?context=%7b%22Tid%22%3a%221eba988e-f725-4323-976e-38aaba6ee3a3%22%2c%22Oid%22%3a%222f8f4d50-3e1b-41ea-99fe-4361ba60ada5%22%7d",
+      "https://teams.microsoft.com/l/meetup-join/19:alTrvfJlXitdMLLxjio8rfnHDhKWaZ3_M-EwK5ewWHg1@thread.tacv2/1730831739131?context=%7B%22Tid%22:%221eba988e-f725-4323-976e-38aaba6ee3a3%22%7D",
+      "https://teams.microsoft.com/l/meetup-join/19:alTrvfJlXitdMLLxjio8rfnHDhKWaZ3_M-EwK5ewWHg1@thread.tacv2/1731342990116?context=%7BTid:1eba988e-f725-4323-976e-38aaba6ee3a3,Oid:2f8f4d50-3e1b-41ea-99fe-4361ba60ada5%7D"
     ]
 
-    test.each(standardUrls)("should parse Teams Live URL: %s", (url) => {
+    test.each(tacv2Urls)("rewrites to the v2 join format: %s", (url) => {
       const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(url + (url.includes("?") ? "&" : "?") + "anon=true")
+      expect(result.meetingId.startsWith(V2_PREFIX)).toBe(true)
+      expect(result.meetingId.endsWith("&anon=true")).toBe(true)
       expect(result.password).toBe("")
     })
   })
@@ -34,91 +77,44 @@ describe("Teams URL Parser", () => {
       "https://teams.live.com/meet/9314184555833?p=00ewkGrA1OJD7Id1NR"
     ]
 
-    test.each(liveUrls)("should parse Teams Live URL: %s", (url) => {
+    test.each(liveUrls)("passes through with its passcode: %s", (url) => {
       const result = parseMeetingUrlFromJoinInfos(url)
       expect(result.meetingId).toBe(url)
       expect(result.password).toBe(new URL(url).searchParams.get("p"))
     })
   })
 
-  describe("Teams Microsoft URLs with Query Parameters", () => {
-    const urlsWithParams = [
-      "https://teams.microsoft.com/l/meetup-join/19:meeting_123@thread.v2/0?context=123",
-      "https://teams.microsoft.com/l/meetup-join/19:meeting_456@thread.v2/0?param=value"
-    ]
-
-    test.each(urlsWithParams)("should parse URL with params: %s", (url) => {
-      const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(`${url}&anon=true`)
-      expect(result.password).toBe("")
-    })
-  })
-
-  describe("Teams Launcher URLs", () => {
-    const launcherUrls = [
-      "https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_YTQxZDliNzQtYzlmMS00OTZhLWE1MzQtNDUzYjhjYzU1ZTVk%40thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%25220deb691f-902d-4dea-8026-5a790862fede%2522%252c%2522Oid%2522%253a%25222d56fa49-dfef-4eca-82e9-5b2802766c02%2522%257d%26anon%3Dtrue",
-      "https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_OWQxZDc4MzYtN2NhMC00MjZkLWI5NmEtYWZkMmNjNjQ1Y2Rm%40thread.v2%2F0%3Fcontext"
-    ]
-
-    test.each(launcherUrls)("should parse Teams Launcher URL: %s", (url) => {
-      const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(url + (url.includes("?") ? "&" : "?") + "anon=true")
-      expect(result.password).toBe("")
-    })
-  })
-
-  describe("Teams Launcher URLs", () => {
-    const launcherUrls = [
-      "https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_YTQxZDliNzQtYzlmMS00OTZhLWE1MzQtNDUzYjhjYzU1ZTVk%40thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%25220deb691f-902d-4dea-8026-5a790862fede%2522%252c%2522Oid%2522%253a%25222d56fa49-dfef-4eca-82e9-5b2802766c02%2522%257d%26anon%3Dtrue",
-      "https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_OWQxZDc4MzYtN2NhMC00MjZkLWI5NmEtYWZkMmNjNjQ1Y2Rm%40thread.v2%2F0%3Fcontext"
-    ]
-
-    test.each(launcherUrls)("should parse Teams Launcher URL: %s", (url) => {
-      const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(url + "&anon=true")
-      expect(result.password).toBe("")
-    })
-  })
-
-  describe("Teams TACV2 URLs", () => {
-    const tacv2Urls = [
-      "https://teams.microsoft.com/l/meetup-join/19:alTrvfJlXitdMLLxjio8rfnHDhKWaZ3_M-EwK5ewWHg1@thread.tacv2/1730831739131?context=%7B%22Tid%22:%221eba988e-f725-4323-976e-38aaba6ee3a3%22%7D",
-      "https://teams.microsoft.com/l/meetup-join/19:alTrvfJlXitdMLLxjio8rfnHDhKWaZ3_M-EwK5ewWHg1@thread.tacv2/1731342990116?context=%7BTid:1eba988e-f725-4323-976e-38aaba6ee3a3,Oid:2f8f4d50-3e1b-41ea-99fe-4361ba60ada5%7D"
-    ]
-
-    test.each(tacv2Urls)("should parse TACV2 URL: %s", (url) => {
-      const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(url + "&anon=true")
-      expect(result.password).toBe("")
-    })
-  })
-
-  describe("Teams URLs with Custom Subdomains", () => {
-    const subdomainUrls = [
+  // Anything the meetup-join rewrite cannot parse is handed to Teams untouched,
+  // which is the safe default: the page itself still resolves these.
+  describe("URLs passed through unchanged", () => {
+    const passthroughUrls = [
+      // no ?context= for the rewrite regex to anchor on
+      "https://teams.microsoft.com/l/meetup-join/19:meeting_456@thread.v2/0?param=value",
+      // launcher shell, not a meetup-join link
+      "https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_OWQxZDc4MzYtN2NhMC00MjZkLWI5NmEtYWZkMmNjNjQ1Y2Rm%40thread.v2%2F0%3Fcontext",
+      // custom subdomain — the rewrite is anchored to bare teams.microsoft.com
       "https://us02web.teams.microsoft.com/l/meetup-join/19:meeting_123@thread.v2/0",
       "https://us06web.teams.microsoft.com/l/meetup-join/19:meeting_456@thread.v2/0"
     ]
 
-    test.each(subdomainUrls)("should parse subdomain URL: %s", (url) => {
+    test.each(passthroughUrls)("leaves the URL alone: %s", (url) => {
       const result = parseMeetingUrlFromJoinInfos(url)
-      expect(result.meetingId).toBe(`${url}?anon=true`)
+      expect(result.meetingId).toBe(url)
       expect(result.password).toBe("")
     })
   })
 
   describe("Invalid URLs", () => {
     const invalidUrls = [
-      "https://not-teams.com/meeting",
-      "https://teams.zoom.us/j/123456",
-      "not-a-url",
-      "https://teams.com/invalid-format",
-      ""
+      { url: "https://not-teams.com/meeting", error: "Invalid Teams URL" },
+      { url: "https://teams.zoom.us/j/123456", error: "Invalid Teams URL" },
+      { url: "https://teams.com/invalid-format", error: "Invalid Teams URL" },
+      { url: "not-a-url", error: "Invalid URL" },
+      { url: "", error: "No meeting URL provided" }
     ]
 
-    test.each(invalidUrls)("should reject invalid URL: %s", (url) => {
-      expect(() => {
-        parseMeetingUrlFromJoinInfos(url)
-      }).toThrow("Invalid Teams URL")
+    test.each(invalidUrls)("rejects $url", ({ url, error }) => {
+      expect(() => parseMeetingUrlFromJoinInfos(url)).toThrow(error)
     })
   })
 
@@ -128,7 +124,7 @@ describe("Teams URL Parser", () => {
       encodeURIComponent("https://teams.microsoft.com/l/meetup-join/19:meeting_456@thread.v2/0")
     ]
 
-    test.each(encodedUrls)("should handle encoded URL: %s", (url) => {
+    test.each(encodedUrls)("handles encoded URL: %s", (url) => {
       const result = parseMeetingUrlFromJoinInfos(url)
       expect(result).toBeDefined()
       expect(result.password).toBe("")
@@ -141,7 +137,7 @@ describe("Teams URL Parser", () => {
       "https://www.google.com/url?q=https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjVhZDgyYjQtZDE2NC00ZDI4LWI3Y2EtN2Y4Zjg3ODQwNzc2%40thread.v2/0"
     ]
 
-    test.each(googleUrls)("should handle Google redirect URL: %s", (url) => {
+    test.each(googleUrls)("unwraps the redirect: %s", (url) => {
       const result = parseMeetingUrlFromJoinInfos(url)
       expect(result).toBeDefined()
       expect(result.password).toBe("")

--- a/test/mocks/https-proxy-agent.ts
+++ b/test/mocks/https-proxy-agent.ts
@@ -1,0 +1,20 @@
+/**
+ * Test stub for https-proxy-agent.
+ *
+ * The real package ships ESM only, and Jest does not transform node_modules —
+ * so any suite that transitively imports it (meet.test.ts → meet.ts →
+ * api/methods.ts → proxy/toggle-proxy.ts) died at parse time with
+ * "Cannot use import statement outside a module" before a single test ran.
+ *
+ * Nothing under test exercises proxying, so a constructor-shaped stand-in is
+ * enough to keep the import graph loadable.
+ */
+export class HttpsProxyAgent {
+  public readonly proxy: string
+
+  constructor(proxy: string) {
+    this.proxy = proxy
+  }
+}
+
+export default HttpsProxyAgent


### PR DESCRIPTION
## Summary

Four defects behind Meet/Zoom speaker attribution, found diagnosing bot `8f065349` (audio_only Meet, 2 participants) whose diarization put 39 gap-free segments on one person.

- **Network diarization died on silence.** The interceptor waited a flat 60s for a first audio frame, then failed the track while logging `readyState=live` — Meet sends no RTP for someone not talking, so a quiet minute looked identical to a broken pipeline. The client's diarization starts at exactly **60.0s**, the timeout boundary. The wait is now bounded by track liveness, not a clock, and one failed track no longer retires the whole path (`RecordingState`'s stale monitor keeps that decision and reacts ~6× sooner).
- **"Unknown" speaker at join (Meet + Zoom).** Teams already repairs this by upgrading the record once a name arrives; Meet and Zoom never got the equivalent, so speech that beat the roster was stamped `"Unknown"` permanently. Fixed once in `SpeakerManager`: names never downgrade, and attribution is withheld for up to 15s while a name is still unresolved.
- **Meet UI observer couldn't detect speech.** It matched 4 hardcoded RGB blues plus an animated sprite; current Meet drives **opacity** on the mic-bar wrapper instead. Added that signal (via `jsname`, which survives class churn), OR'd with the old one so it can only add detections, plus a `[MEET-DEBUG-SIGNALS]` log so the next markup change is visible in the bot log.
- **Test suite: 18 failures → 66/66.** `meet.test.ts` never ran at all (ESM `https-proxy-agent` killed it at parse time — 14 tests recovered); 15 Teams tests were asserting an error path because `GLOBAL.get()` throws untested; 2 Meet tests had the wrong error string.

Not changed, deliberately: **audio_only → speaker view** is a no-op here — the observer has zero references to video tiles and reads only the People panel, which audio_only already opens. **Teams/Zoom UI observers** need real DOM snapshots first; guessing at markup is how Meet's detector broke.

## Testing

- `tsc --noEmit` clean; biome clean on all changed files.
- Full suite green: **66 passed, 0 failed** (was 18 failed / 36 passed).
- Diagnosis is evidence-backed: prod artifacts, a live People-panel DOM snapshot, and a local run's bot log.

## Release Notes

- Meet bots no longer lose speaker separation when the meeting opens with a quiet minute.
- Meet and Zoom no longer label the first speech of a meeting as "Unknown".
- Meet's fallback speaker detection works against Meet's current UI.