### PR TITLE
fix(zoom): preserve ?tk= webinar registration token

### DIFF
--- a/src/urlParser/zoomUrlParser.test.ts
+++ b/src/urlParser/zoomUrlParser.test.ts
@@ -103,6 +103,29 @@ describe("Zoom URL Parser", () => {
     })
   })
 
+  describe("parseZoomMeetingUrl — personalized webinar links (?tk=)", () => {
+    // The tk token is what admits a registered attendee into a
+    // registration-required webinar. Extracting only the numeric id would
+    // rewrite to the anonymous /wc/ URL and hit the registration wall
+    // (prod 2026-08-03: 136/148 join failures).
+    test("/w/ link with tk carries the raw URL so the token survives", async () => {
+      const raw = "https://zoom.us/w/99094129400?tk=abc.def&uuid=WN_xxx"
+      const r = await parseZoomMeetingUrl(raw)
+      expect(r.meetingId).toBe(raw)
+    })
+
+    test("regional host /w/ link with tk carries the raw URL", async () => {
+      const raw = "https://us06web.zoom.us/w/85290429520?tk=xyz"
+      const r = await parseZoomMeetingUrl(raw)
+      expect(r.meetingId).toBe(raw)
+    })
+
+    test("/w/ link WITHOUT tk still falls back to the numeric id", async () => {
+      const r = await parseZoomMeetingUrl("https://zoom.us/w/99094129400?uuid=WN_xxx")
+      expect(r.meetingId).toBe("99094129400")
+    })
+  })
+
   describe("parseZoomMeetingUrl — white-label portals", () => {
     test("non-canonical host with numeric id falls back to id", async () => {
       const r = await parseZoomMeetingUrl(
@@ -140,6 +163,17 @@ describe("Zoom URL Parser", () => {
     test("leaves white-label portals untouched", () => {
       const portal = "https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284?password=p"
       expect(buildZoomWebClientUrl(portal)).toBe(portal)
+    })
+
+    test("leaves a personalized ?tk= webinar link byte-identical", () => {
+      const tk = "https://zoom.us/w/99094129400?tk=abc.def&uuid=WN_xxx"
+      expect(buildZoomWebClientUrl(tk)).toBe(tk)
+    })
+
+    test("still rewrites a /j/ URL without tk (no regression)", () => {
+      expect(buildZoomWebClientUrl("https://zoom.us/j/84335626851?pwd=x")).toBe(
+        "https://app.zoom.us/wc/84335626851/join?pwd=x"
+      )
     })
 
     test("leaves zoom Events URLs untouched", () => {

--- a/src/urlParser/zoomUrlParser.test.ts
+++ b/src/urlParser/zoomUrlParser.test.ts
@@ -124,6 +124,22 @@ describe("Zoom URL Parser", () => {
       const r = await parseZoomMeetingUrl("https://zoom.us/w/99094129400?uuid=WN_xxx")
       expect(r.meetingId).toBe("99094129400")
     })
+
+    // The id carried through must be the NORMALISED url: getMeetingLink hands
+    // any non-numeric id straight to buildZoomWebClientUrl, whose `new URL()`
+    // would throw on the raw form and flag the meeting InvalidMeetingUrl.
+    test("a quoted tk link carries the dequoted URL", async () => {
+      const r = await parseZoomMeetingUrl('"https://zoom.us/w/99094129400?tk=abc"')
+      expect(r.meetingId).toBe("https://zoom.us/w/99094129400?tk=abc")
+      expect(buildZoomWebClientUrl(r.meetingId)).toBe(
+        "https://zoom.us/w/99094129400?tk=abc"
+      )
+    })
+
+    test("a scheme-less, padded tk link carries the normalised URL", async () => {
+      const r = await parseZoomMeetingUrl("  zoom.us/w/99094129400?tk=abc  ")
+      expect(r.meetingId).toBe("https://zoom.us/w/99094129400?tk=abc")
+    })
   })
 
   describe("parseZoomMeetingUrl — white-label portals", () => {
@@ -168,6 +184,23 @@ describe("Zoom URL Parser", () => {
     test("leaves a personalized ?tk= webinar link byte-identical", () => {
       const tk = "https://zoom.us/w/99094129400?tk=abc.def&uuid=WN_xxx"
       expect(buildZoomWebClientUrl(tk)).toBe(tk)
+    })
+
+    // tk is a credential and this URL is navigated verbatim, so it must never
+    // leave over cleartext. zoom.us is HTTPS-only, so upgrade instead of
+    // rejecting — a rejected link would fail a joinable meeting.
+    test("upgrades an http:// tk link to https on canonical hosts", () => {
+      expect(buildZoomWebClientUrl("http://zoom.us/w/99094129400?tk=abc")).toBe(
+        "https://zoom.us/w/99094129400?tk=abc"
+      )
+      expect(
+        buildZoomWebClientUrl("http://us06web.zoom.us/w/85290429520?tk=xyz")
+      ).toBe("https://us06web.zoom.us/w/85290429520?tk=xyz")
+    })
+
+    test("leaves an http:// tk link on a white-label host alone", () => {
+      const portal = "http://corp.example.com/webinar/99094129400?tk=abc"
+      expect(buildZoomWebClientUrl(portal)).toBe(portal)
     })
 
     test("still rewrites a /j/ URL without tk (no regression)", () => {

--- a/src/urlParser/zoomUrlParser.ts
+++ b/src/urlParser/zoomUrlParser.ts
@@ -46,10 +46,12 @@ export async function parseZoomMeetingUrl(meeting_url: string): Promise<ZoomUrlC
     // the meeting (prod 2026-08-03: 136 of 148 join failures were valid tk
     // links destroyed this way; PR #273 added the ZoomWebinarRegistrationRequired
     // terminal error for the anonymous case — with a token we must never hit
-    // it). Carry the raw URL as the id, same as the white-label branch, so
-    // getMeetingLink/buildZoomWebClientUrl navigate it untouched.
+    // it). Carry the URL as the id, same as the white-label branch, so
+    // getMeetingLink/buildZoomWebClientUrl navigate it untouched. Carry
+    // cleanUrl, not meeting_url: a quoted or scheme-less invite would fail
+    // buildZoomWebClientUrl's `new URL()` and get flagged InvalidMeetingUrl.
     if (url.searchParams.get("tk")) {
-      return { meetingId: meeting_url, password: pwd }
+      return { meetingId: cleanUrl, password: pwd }
     }
 
     if (isCanonicalZoomHost && meetingId) {
@@ -91,6 +93,8 @@ export async function parseZoomMeetingUrl(meeting_url: string): Promise<ZoomUrlC
 export function buildZoomWebClientUrl(meetingUrl: string, password?: string): string {
   try {
     const url = new URL(meetingUrl)
+    const isCanonicalZoomHost =
+      url.hostname === "zoom.us" || url.hostname.endsWith(".zoom.us")
 
     // Zoom Events URLs self-redirect to the web client — leave untouched.
     if (url.hostname === "events.zoom.us") return meetingUrl
@@ -98,12 +102,21 @@ export function buildZoomWebClientUrl(meetingUrl: string, password?: string): st
     // it as-is — Zoom's own redirect applies the token and lands in the web
     // client. Rewriting to the anonymous /wc/ URL would drop the token and
     // hit the registration wall.
-    if (url.searchParams.get("tk")) return meetingUrl
+    if (url.searchParams.get("tk")) {
+      // tk is a credential and this URL goes straight to page.goto, so it must
+      // not travel in cleartext. Canonical zoom.us is HTTPS-only (HSTS
+      // preloaded) — upgrade an http:// invite rather than reject it, since
+      // rejecting would fail a link that is otherwise perfectly joinable.
+      // Non-canonical hosts are left alone: we can't assume they serve HTTPS.
+      if (url.protocol === "http:" && isCanonicalZoomHost) {
+        url.protocol = "https:"
+        return url.toString()
+      }
+      return meetingUrl
+    }
     // Already a web-client URL — leave untouched (but ensure pwd is present).
     if (meetingUrl.includes("/wc/")) return meetingUrl
 
-    const isCanonicalZoomHost =
-      url.hostname === "zoom.us" || url.hostname.endsWith(".zoom.us")
     if (!isCanonicalZoomHost) {
       // White-label portal — navigate the original; human assists via VNC.
       return meetingUrl

--- a/src/urlParser/zoomUrlParser.ts
+++ b/src/urlParser/zoomUrlParser.ts
@@ -40,6 +40,18 @@ export async function parseZoomMeetingUrl(meeting_url: string): Promise<ZoomUrlC
     const pathMatch = url.pathname.match(/\/(?:j|s|wc|wc\/join)\/(\d{8,})/)
     const meetingId = pathMatch?.[1] ?? url.pathname.match(/(\d{8,})/)?.[1]
 
+    // ?tk= is a per-registrant webinar token (personalized /w/ links from a
+    // registration-required webinar). Rewriting to the anonymous /wc/<id>/join
+    // URL discards it and lands the bot on the registration wall instead of
+    // the meeting (prod 2026-08-03: 136 of 148 join failures were valid tk
+    // links destroyed this way; PR #273 added the ZoomWebinarRegistrationRequired
+    // terminal error for the anonymous case — with a token we must never hit
+    // it). Carry the raw URL as the id, same as the white-label branch, so
+    // getMeetingLink/buildZoomWebClientUrl navigate it untouched.
+    if (url.searchParams.get("tk")) {
+      return { meetingId: meeting_url, password: pwd }
+    }
+
     if (isCanonicalZoomHost && meetingId) {
       return { meetingId, password: pwd }
     }
@@ -82,6 +94,11 @@ export function buildZoomWebClientUrl(meetingUrl: string, password?: string): st
 
     // Zoom Events URLs self-redirect to the web client — leave untouched.
     if (url.hostname === "events.zoom.us") return meetingUrl
+    // Personalized webinar link carrying a ?tk= registration token: navigate
+    // it as-is — Zoom's own redirect applies the token and lands in the web
+    // client. Rewriting to the anonymous /wc/ URL would drop the token and
+    // hit the registration wall.
+    if (url.searchParams.get("tk")) return meetingUrl
     // Already a web-client URL — leave untouched (but ensure pwd is present).
     if (meetingUrl.includes("/wc/")) return meetingUrl
 


### PR DESCRIPTION
## Problem

Personalized Zoom webinar links look like `https://zoom.us/w/99094129400?tk=<registration-token>&uuid=WN_xxx`. The `tk` token is what admits a registered attendee into a registration-required webinar — and the bot destroys it:

1. `parseZoomMeetingUrl` has no `/w/` branch in its path regex, so the loose `(\d{8,})` fallback extracts just the numeric id; `tk` is read nowhere.
2. `getMeetingLink` seeds `https://zoom.us/j/<id>` from the numeric id.
3. `buildZoomWebClientUrl` rewrites that to the anonymous `https://app.zoom.us/wc/<id>/join`, Zoom 302s to the registration page, and the join dies with `[Zoom] Pre-join name input never appeared` on all 6 SQS attempts.

Verified in prod on 2026-08-03: **136 of 148** of an on-prem customer's daily Zoom join failures were valid tk links destroyed by this rewrite — per-attempt logs show `Attempting to open meeting page: https://app.zoom.us/wc/<id>/join` with the tk stripped, and screen recordings show the bot parked on the registration page.

## Fix

Pass the original tk URL through untouched (~4 lines in `src/urlParser/zoomUrlParser.ts`):

- `parseZoomMeetingUrl`: when `?tk=` is present, carry the raw URL as the meetingId (same shape the white-label branch already uses).
- `buildZoomWebClientUrl`: when `?tk=` is present, return the URL as-is — Zoom's own redirect applies the token and lands in the web client.

No change needed in `zoom.ts`: `getMeetingLink` already passes any non-numeric meetingId straight to `buildZoomWebClientUrl`, which now early-returns it.

Complements #273, which added the `ZoomWebinarRegistrationRequired` terminal error for the anonymous case — this PR prevents ever hitting that wall when a token exists.

## Tests

`src/urlParser/zoomUrlParser.test.ts`: 21 → 26, all passing; `tsc --noEmit` clean.

- `/w/<id>?tk=...` → meetingId is the full original URL (bare + regional host)
- `buildZoomWebClientUrl` returns a tk URL byte-identical
- `/w/<id>` WITHOUT tk keeps current behavior (numeric id fallback)
- `/j/<id>?pwd=x` without tk still rewrites to `app.zoom.us/wc/<id>/join?pwd=x` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)