### PR TITLE
fix(zoom): ignore chat messages and hidden elements in meeting-end denial detection

### DIFF
--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -53,6 +53,21 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
       errorMessage: "Bot removed or Zoom meeting ended"
     }
   ],
+  // Never treat chat content as a meeting-end signal. The bot's own entry chat
+  // message contains "…the bot can be removed from the meeting upon simple
+  // request.", which tripped the BotRemoved denial pattern ~200ms after the
+  // message was sent — the bot killed itself 1-2s after joining. Any participant
+  // typing "removed from the meeting"/"meeting has ended" into chat (message or
+  // the compose box) would do the same. Genuine removal/meeting-ended UI is a
+  // Zoom modal / full-page overlay (.zm-modal, leave page), never inside the
+  // chat panel (#chat > .chat-container, items .new-chat-item__*/
+  // .new-chat-message__*, compose .chat-rtf-box__*).
+  denialIgnoreWithinSelectors: [
+    "#chat",
+    ".chat-container",
+    ".chat-rtf-box__editor-outer",
+    '[class*="new-chat"]'
+  ],
   waitingRoomPattern: {
     // The waiting room has no unique class — only text. Substring match survives
     // minor copy changes.

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -175,6 +175,108 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
       const result = await detector.isDenied(page)
       expect(result.matched).toBe(false)
     })
