### PR TITLE
fix: fix bug when speakers are unknown in diariization to be backfilled

### DIFF
--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -92,6 +92,22 @@ export class DiarizationTracker {
   }
 
   /**
+   * Relabel the still-open segment if it is attributed to `from`.
+   *
+   * Segments are only written to the file when they close, so a segment opened
+   * before the roster resolved can be repaired in memory and reach the artifact
+   * already correct. Returns true if a rename happened.
+   */
+  public renameOpenSegment(from: string, to: string, userId: number): boolean {
+    if (this.isEnded || !this.currentSegment || this.currentSegment.speaker !== from) {
+      return false
+    }
+    this.currentSegment.speaker = to
+    this.currentSegment.userId = userId
+    return true
+  }
+
+  /**
    * True once at least one speaker segment was ever opened this meeting.
    * Distinguishes "network diarization NEVER produced data" (source is dead —
    * fall back fast) from "was producing, currently quiet" (normal silence —

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -13,12 +13,6 @@ import { createSequentialIdManager, generateStableUserId } from "./utils/speaker
 /** The placeholder every platform's interceptor falls back to before a roster lands. */
 const UNKNOWN_SPEAKER = "Unknown"
 
-/**
- * How long after the first network update an unresolved name is still assumed
- * to be a roster race rather than a genuinely nameless participant.
- */
-const ROSTER_GRACE_MS = 15000
-
 export class SpeakerManager {
   private static instance: SpeakerManager | null = null
   private currentSpeaker: SpeakerData | null = null
@@ -32,9 +26,6 @@ export class SpeakerManager {
   // a later payload can omit a name that an earlier one carried; without this,
   // a participant flips back to "Unknown" mid-meeting.
   private deviceNames = new Map<string, string>()
-  // When each device was first seen, so the roster-race grace window below is
-  // scoped to that participant rather than to the start of the meeting.
-  private deviceFirstSeen = new Map<string, number>()
 
   private constructor() {}
 
@@ -53,28 +44,31 @@ export class SpeakerManager {
 
     if (incoming && incoming !== UNKNOWN_SPEAKER) {
       if (deviceId) {
+        const previous = this.deviceNames.get(deviceId)
         this.deviceNames.set(deviceId, incoming)
+        // First time this device got a real name. If speech already opened a
+        // segment under the placeholder, repair it in place rather than leaving
+        // the opening of the meeting mislabelled.
+        if (previous === undefined) {
+          const renamed = this.diarizationTracker?.renameOpenSegment(
+            UNKNOWN_SPEAKER,
+            incoming,
+            this.sequentialIdManager.getSequentialId(
+              generateStableUserId(incoming, user.profilePicture)
+            )
+          )
+          if (renamed) {
+            console.log(
+              `[SpeakerManager] Roster resolved late — backfilled the open segment to the correct speaker`
+            )
+          }
+        }
       }
       return incoming
     }
 
     const remembered = deviceId ? this.deviceNames.get(deviceId) : undefined
     return remembered ?? UNKNOWN_SPEAKER
-  }
-
-  /**
-   * Timestamp this device was first observed, recording it on first sight.
-   * Devices without an id share a single bucket — they cannot be told apart, so
-   * the best available behaviour is to grant the grace window once.
-   */
-  private firstSeenAt(deviceId: string | undefined, timestamp: number): number {
-    const key = deviceId || ""
-    const existing = this.deviceFirstSeen.get(key)
-    if (existing !== undefined) {
-      return existing
-    }
-    this.deviceFirstSeen.set(key, timestamp)
-    return timestamp
   }
 
   /**
@@ -179,24 +173,21 @@ export class SpeakerManager {
         // Return SpeakerData for diarization.
         //
         // Audio can beat the roster: the first CSRC often resolves to a device
-        // whose name has not been decoded yet, and attributing that speech to
-        // the literal string "Unknown" burns it into the artifact permanently.
-        // Withhold the speaking flag while the name is still unresolved and the
-        // device is newly seen — the roster lands within a second or two, and
-        // the segment then opens under the correct name. After the grace window
-        // an unresolved name is real (not a race), so stop suppressing.
+        // whose name has not been decoded yet. NEVER drop that speech — an
+        // earlier version withheld the speaking flag until the name resolved,
+        // which silently deleted the opening seconds of the meeting from the
+        // artifact (preprod bot 99517dc3: first segment at 10.0s, so everything
+        // before it had no segment and rendered as "Unknown" downstream).
         //
-        // The window is per-device, not per-meeting: someone joining at minute
-        // 20 races their own roster entry exactly like the participants present
-        // at the start, and a meeting-wide anchor would have expired long ago.
-        const nameResolved = stableName !== UNKNOWN_SPEAKER
-        const withinRosterGrace =
-          timestamp - this.firstSeenAt(user.deviceId, timestamp) < ROSTER_GRACE_MS
+        // Emit the segment immediately under whatever name we have, and let
+        // resolveNetworkName() backfill the real name into the still-open
+        // segment once the roster lands. Speech is never lost; at worst a
+        // segment is briefly labelled "Unknown" in memory before being renamed.
         return {
           name: stableName,
           id: sequentialId,
           timestamp,
-          isSpeaking: user.isSpeaking === true && (nameResolved || !withinRosterGrace)
+          isSpeaking: user.isSpeaking === true
         }
       })
 


### PR DESCRIPTION
## Summary

Diarization showed "Unknown" at the start of Meet and Zoom meetings. The cause was a fix of mine that made it worse: a roster-race grace window withheld the speaking flag until a participant's name resolved, which didn't defer that speech — it **discarded** it. Preprod bot `99517dc3` shows the shape exactly: zero "Unknown" segments, but the first segment starts at **10.022s**, so everything spoken before then had no segment to map to and rendered as Unknown downstream.

Replaced discard with backfill:

- Segments now open immediately under whatever name is available — speech is never dropped.
- `DiarizationTracker.renameOpenSegment()` repairs the label in place once the roster lands. Segments are only written when they *close*, so the artifact comes out already correct.
- Removed `ROSTER_GRACE_MS` and the per-device first-seen map; suppression was the wrong mechanism.

Worst case is now a segment briefly labelled "Unknown" in memory before being renamed, instead of missing audio.

## Testing

- `tsc --noEmit` clean; biome clean on both changed files.
- Full suite green: **66 passed, 0 failed**.
- Evidence-driven, not speculative: preprod `99517dc3` (Meet, 66 segments, 2 named speakers, 0 Unknown, first segment 10.022s) identified the gap; a local Meet run reproduced correct end-to-end diarization once audio was flowing.
- **Not verified in preprod yet** — needs one Meet call where someone speaks in the first few seconds. Expect the first segment at ~0-2s rather than 10s, and a `[SpeakerManager] Roster resolved late — backfilled…` line when the race actually happens.

## Release Notes

- Speech at the very start of Meet and Zoom meetings is no longer missing from diarization.
- Speakers whose name arrives late are relabelled correctly instead of being dropped or left as "Unknown".
