### PR TITLE
fix(zoom): terminal error for registration-required webinars

### DIFF
--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -299,6 +299,17 @@ export class ZoomProvider implements MeetingProviderInterface {
     try {
       await page.waitForSelector(NAME_INPUT, { timeout: 30_000 })
     } catch {
+      // Registration-required webinar: Zoom server-side-redirects /wc/<id>/join
+      // to its registration page, so no name input can ever render — from any
+      // pod or IP. Deterministic (bots ca8d3a00 / a32de694 burned 6 pods each
+      // on this); fail terminal with a reason the customer can act on.
+      const finalUrl = page.url()
+      if (/\bzoom\.us\/webinar\/register\//.test(finalUrl)) {
+        GLOBAL.setError(MeetingEndReason.ZoomWebinarRegistrationRequired)
+        throw new Error(
+          `[Zoom] zoom_webinar_registration_required: join URL redirected to ${finalUrl.split("?")[0]}`
+        )
+      }
       // The wall can render here instead of a name field — check before failing.
       const wall = await this.detectBotWall(page)
       if (wall) {

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -6,7 +6,11 @@ import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
 import type { MeetingProviderInterface } from "../types"
-import { buildZoomWebClientUrl, parseZoomMeetingUrl } from "../urlParser/zoomUrlParser"
+import {
+  buildZoomWebClientUrl,
+  parseZoomMeetingUrl,
+  parseZoomRegistrationUrl
+} from "../urlParser/zoomUrlParser"
 import { humanClick, humanType } from "../utils/humanize"
 import { formatError } from "../utils/Logger"
 import { createStateDetector } from "../utils/meeting-state-detector"
@@ -303,11 +307,13 @@ export class ZoomProvider implements MeetingProviderInterface {
       // to its registration page, so no name input can ever render — from any
       // pod or IP. Deterministic (bots ca8d3a00 / a32de694 burned 6 pods each
       // on this); fail terminal with a reason the customer can act on.
-      const finalUrl = page.url()
-      if (/\bzoom\.us\/webinar\/register\//.test(finalUrl)) {
+      const registrationUrl = parseZoomRegistrationUrl(page.url())
+      if (registrationUrl) {
         GLOBAL.setError(MeetingEndReason.ZoomWebinarRegistrationRequired)
+        // origin+pathname only: the registration URL's query can carry the
+        // registrant token and this message ends up in logs/telemetry.
         throw new Error(
-          `[Zoom] zoom_webinar_registration_required: join URL redirected to ${finalUrl.split("?")[0]}`
+          `[Zoom] zoom_webinar_registration_required: join URL redirected to ${registrationUrl.origin}${registrationUrl.pathname}`
         )
       }
       // The wall can render here instead of a name field — check before failing.

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -184,6 +184,12 @@ export class WaitingRoomState extends BaseState {
             `[Zoom] Pre-join failure (${endReason ?? "unknown"}) — marking retryable (fresh pod/IP)`
           )
           GLOBAL.setShouldRetry(true)
+        } else {
+          // A terminal reason is authoritative. Clear any stale retryable flag
+          // set earlier in this attempt (e.g. a transient goto failure inside
+          // openMeetingPage), or error-state suppresses the terminal webhook
+          // and main.ts requeues a failure that can never succeed.
+          GLOBAL.setShouldRetry(false)
         }
       }
 

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -174,7 +174,10 @@ export class WaitingRoomState extends BaseState {
           // genuine no-captcha timeout ends here as ExitingMeetingBeforeRecord /
           // TimeoutWaitingToStart and stops.
           MeetingEndReason.ExitingMeetingBeforeRecord,
-          MeetingEndReason.BotNotAccepted
+          MeetingEndReason.BotNotAccepted,
+          // Registration-required webinar: the join URL server-side-redirects to
+          // zoom.us/webinar/register/ for every pod/IP — retrying can never help.
+          MeetingEndReason.ZoomWebinarRegistrationRequired
         ]
         if (!endReason || !ZOOM_TERMINAL.includes(endReason)) {
           console.log(

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -46,6 +46,10 @@ export enum MeetingEndReason {
   // SDK. Maps to the api-server's ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED error code.
   ZoomAnonymousJoinNotAllowed = "zoomAnonymousJoinNotAllowed",
   ZoomPasscodeRequired = "zoomPasscodeRequired",
+  // The /wc/<id>/join URL server-side-redirected to zoom.us/webinar/register/… :
+  // the webinar requires per-registrant registration (name+email → personal tk=
+  // link), so an anonymous join can never succeed from any pod/IP. Terminal.
+  ZoomWebinarRegistrationRequired = "zoomWebinarRegistrationRequired",
   // Authenticated Teams bot (username/password) — failure modes the api-server distinguishes.
   // Invalid/Captcha/Mfa flip the teams_login to invalid (per-account); Timeout is transient.
   TeamsLoginFailedInvalidCredentials = "teamsLoginFailedInvalidCredentials",
@@ -94,6 +98,8 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "This Zoom meeting rejected the recording bot because it joined anonymously — the host's account blocks anonymous/automated browser joins. We recommend recording it via Zoom RTMS (or the native SDK with a user-authorized credential)."
     case MeetingEndReason.ZoomPasscodeRequired:
       return "Zoom meeting requires a passcode that was not supplied in the meeting URL (?pwd=)."
+    case MeetingEndReason.ZoomWebinarRegistrationRequired:
+      return "This Zoom webinar requires registration: Zoom redirected the join URL to its registration page, so the bot cannot join anonymously. Register the bot first and use the personalized join link (tk=) from the confirmation, or disable required registration for the webinar."
     case MeetingEndReason.TeamsLoginFailedInvalidCredentials:
       return "Microsoft rejected the account email/password. Update the teams_login credentials."
     case MeetingEndReason.TeamsLoginFailedCaptcha:

--- a/src/urlParser/zoomUrlParser.test.ts
+++ b/src/urlParser/zoomUrlParser.test.ts
@@ -1,6 +1,10 @@
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
-import { buildZoomWebClientUrl, parseZoomMeetingUrl } from "./zoomUrlParser"
+import {
+  buildZoomWebClientUrl,
+  parseZoomMeetingUrl,
+  parseZoomRegistrationUrl
+} from "./zoomUrlParser"
 
 // GLOBAL.setError is called on the throw path; stub the singleton so the parser
 // unit tests don't need the full bot runtime.
@@ -225,6 +229,55 @@ describe("Zoom URL Parser", () => {
       expect(thrown!.message).toMatch(/Invalid Zoom meeting URL/)
       expect(thrown!.message).not.toContain("SuperSecret123")
       expect(setErrorMock).toHaveBeenCalledWith(MeetingEndReason.InvalidMeetingUrl)
+    })
+  })
+
+  // A match here makes the join failure TERMINAL (no SQS requeue), so a false
+  // positive costs a customer the whole retry budget of a joinable meeting.
+  describe("parseZoomRegistrationUrl", () => {
+    test("matches the canonical webinar registration page", () => {
+      const u = parseZoomRegistrationUrl("https://zoom.us/webinar/register/WN_abc123")
+      expect(u?.pathname).toBe("/webinar/register/WN_abc123")
+    })
+
+    test("matches on a regional host", () => {
+      expect(
+        parseZoomRegistrationUrl("https://us02web.zoom.us/webinar/register/WN_abc")
+      ).toBeDefined()
+    })
+
+    test("does NOT match a lookalike host", () => {
+      expect(
+        parseZoomRegistrationUrl("https://foo-zoom.us/webinar/register/WN_abc")
+      ).toBeUndefined()
+      expect(
+        parseZoomRegistrationUrl("https://evilzoom.us.attacker.com/webinar/register/WN_abc")
+      ).toBeUndefined()
+    })
+
+    test("does NOT match a registration URL echoed in a query or fragment", () => {
+      expect(
+        parseZoomRegistrationUrl(
+          "https://app.zoom.us/wc/123/join?next=https://zoom.us/webinar/register/WN_abc"
+        )
+      ).toBeUndefined()
+      expect(
+        parseZoomRegistrationUrl("https://app.zoom.us/wc/123/join#zoom.us/webinar/register/WN_abc")
+      ).toBeUndefined()
+    })
+
+    test("does NOT match an ordinary join URL, or a malformed one", () => {
+      expect(parseZoomRegistrationUrl("https://app.zoom.us/wc/84335626851/join")).toBeUndefined()
+      expect(parseZoomRegistrationUrl("not a url")).toBeUndefined()
+      expect(parseZoomRegistrationUrl("")).toBeUndefined()
+    })
+
+    test("reported origin+pathname drops the query that carries the token", () => {
+      const u = parseZoomRegistrationUrl(
+        "https://zoom.us/webinar/register/WN_abc?tk=SuperSecret123#frag"
+      )
+      expect(`${u?.origin}${u?.pathname}`).toBe("https://zoom.us/webinar/register/WN_abc")
+      expect(`${u?.origin}${u?.pathname}`).not.toContain("SuperSecret123")
     })
   })
 })

--- a/src/urlParser/zoomUrlParser.ts
+++ b/src/urlParser/zoomUrlParser.ts
@@ -86,6 +86,33 @@ export async function parseZoomMeetingUrl(meeting_url: string): Promise<ZoomUrlC
 }
 
 /**
+ * Recognise Zoom's webinar registration page, returning the parsed URL (or
+ * undefined when the URL is not one).
+ *
+ * A registration-required webinar server-side-redirects /wc/<id>/join to
+ * <zoom-host>/webinar/register/<id>, where the only way in is a name+email
+ * form — so no pre-join input can ever render, from any pod or IP.
+ *
+ * Match on the parsed host and path, never on a substring of the serialized
+ * URL: this classification makes the failure TERMINAL, so a false positive
+ * (lookalike host such as foo-zoom.us, or a registration link echoed back in
+ * a ?next= query) would burn the whole retry budget of a meeting that was
+ * merely slow to render.
+ */
+export function parseZoomRegistrationUrl(rawUrl: string): URL | undefined {
+  try {
+    const url = new URL(rawUrl)
+    const isCanonicalZoomHost =
+      url.hostname === "zoom.us" || url.hostname.endsWith(".zoom.us")
+    if (!isCanonicalZoomHost) return undefined
+    return /^\/webinar\/register(?:\/|$)/i.test(url.pathname) ? url : undefined
+  } catch {
+    // Malformed URL — keep the generic (retryable) join failure.
+    return undefined
+  }
+}
+
+/**
  * Build the Zoom Web Client URL the bot actually navigates.
  * Rewrites ONLY canonical zoom.us hosts to app.zoom.us/wc/<id>/join; everything
  * else (white-label portals, or an already-built /wc/ URL) is returned as-is.


### PR DESCRIPTION
## Problem

Two customer bots `ca8d3a00` and `a32de694` (Aug 3): valid `app.zoom.us/wc/<id>/join` URLs, but the targets are **registration-required Zoom webinars**. Zoom server-side-redirects the join URL to `zoom.us/webinar/register/WN_…`, where the only path in is a registration form (name + email → per-registrant `tk=` join link). No pre-join name input ever renders.

The bot threw `[Zoom] Pre-join name input never appeared` → generic `cannotJoinMeeting` → **retryable** → 6 pods per bot, 12/12 identical ~40s failures, customer saw only `joining_call` → `recording_failed` and assumed Zoom bot-detection.

Verified two ways:
- the pods' own screen recordings show the webinar registration/landing page, no join form;
- `curl -L` of both join URLs (plain HTTP client, unrelated IP) 302s to the registration page — deterministic per webinar config, nothing to do with detection.

## Fix

- New `MeetingEndReason.ZoomWebinarRegistrationRequired` with an actionable message (register the bot and use the `tk=` link, or disable required registration).
- `zoom.ts`: on name-input timeout, check `page.url()` for `/webinar/register/` **before** the anti-bot-wall check → fail with the new reason.
- `waiting-room-state.ts`: reason added to `ZOOM_TERMINAL` → no SQS requeue.

Flows through the existing error-state default path as `meeting_error` + `recording_failed` with the explicit message — no new api-server event code, so older/on-prem api-servers keep accepting it.

## Follow-up (separate, product call)

Auto-register flow for open-registration webinars: submit first-name+email on the registration page, harvest the `tk=` join link from the confirmation (works when approval is automatic). Manual-approval webinars stay impossible by design.

## Tests

`tsc --noEmit` clean. Jest: 52 passed; the 17 failures in `meet.test.ts` / `meeting-state-detector.test.ts` pre-exist on clean `origin/v2-improvements` (verified via stash).

Related: #272 (truncated-URL terminal), Meeting-BaaS/meeting-baas-v2#356 (API-side 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