+
+    it("does NOT match denial text in a visibility:hidden element (non-zero rect)", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div style="visibility:hidden">You have been removed from the meeting</div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+  })
+
+  describe("phrase split across nested elements (Playwright text= parity)", () => {
+    it("matches a phrase spanning nested inline elements — no single leaf contains it", async () => {
+      await page.setContent(`
+        <div class="zm-modal">
+          <div class="zm-modal-body-title">You have <span>been removed</span> from the meeting</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.matchedText).toBe("removed from the meeting")
+      expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
+    })
+
+    it("still ignores a split phrase when it sits inside the chat panel", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="chat-container">
+          <div>the bot can be <span>removed from</span> the meeting on request</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+  })
+
+  describe("open shadow DOM (Playwright text= parity)", () => {
+    it("matches denial text inside an open shadow root", async () => {
+      await page.setContent('<div id="host"></div>')
+      await page.evaluate(() => {
+        const host = document.getElementById("host") as HTMLElement
+        const shadow = host.attachShadow({ mode: "open" })
+        const modal = document.createElement("div")
+        modal.className = "zm-modal"
+        modal.textContent = "You have been removed from the meeting"
+        shadow.appendChild(modal)
+      })
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.matchedText).toBe("removed from the meeting")
+      expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
+    })
+
+    it("does NOT match shadow content whose host lives inside an ignored container", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="chat-container"><div id="chat-host"></div></div>`)
+      await page.evaluate(() => {
+        const host = document.getElementById("chat-host") as HTMLElement
+        const shadow = host.attachShadow({ mode: "open" })
+        const message = document.createElement("div")
+        message.textContent = "the bot can be removed from the meeting upon simple request."
+        shadow.appendChild(message)
+      })
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+  })
+
+  describe("invalid ignore-selector tolerance", () => {
+    const brokenSelectorConfig: StateDetectionConfig = {
+      providerName: "Broken selector (test)",
+      denialPatterns: [
+        {
+          texts: ["removed from the meeting"],
+          reason: MeetingEndReason.BotRemoved
+        }
+      ],
+      // one malformed selector mixed into valid ones
+      denialIgnoreWithinSelectors: [":::bad", ".chat-container"],
+      inMeetingPattern: { selectors: [], threshold: 1 }
+    }
+    const brokenSelectorDetector = createStateDetector(brokenSelectorConfig)
+
+    it("still detects genuine denial UI and does not throw", async () => {
+      await page.setContent(`
+        <div class="zm-modal">You have been removed from the meeting</div>`)
+
+      const result = await brokenSelectorDetector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
+    })
+
+    it("valid selectors alongside the malformed one still scope out chat", async () => {
+      await page.setContent(`
+        <div class="chat-container">the bot can be removed from the meeting upon request</div>`)
+
+      const result = await brokenSelectorDetector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
   })
 
   describe("backward compatibility (no denialIgnoreWithinSelectors)", () => {

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -1,0 +1,208 @@
+import { type Browser, type BrowserContext, type Page, chromium } from "@playwright/test"
+import { MeetingEndReason } from "../state-machine/types"
+import { type StateDetectionConfig, createStateDetector } from "./meeting-state-detector"
+
+/**
+ * Regression tests for the Zoom self-kill bug: the meeting-end detector matched
+ * denial phrases ("removed from the meeting", "meeting has ended") anywhere on
+ * the page — including the bot's OWN entry chat message, which contains
+ * "…the bot can be removed from the meeting upon simple request." The bot ended
+ * itself with reason botRemoved ~200ms after sending it. Also griefable: any
+ * participant typing a denial phrase into chat killed the bot.
+ *
+ * These tests run against a real Chromium page (real DOM: closest(),
+ * getBoundingClientRect, TreeWalker) rather than mocks.
+ */
+
+jest.setTimeout(60_000)
+
+// Mirrors the relevant parts of ZOOM_STATE_CONFIG (BotRemoved pattern + chat scoping)
+const ZOOM_LIKE_CONFIG: StateDetectionConfig = {
+  providerName: "Zoom Web (test)",
+  denialPatterns: [
+    {
+      texts: ["automated bots aren't allowed"],
+      reason: MeetingEndReason.ZoomAnonymousJoinNotAllowed,
+      errorMessage: "anti-bot wall"
+    },
+    {
+      texts: [
+        "This meeting has been ended by host",
+        "removed from the meeting",
+        "meeting has ended"
+      ],
+      reason: MeetingEndReason.BotRemoved,
+      errorMessage: "Bot removed or Zoom meeting ended"
+    }
+  ],
+  denialIgnoreWithinSelectors: [
+    "#chat",
+    ".chat-container",
+    ".chat-rtf-box__editor-outer",
+    '[class*="new-chat"]'
+  ],
+  inMeetingPattern: {
+    selectors: ['button[aria-label="Leave"]'],
+    threshold: 1,
+    checkVisibility: true
+  }
+}
+
+// Chat panel markup as rendered by the real Zoom web client (from the crash
+// HTML snapshot of bot 02c5dd71-28ce-4902-a96c-6ad10e95d04b)
+const chatPanelHtml = (messageText: string) => `
+  <div id="chat">
+    <div class="chat-container window-content-bottom chat-container--normal chat-container--dark">
+      <div class="chat-container__chat-list">
+        <div class="new-chat-item__container">
+          <div class="new-chat-message__text-box">
+            <span class="new-chat-message__content">${messageText}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>`
+
+const IN_MEETING_HTML = '<button aria-label="Leave">Leave</button>'
+
+describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
+  let browser: Browser
+  let context: BrowserContext
+  let page: Page
+
+  beforeAll(async () => {
+    browser = await chromium.launch()
+  })
+
+  afterAll(async () => {
+    await browser?.close()
+  })
+
+  beforeEach(async () => {
+    context = await browser.newContext()
+    page = await context.newPage()
+  })
+
+  afterEach(async () => {
+    await context?.close()
+  })
+
+  const detector = createStateDetector(ZOOM_LIKE_CONFIG)
+
+  describe("chat content is ignored", () => {
+    it("does NOT match the bot's own entry chat message containing 'removed from the meeting'", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        ${chatPanelHtml(
+          "Hello! This meeting is being recorded — the bot can be removed from the meeting upon simple request."
+        )}`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
+    it("does NOT match a participant typing 'meeting has ended' into a chat message (griefing vector)", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        ${chatPanelHtml("lol watch this: meeting has ended")}`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
+    it("does NOT match denial text typed into the chat compose box", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="chat-rtf-box__editor-outer">
+          <div class="chat-rtf-box__editor">You have been removed from the meeting</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+  })
+
+  describe("genuine denial UI still detected", () => {
+    it("matches the same phrase in a visible Zoom modal outside the chat panel", async () => {
+      await page.setContent(`
+        <div class="zm-modal zm-modal-legacy">
+          <div class="zm-modal-body-title">You have been removed from the meeting</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.matchedText).toBe("removed from the meeting")
+      expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
+    })
+
+    it("still detects a genuine removal modal even when chat also contains the phrase", async () => {
+      await page.setContent(`
+        ${chatPanelHtml("the bot can be removed from the meeting upon simple request.")}
+        <div class="zm-modal">
+          <div>You have been removed from the meeting</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
+    })
+
+    it("matches case-insensitively (Playwright text= semantics preserved)", async () => {
+      await page.setContent("<div>THIS MEETING HAS BEEN ENDED BY HOST</div>")
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.matchedText).toBe("This meeting has been ended by host")
+    })
+
+    it("respects pattern priority order (first configured pattern wins)", async () => {
+      await page.setContent(`
+        <div>meeting has ended</div>
+        <div>Sorry, automated bots aren't allowed in this meeting</div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.pattern?.reason).toBe(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+    })
+  })
+
+  describe("visibility requirement", () => {
+    it("does NOT match denial text in a display:none element (hidden template DOM)", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div style="display:none">You have been removed from the meeting</div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+  })
+
+  describe("backward compatibility (no denialIgnoreWithinSelectors)", () => {
+    const legacyConfig: StateDetectionConfig = {
+      providerName: "Legacy (test)",
+      denialPatterns: [
+        {
+          texts: ["You've been removed"],
+          reason: MeetingEndReason.BotRemoved
+        }
+      ],
+      inMeetingPattern: { selectors: [], threshold: 1 }
+    }
+    const legacyDetector = createStateDetector(legacyConfig)
+
+    it("matches visible denial text anywhere on the page", async () => {
+      await page.setContent("<main><p>You've been removed by the host</p></main>")
+
+      const result = await legacyDetector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.matchedText).toBe("You've been removed")
+    })
+
+    it("returns no match on a normal in-meeting page", async () => {
+      await page.setContent(`${IN_MEETING_HTML}<div>Recording in progress</div>`)
+
+      const result = await legacyDetector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+  })
+})

--- a/src/utils/meeting-state-detector.ts
+++ b/src/utils/meeting-state-detector.ts
@@ -104,13 +104,24 @@ async function checkIndicators(
  * Runs INSIDE the page via page.evaluate — must stay fully self-contained
  * (no references to module scope, or Playwright's function serialization breaks).
  *
- * Scans every leaf element (childElementCount === 0) for the denial texts with
- * the same semantics as Playwright's `text=` engine (case-insensitive,
- * whitespace-normalized substring), and returns the index into `texts` of the
- * highest-priority match — or -1. A match only counts if the element:
- *  - is NOT inside any `ignoreSelectors` subtree (checked via closest()), and
- *  - is actually rendered (non-zero getBoundingClientRect — same lesson as
- *    commit f429129f: hidden template DOM must not trigger detection).
+ * Mirrors Playwright's `text=` engine semantics (which the old locator-based
+ * isDenied relied on): case-insensitive, whitespace-normalized SUBTREE-text
+ * substring matching — so a phrase split across nested elements
+ * (`You have <span>been removed</span> from the meeting`) still matches — and
+ * pierces OPEN shadow roots. Returns the index into `texts` of the
+ * highest-priority (lowest-index) match, or -1.
+ *
+ * For each needle, the INNERMOST matching elements (matching, with no matching
+ * child element) are the candidates — mirroring Playwright's innermost-match
+ * behavior — and a candidate only counts if it:
+ *  - is NOT inside any `ignoreSelectors` subtree. Ancestry is walked across
+ *    shadow boundaries (ShadowRoot → host), testing matches() at each hop;
+ *  - is actually rendered: non-zero getBoundingClientRect (same lesson as
+ *    commit f429129f: hidden template DOM must not trigger detection) AND
+ *    computed `visibility: visible` (visibility:hidden keeps a non-zero rect).
+ *
+ * Subtree text is computed bottom-up in ONE post-order pass and memoized, so
+ * the per-needle innermost search is just map lookups — not innerText per node.
  *
  * Exported for tests; production callers go through isDenied().
  */
@@ -123,47 +134,88 @@ export const findVisibleDenialTextIndex = (args: {
   const root = document.body || document.documentElement
   if (!root) return -1
 
-  let best = -1
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
-  let el: Element | null = root
-  while (el) {
-    if (el.childElementCount === 0 && el.textContent) {
-      const haystack = normalize(el.textContent)
-      if (haystack) {
-        // Lowest matching index = highest-priority pattern (config order)
-        let matchedIndex = -1
-        const limit = best === -1 ? needles.length : best
-        for (let i = 0; i < limit; i++) {
-          if (needles[i] && haystack.includes(needles[i])) {
-            matchedIndex = i
-            break
-          }
-        }
-        if (matchedIndex !== -1) {
-          let ignored = false
-          for (const selector of args.ignoreSelectors) {
-            try {
-              if (el.closest(selector)) {
-                ignored = true
-                break
-              }
-            } catch (_e) {
-              // Invalid selector must never break end-of-meeting detection
-            }
-          }
-          if (!ignored) {
-            const rect = el.getBoundingClientRect()
-            if (rect.width > 0 && rect.height > 0) {
-              best = matchedIndex
-              if (best === 0) return 0
-            }
-          }
-        }
+  // ── one post-order pass: normalized subtree text per element, entering
+  //    open shadow roots ──────────────────────────────────────────────────
+  const subtreeText = new Map<Element, string>()
+  const collectText = (node: Element | ShadowRoot): string => {
+    let raw = ""
+    if (node instanceof Element && node.shadowRoot) {
+      raw += ` ${collectText(node.shadowRoot)} `
+    }
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        raw += (child as Text).data
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        raw += collectText(child as Element)
       }
     }
-    el = walker.nextNode() as Element | null
+    if (node instanceof Element) subtreeText.set(node, normalize(raw))
+    return raw
   }
-  return best
+  collectText(root)
+
+  // Child elements including those in an open shadow root
+  const childElements = (el: Element): Element[] => {
+    const kids: Element[] = []
+    if (el.shadowRoot) {
+      for (const child of el.shadowRoot.children) kids.push(child)
+    }
+    for (const child of el.children) kids.push(child)
+    return kids
+  }
+
+  // Innermost matching elements: subtree text matches the needle, but no child
+  // element's does. Returns whether `el` matches; pushes innermost into `out`.
+  const findInnermost = (el: Element, needle: string, out: Element[]): boolean => {
+    const text = subtreeText.get(el)
+    if (!text || !text.includes(needle)) return false
+    let childMatched = false
+    for (const child of childElements(el)) {
+      if (findInnermost(child, needle, out)) childMatched = true
+    }
+    if (!childMatched) out.push(el)
+    return true
+  }
+
+  // Ancestry walk that crosses shadow boundaries (ShadowRoot → host)
+  const isIgnored = (el: Element): boolean => {
+    let node: Node | null = el
+    while (node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        for (const selector of args.ignoreSelectors) {
+          try {
+            if ((node as Element).matches(selector)) return true
+          } catch (_e) {
+            // Invalid selector must never break end-of-meeting detection
+          }
+        }
+        node = node.parentNode
+      } else if (node instanceof ShadowRoot) {
+        node = node.host
+      } else {
+        node = node.parentNode
+      }
+    }
+    return false
+  }
+
+  const isRendered = (el: Element): boolean => {
+    const rect = el.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) return false
+    const view = el.ownerDocument.defaultView || window
+    return view.getComputedStyle(el).visibility === "visible"
+  }
+
+  // Needles in config order: the first one with a valid rendered match wins
+  for (let i = 0; i < needles.length; i++) {
+    if (!needles[i]) continue
+    const candidates: Element[] = []
+    findInnermost(root, needles[i], candidates)
+    for (const candidate of candidates) {
+      if (!isIgnored(candidate) && isRendered(candidate)) return i
+    }
+  }
+  return -1
 }
 
 /**

--- a/src/utils/meeting-state-detector.ts
+++ b/src/utils/meeting-state-detector.ts
@@ -28,6 +28,13 @@ export type SelectorPattern = {
 export type StateDetectionConfig = {
   providerName: string
   denialPatterns: DenialPattern[]
+  // Subtrees whose text must NEVER count as a denial match. Needed because
+  // denial phrases are generic enough to appear in user-generated content:
+  // the Zoom bot's own entry chat message contains "removed from the meeting",
+  // which used to trip isDenied() ~200ms after joining and kill the bot.
+  // Matched elements are discarded when `element.closest(selector)` hits any
+  // of these selectors.
+  denialIgnoreWithinSelectors?: string[]
   waitingRoomPattern?: SelectorPattern
   inMeetingPattern: SelectorPattern
   // Pre-join flow screens, each identified by any one of several selectors so a
@@ -94,6 +101,72 @@ async function checkIndicators(
 }
 
 /**
+ * Runs INSIDE the page via page.evaluate — must stay fully self-contained
+ * (no references to module scope, or Playwright's function serialization breaks).
+ *
+ * Scans every leaf element (childElementCount === 0) for the denial texts with
+ * the same semantics as Playwright's `text=` engine (case-insensitive,
+ * whitespace-normalized substring), and returns the index into `texts` of the
+ * highest-priority match — or -1. A match only counts if the element:
+ *  - is NOT inside any `ignoreSelectors` subtree (checked via closest()), and
+ *  - is actually rendered (non-zero getBoundingClientRect — same lesson as
+ *    commit f429129f: hidden template DOM must not trigger detection).
+ *
+ * Exported for tests; production callers go through isDenied().
+ */
+export const findVisibleDenialTextIndex = (args: {
+  texts: string[]
+  ignoreSelectors: string[]
+}): number => {
+  const normalize = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase()
+  const needles = args.texts.map(normalize)
+  const root = document.body || document.documentElement
+  if (!root) return -1
+
+  let best = -1
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  let el: Element | null = root
+  while (el) {
+    if (el.childElementCount === 0 && el.textContent) {
+      const haystack = normalize(el.textContent)
+      if (haystack) {
+        // Lowest matching index = highest-priority pattern (config order)
+        let matchedIndex = -1
+        const limit = best === -1 ? needles.length : best
+        for (let i = 0; i < limit; i++) {
+          if (needles[i] && haystack.includes(needles[i])) {
+            matchedIndex = i
+            break
+          }
+        }
+        if (matchedIndex !== -1) {
+          let ignored = false
+          for (const selector of args.ignoreSelectors) {
+            try {
+              if (el.closest(selector)) {
+                ignored = true
+                break
+              }
+            } catch (_e) {
+              // Invalid selector must never break end-of-meeting detection
+            }
+          }
+          if (!ignored) {
+            const rect = el.getBoundingClientRect()
+            if (rect.width > 0 && rect.height > 0) {
+              best = matchedIndex
+              if (best === 0) return 0
+            }
+          }
+        }
+      }
+    }
+    el = walker.nextNode() as Element | null
+  }
+  return best
+}
+
+/**
  * Factory function to create a state detector with captured config
  * Returns an object with detection methods (closure pattern)
  */
@@ -101,17 +174,32 @@ export const createStateDetector = (config: StateDetectionConfig): MeetingStateD
   const detector: MeetingStateDetector = {
     isDenied: async (page) => {
       try {
+        const allTexts: string[] = []
         for (const pattern of config.denialPatterns) {
-          for (const text of pattern.texts) {
-            const element = page.locator(`text=${text}`)
-            if ((await element.count()) > 0) {
+          allTexts.push(...pattern.texts)
+        }
+        if (allTexts.length === 0) {
+          return { state: "denied", matched: false }
+        }
+
+        // Single in-page pass instead of one locator round-trip per phrase
+        const matchedIndex = await page.evaluate(findVisibleDenialTextIndex, {
+          texts: allTexts,
+          ignoreSelectors: config.denialIgnoreWithinSelectors ?? []
+        })
+
+        if (matchedIndex >= 0) {
+          let offset = 0
+          for (const pattern of config.denialPatterns) {
+            if (matchedIndex < offset + pattern.texts.length) {
               return {
                 state: "denied",
                 matched: true,
-                matchedText: text,
+                matchedText: pattern.texts[matchedIndex - offset],
                 pattern
               }
             }
+            offset += pattern.texts.length
           }
         }
         return { state: "denied", matched: false }


### PR DESCRIPTION
## Bug

The Zoom browser bot's meeting-end detector kills the bot when it reads its **own entry chat message**.

Timeline (reproduced twice — bot `02c5dd71-28ce-4902-a96c-6ad10e95d04b` on-prem, bot `b10d975a-728d-4545-9c14-17718612fa54` prod):

1. Bot is admitted to the meeting.
2. Bot sends its entry chat message: "…the bot can be removed from the meeting upon simple request."
3. **169ms later**: `[Zoom] End detected: "removed from the meeting"` → end reason `botRemoved` → bot leaves ~1-2s after joining.

Root cause: `denialPatterns` in `zoom-state-config.ts` include generic phrases ("removed from the meeting", "meeting has ended"), and `isDenied()` matched each phrase with a whole-page `text=` locator — case-insensitive substring, no visibility check, no container scoping. The chat DOM matches.

### Griefing vector

Any participant could kill any recording bot by typing "removed from the meeting" or "meeting has ended" into chat — as a sent message **or** merely into the compose textarea. Fixed by the same scoping.

## Fix

- **`src/utils/meeting-state-detector.ts`**
  - New optional `StateDetectionConfig.denialIgnoreWithinSelectors: string[]` — a denial-text match whose element sits inside any of these subtrees (`element.closest`) is discarded.
  - Matches must be on a **rendered** element (non-zero `getBoundingClientRect`) — same lesson as f429129f (captcha detection only fires on a rendered element), so hidden template DOM can no longer trigger denial.
  - `isDenied` now runs a single `page.evaluate` that TreeWalks leaf elements, instead of one locator round-trip per phrase per poll. Case-insensitive whitespace-normalized substring semantics and pattern priority order are preserved.
  - Configs without the new field (Meet/Teams) behave as before, except the (intentional) visibility requirement.
- **`src/meeting/zoom-state-config.ts`**
  - `denialIgnoreWithinSelectors: ['#chat', '.chat-container', '.chat-rtf-box__editor-outer', '[class*="new-chat"]']` — chat panel, message items, compose box. Selectors verified against the crash DOM snapshot of bot `02c5dd71`. Genuine removal/meeting-ended UI is a `zm-modal`/full-page overlay, never inside the chat container, so real removals are still detected.

## Tests

New `src/utils/meeting-state-detector.test.ts` — runs against a **real Chromium page** (real `closest()`/`getBoundingClientRect`/TreeWalker), with chat markup copied from the real Zoom web client crash snapshot:

- bot's own entry message in `.chat-container` → NOT denied
- "meeting has ended" typed as a chat message (griefing) → NOT denied
- denial text in the compose box → NOT denied
- same phrase in a visible `zm-modal` outside chat → denied (`BotRemoved`)
- chat phrase + genuine modal simultaneously → denied
- `display:none` element → NOT denied
- case-insensitive matching preserved; pattern priority order preserved
- legacy config without `denialIgnoreWithinSelectors` → unchanged behavior

Results: 10/10 new tests pass; full suite 62/62 tests pass (the `meet.test.ts` suite compile failure is pre-existing on `v2-improvements`, unrelated axios typing error). `tsc --noEmit` and the release build (`tsc -p tsconfig.release.json`) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)