### PR TITLE
fix: repair late-roster speaker names and stop retiring the Teams network path early

### DIFF
--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DiarizationTracker } from "./diarization-tracker"
+import type { SpeakerData } from "./types"
+
+const TEMP_DIR = mkdtempSync(join(tmpdir(), "diarization-test-"))
+
+jest.mock("./utils/PathManager", () => ({
+  PathManager: {
+    getInstance: () => ({ getTempPath: () => TEMP_DIR })
+  }
+}))
+
+const MEETING_START = 1_000_000
+
+function speech(deviceId: string, name: string, atSeconds: number): SpeakerData {
+  return {
+    name,
+    id: 0,
+    timestamp: MEETING_START + atSeconds * 1000,
+    isSpeaking: true,
+    deviceId
+  }
+}
+
+function readSegments(): Array<{ speaker: string; user_id: number }> {
+  return readFileSync(join(TEMP_DIR, "diarization.jsonl"), "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l))
+}
+
+function freshTracker(): DiarizationTracker {
+  // Singleton — reset between cases so each starts with an empty buffer.
+  ;(DiarizationTracker as unknown as { instance: DiarizationTracker | null }).instance = null
+  return DiarizationTracker.getInstance()
+}
+
+describe("DiarizationTracker backfill", () => {
+  it("repairs segments already flushed to disk before the roster resolved", () => {
+    const tracker = freshTracker()
+
+    // Audio beats the roster: several turns are recorded before any name is
+    // known. Each updateSpeaker call CLOSES and writes the previous segment, so
+    // by the time the roster lands these are already on disk — this is the exact
+    // production case the open-segment-only repair could not fix.
+    tracker.updateSpeaker(speech("dev-a", "Unknown", 1), MEETING_START)
+    tracker.updateSpeaker(speech("dev-a", "Unknown", 3), MEETING_START)
+    tracker.updateSpeaker(speech("dev-a", "Unknown", 5), MEETING_START)
+
+    return tracker
+      .end(MEETING_START + 7000, MEETING_START, (deviceId) =>
+        deviceId === "dev-a" ? { name: "Amr El Shimy", userId: 2 } : undefined
+      )
+      .then(() => {
+        const segments = readSegments()
+        expect(segments).toHaveLength(3)
+        expect(segments.every((s) => s.speaker === "Amr El Shimy")).toBe(true)
+        expect(segments.every((s) => s.user_id === 2)).toBe(true)
+      })
+  })
+
+  it("matches by device, never by name, so speech is not handed to the wrong person", async () => {
+    const tracker = freshTracker()
+
+    // Two participants are both "Unknown" at the same time. Renaming by name
+    // alone would relabel whichever segment happened to be open.
+    tracker.updateSpeaker(speech("dev-a", "Unknown", 1), MEETING_START)
+    tracker.updateSpeaker(speech("dev-b", "Unknown", 4), MEETING_START)
+
+    await tracker.end(MEETING_START + 6000, MEETING_START, (deviceId) =>
+      deviceId === "dev-a"
+        ? { name: "Amr El Shimy", userId: 2 }
+        : { name: "Johnny", userId: 3 }
+    )
+
+    const segments = readSegments()
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({ speaker: "Amr El Shimy", user_id: 2 })
+    expect(segments[1]).toMatchObject({ speaker: "Johnny", user_id: 3 })
+  })
+
+  it("leaves a device the roster never named as Unknown rather than guessing", async () => {
+    const tracker = freshTracker()
+
+    tracker.updateSpeaker(speech("dev-a", "Unknown", 1), MEETING_START)
+    tracker.updateSpeaker(speech("ghost", "Unknown", 3), MEETING_START)
+
+    await tracker.end(MEETING_START + 5000, MEETING_START, (deviceId) =>
+      deviceId === "dev-a" ? { name: "Amr El Shimy", userId: 2 } : undefined
+    )
+
+    const segments = readSegments()
+    expect(segments[0].speaker).toBe("Amr El Shimy")
+    expect(segments[1].speaker).toBe("Unknown")
+  })
+
+  it("does not disturb segments that already had a real name", async () => {
+    const tracker = freshTracker()
+
+    tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 1), MEETING_START)
+    tracker.updateSpeaker(speech("dev-b", "Johnny", 3), MEETING_START)
+
+    await tracker.end(MEETING_START + 5000, MEETING_START, () => ({
+      name: "SHOULD NOT APPLY",
+      userId: 99
+    }))
+
+    const segments = readSegments()
+    expect(segments.map((s) => s.speaker)).toEqual(["Amr El Shimy", "Johnny"])
+  })
+})

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -1,6 +1,7 @@
 import { createWriteStream, type WriteStream } from "node:fs"
+import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import type { SpeakerData } from "./types"
+import { type SpeakerData, UNKNOWN_SPEAKER } from "./types"
 import { PathManager } from "./utils/PathManager"
 
 interface DiarizationSegment {
@@ -28,11 +29,25 @@ export interface DiarizationHealthStatus {
   status: DiarizationHealthStatusLevel
 }
 
+/** Resolves a network device to its final name/id, once the roster is complete. */
+export type SpeakerResolver = (deviceId: string) => { name: string; userId: number } | undefined
+
 export class DiarizationTracker {
   private static instance: DiarizationTracker | null = null
   private fileStream: WriteStream | null = null
-  private currentSegment: { speaker: string; startTime: number; userId: number } | null = null
+  private currentSegment: {
+    speaker: string
+    startTime: number
+    userId: number
+    deviceId?: string
+  } | null = null
   private recentSegments: DiarizationSegment[] = [] // Last 5 closed segments
+  // EVERY segment produced this meeting, with the device it belongs to. This is
+  // the authoritative copy: the file is rewritten from it on end() so segments
+  // that were flushed while a name was still unresolved can be repaired.
+  // Without this, only the single open segment could ever be fixed and every
+  // "Unknown" already written to disk stayed wrong forever.
+  private allSegments: Array<{ segment: DiarizationSegment; deviceId?: string }> = []
   private filePath: string
   private isEnded = false
   private hasTrackedAnySegment = false // True once ANY speaker segment was ever opened
@@ -74,6 +89,10 @@ export class DiarizationTracker {
         user_id: this.currentSegment.userId
       }
       this.writeToFile(closedSegment)
+      this.allSegments.push({
+        segment: closedSegment,
+        deviceId: this.currentSegment.deviceId
+      })
 
       // Add to recent segments (keep max 5)
       this.recentSegments.push(closedSegment)
@@ -86,25 +105,35 @@ export class DiarizationTracker {
     this.currentSegment = {
       speaker: speaker.name,
       startTime: relativeTime,
-      userId: speaker.id
+      userId: speaker.id,
+      deviceId: speaker.deviceId
     }
     this.hasTrackedAnySegment = true
   }
 
   /**
-   * Relabel the still-open segment if it is attributed to `from`.
+   * Repair every segment still attributed to the placeholder, using the final
+   * roster. Returns how many were fixed.
    *
-   * Segments are only written to the file when they close, so a segment opened
-   * before the roster resolved can be repaired in memory and reach the artifact
-   * already correct. Returns true if a rename happened.
+   * Matching is by DEVICE, never by name: two participants can both be sitting
+   * under "Unknown" at once, and renaming by name alone would hand one person's
+   * speech to the other.
    */
-  public renameOpenSegment(from: string, to: string, userId: number): boolean {
-    if (this.isEnded || !this.currentSegment || this.currentSegment.speaker !== from) {
-      return false
+  private repairUnknownSpeakers(resolve: SpeakerResolver): number {
+    let repaired = 0
+    for (const entry of this.allSegments) {
+      if (entry.segment.speaker !== UNKNOWN_SPEAKER || !entry.deviceId) {
+        continue
+      }
+      const resolved = resolve(entry.deviceId)
+      if (!resolved || resolved.name === UNKNOWN_SPEAKER) {
+        continue
+      }
+      entry.segment.speaker = resolved.name
+      entry.segment.user_id = resolved.userId
+      repaired++
     }
-    this.currentSegment.speaker = to
-    this.currentSegment.userId = userId
-    return true
+    return repaired
   }
 
   /**
@@ -123,60 +152,76 @@ export class DiarizationTracker {
    * @param meetingStartTime - Meeting start timestamp in milliseconds
    * @returns Promise that resolves when the file stream is fully closed and flushed
    */
-  public end(lastTimestamp: number, meetingStartTime: number): Promise<void> {
+  public async end(
+    lastTimestamp: number,
+    meetingStartTime: number,
+    resolveSpeaker?: SpeakerResolver
+  ): Promise<void> {
     if (this.isEnded) {
-      return Promise.resolve()
+      return
     }
     this.isEnded = true
 
-    // Close the file stream and wait for it to finish flushing
-    if (this.fileStream) {
-      return new Promise<void>((resolve, reject) => {
-        const stream = this.fileStream!
-        this.fileStream = null
-
-        // Write the last segment if it exists
-        if (this.currentSegment) {
-          const relativeTime = (lastTimestamp - meetingStartTime) / 1000
-          const finalSegment: DiarizationSegment = {
-            speaker: this.currentSegment.speaker,
-            start_time: this.currentSegment.startTime,
-            end_time: relativeTime,
-            user_id: this.currentSegment.userId
-          }
-          const line = `${JSON.stringify(finalSegment)}\n`
-
-          // Write the final segment and check if we need to wait for drain
-          const writeSuccess = stream.write(line)
-          if (!writeSuccess) {
-            // If write returned false, wait for drain before ending
-            stream.once("drain", () => {
-              stream.end()
-            })
-          } else {
-            // Write was successful, can end immediately
-            stream.end()
-          }
-        } else {
-          // No final segment to write, just end the stream
-          stream.end()
-        }
-
-        // Wait for the stream to finish flushing all data
-        stream.once("finish", () => {
-          console.log(`Diarization tracking completed: ${this.filePath}`)
-          resolve()
-        })
-
-        stream.once("error", (error) => {
-          console.error(`DiarizationTracker: Error closing stream: ${error}`)
-          reject(error)
-        })
+    // Close the final segment into the buffer so it can be repaired too — it is
+    // frequently the one that opened before the roster landed.
+    if (this.currentSegment) {
+      this.allSegments.push({
+        segment: {
+          speaker: this.currentSegment.speaker,
+          start_time: this.currentSegment.startTime,
+          end_time: (lastTimestamp - meetingStartTime) / 1000,
+          user_id: this.currentSegment.userId
+        },
+        deviceId: this.currentSegment.deviceId
       })
+      this.currentSegment = null
     }
 
+    const repaired = resolveSpeaker ? this.repairUnknownSpeakers(resolveSpeaker) : 0
+    if (repaired > 0) {
+      console.log(
+        `[DiarizationTracker] Backfilled ${repaired} segment(s) that were written before the roster resolved`
+      )
+    }
+
+    await this.closeStream()
+
+    // Rewrite from the in-memory buffer, which is authoritative. Appending as we
+    // go keeps a usable file if the pod dies mid-meeting, but the append log can
+    // contain names that were still unresolved at the time they were flushed.
+    try {
+      const body = this.allSegments.map((e) => `${JSON.stringify(e.segment)}\n`).join("")
+      await writeFile(this.filePath, body)
+    } catch (error) {
+      console.error(`DiarizationTracker: Failed to rewrite ${this.filePath}: ${error}`)
+    }
+
+    const stillUnknown = this.allSegments.filter(
+      (e) => e.segment.speaker === UNKNOWN_SPEAKER
+    ).length
+    if (stillUnknown > 0) {
+      console.warn(
+        `[DiarizationTracker] ${stillUnknown}/${this.allSegments.length} segment(s) remain "${UNKNOWN_SPEAKER}" — the roster never resolved those devices`
+      )
+    }
     console.log(`Diarization tracking completed: ${this.filePath}`)
-    return Promise.resolve()
+  }
+
+  /** Flush and close the append stream, resolving even if it errors. */
+  private closeStream(): Promise<void> {
+    const stream = this.fileStream
+    this.fileStream = null
+    if (!stream) {
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      stream.end()
+      stream.once("finish", () => resolve())
+      stream.once("error", (error) => {
+        console.error(`DiarizationTracker: Error closing stream: ${error}`)
+        resolve()
+      })
+    })
   }
 
   /**

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -187,8 +187,8 @@ export class SpeakerManager {
         // whose name has not been decoded yet. NEVER drop that speech — an
         // earlier version withheld the speaking flag until the name resolved,
         // which silently deleted the opening seconds of the meeting from the
-        // artifact (preprod bot 99517dc3: first segment at 10.0s, so everything
-        // before it had no segment and rendered as "Unknown" downstream).
+        // artifact: the first segment landed ten seconds in, and everything
+        // before it rendered as "Unknown" downstream.
         //
         // Emit the segment immediately under whatever name we have. deviceId is
         // what makes the repair possible: at finalize every segment still marked

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -6,13 +6,11 @@ import { GLOBAL } from "./singleton"
 import { MeetingStateMachine } from "./state-machine/machine"
 import type { ParticipantState } from "./state-machine/types"
 import { Streaming } from "./streaming"
-import type { Participant, SpeakerData } from "./types"
+import { type Participant, type SpeakerData, UNKNOWN_SPEAKER } from "./types"
 import { PathManager } from "./utils/PathManager"
 import { PiiRedactor } from "./utils/PiiRedactor"
 import { createSequentialIdManager, generateStableUserId } from "./utils/speaker-id"
 
-/** The placeholder every platform's interceptor falls back to before a roster lands. */
-const UNKNOWN_SPEAKER = "Unknown"
 
 export class SpeakerManager {
   private static instance: SpeakerManager | null = null
@@ -27,6 +25,9 @@ export class SpeakerManager {
   // a later payload can omit a name that an earlier one carried; without this,
   // a participant flips back to "Unknown" mid-meeting.
   private deviceNames = new Map<string, string>()
+  // Profile picture per device, so a backfilled segment gets the same stable id
+  // the live path would have produced for that participant.
+  private deviceProfilePictures = new Map<string, string | undefined>()
 
   private constructor() {}
 
@@ -45,25 +46,8 @@ export class SpeakerManager {
 
     if (incoming && incoming !== UNKNOWN_SPEAKER) {
       if (deviceId) {
-        const previous = this.deviceNames.get(deviceId)
         this.deviceNames.set(deviceId, incoming)
-        // First time this device got a real name. If speech already opened a
-        // segment under the placeholder, repair it in place rather than leaving
-        // the opening of the meeting mislabelled.
-        if (previous === undefined) {
-          const renamed = this.diarizationTracker?.renameOpenSegment(
-            UNKNOWN_SPEAKER,
-            incoming,
-            this.sequentialIdManager.getSequentialId(
-              generateStableUserId(incoming, user.profilePicture)
-            )
-          )
-          if (renamed) {
-            console.log(
-              `[SpeakerManager] Roster resolved late — backfilled the open segment to the correct speaker`
-            )
-          }
-        }
+        this.deviceProfilePictures.set(deviceId, user.profilePicture)
       }
       return incoming
     }
@@ -102,10 +86,36 @@ export class SpeakerManager {
       const lastTimestamp = Date.now()
       const meetingStartTime = MeetingStateMachine.instance.getStartTime()
       if (meetingStartTime) {
-        // Wait for the stream to fully flush before continuing
-        await instance.diarizationTracker.end(lastTimestamp, meetingStartTime)
+        // Hand over the FINAL roster so any segment written while a participant
+        // was still unnamed gets repaired before the artifact is uploaded. The
+        // live path can only ever fix the segment that is still open; by the end
+        // of the meeting we know every name we are ever going to know.
+        await instance.diarizationTracker.end(
+          lastTimestamp,
+          meetingStartTime,
+          (deviceId) => instance.resolveDeviceForBackfill(deviceId)
+        )
       }
     }
+  }
+
+  /** Final name + stable id for a device, or undefined if it never resolved. */
+  private resolveDeviceForBackfill(
+    deviceId: string
+  ): { name: string; userId: number } | undefined {
+    const name = this.deviceNames.get(deviceId)
+    if (!name || name === UNKNOWN_SPEAKER) {
+      return undefined
+    }
+    return {
+      name,
+      userId: this.idForDevice(name, this.deviceProfilePictures.get(deviceId))
+    }
+  }
+
+  /** Sequential id for a resolved participant, matching the live path exactly. */
+  private idForDevice(name: string, profilePicture: string | undefined): number {
+    return this.sequentialIdManager.getSequentialId(generateStableUserId(name, profilePicture))
   }
 
   public async handleSpeakerUpdate(speakers: SpeakerData[]): Promise<void> {
@@ -180,14 +190,15 @@ export class SpeakerManager {
         // artifact (preprod bot 99517dc3: first segment at 10.0s, so everything
         // before it had no segment and rendered as "Unknown" downstream).
         //
-        // Emit the segment immediately under whatever name we have, and let
-        // resolveNetworkName() backfill the real name into the still-open
-        // segment once the roster lands. Speech is never lost; at worst a
-        // segment is briefly labelled "Unknown" in memory before being renamed.
+        // Emit the segment immediately under whatever name we have. deviceId is
+        // what makes the repair possible: at finalize every segment still marked
+        // "Unknown" is matched back to its participant by device and relabelled,
+        // including the ones already flushed to disk.
         return {
           name: stableName,
           id: sequentialId,
           timestamp,
+          deviceId: user.deviceId,
           isSpeaking: user.isSpeaking === true
         }
       })

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -7,7 +7,11 @@ import { startUIBasedObserver } from "../../meeting/meet/ui-observer"
 import { type AudioWarningEvent, ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { GLOBAL } from "../../singleton"
 import { SpeakerManager } from "../../speaker-manager"
-import { checkDiarizationHealth, logHealthStatus } from "../../utils/diarization-monitor"
+import {
+  checkDiarizationHealth,
+  logHealthStatus,
+  networkMinDwellMs
+} from "../../utils/diarization-monitor"
 import { formatError } from "../../utils/Logger"
 import { sleep } from "../../utils/sleep"
 import { SoundLevelMonitor } from "../../utils/sound-level-monitor"
@@ -59,11 +63,6 @@ const STALE_EVENT_THRESHOLD = 10
 // (e.g. ticket 19961784714714: 60s solo test calls, transcript speakers all
 // "Unknown") could mathematically never reach the 10-event threshold.
 const NEVER_PRODUCED_STALE_THRESHOLD = 2
-// Zoom only: grace before the stale detector may retire the network path. Zoom's
-// roster doesn't arrive with the first signaling frames, and the fast threshold was
-// retiring it ~8s after admission, before it could produce anything. The interceptor
-// runs its own self-check at 45s, so the DOM observer stays the backstop.
-const ZOOM_NETWORK_MIN_DWELL_MS = 45_000
 
 export class RecordingState extends BaseState {
   private readonly enteredAt: number = Date.now()
@@ -453,16 +452,16 @@ export class RecordingState extends BaseState {
 
         // Check if we should trigger fallback (Meet, Teams or Zoom, network
         // diarization active).
-        const zoomDwellElapsed = Date.now() - this.enteredAt
+        const minDwellMs = networkMinDwellMs(meetingPlatform)
+        const dwellElapsed = Date.now() - this.enteredAt
         if (
-          meetingPlatform === "zoom" &&
           this.consecutiveStaleCount >= threshold &&
-          zoomDwellElapsed < ZOOM_NETWORK_MIN_DWELL_MS &&
+          dwellElapsed < minDwellMs &&
           !GLOBAL.hasNetworkInterceptionSetupFailed() &&
           !GLOBAL.hasDiarizationFallbackTriggered()
         ) {
           console.log(
-            `[DiarizationHealth] [zoom] ⏳ Holding network path (${Math.round(zoomDwellElapsed / 1000)}s < ${ZOOM_NETWORK_MIN_DWELL_MS / 1000}s) — roster may still be arriving`
+            `[DiarizationHealth] [${meetingPlatform}] ⏳ Holding network path (${Math.round(dwellElapsed / 1000)}s < ${minDwellMs / 1000}s) — speaker signal may still be arriving`
           )
           return
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,11 +40,21 @@ export type StopRecordParams = {
   user_id: number
 }
 
+/** Placeholder every platform's interceptor falls back to before a roster lands. */
+export const UNKNOWN_SPEAKER = "Unknown"
+
 export type SpeakerData = {
   name: string
   id: number // Sequential user ID (0 for UI-based detection, 1+ for network-based)
   timestamp: number
   isSpeaking: boolean
+  /**
+   * Network device this speech belongs to, when known. Carried so a segment
+   * opened before the roster resolved can be repaired against the right
+   * participant later — renaming by name alone would attribute one person's
+   * speech to another.
+   */
+  deviceId?: string
 }
 export type MeetingProvider = output<typeof MeetingPlatformSchema>
 

--- a/src/utils/diarization-monitor.test.ts
+++ b/src/utils/diarization-monitor.test.ts
@@ -1,0 +1,22 @@
+import { networkMinDwellMs } from "./diarization-monitor"
+
+describe("networkMinDwellMs", () => {
+  it("protects the Teams network path long enough for dominant-speaker history to arrive", () => {
+    // Teams has no per-participant audio levels, so the only speaking signal is
+    // the data-channel dominant-speaker history, observed still at dsh=1 fifteen
+    // seconds in. The stale detector can retire the path after ~10s of sound.
+    expect(networkMinDwellMs("teams")).toBeGreaterThanOrEqual(60_000)
+  })
+
+  it("keeps the Zoom dwell aligned with the interceptor's own 45s self-check", () => {
+    expect(networkMinDwellMs("zoom")).toBe(45_000)
+  })
+
+  it("does not delay the Meet fallback: its audio levels arrive immediately", () => {
+    expect(networkMinDwellMs("meet")).toBe(0)
+  })
+
+  it("treats an unknown platform as unprotected rather than throwing", () => {
+    expect(networkMinDwellMs("unknown-platform")).toBe(0)
+  })
+})

--- a/src/utils/diarization-monitor.ts
+++ b/src/utils/diarization-monitor.ts
@@ -26,6 +26,38 @@ export async function checkDiarizationHealth(
   return tracker.hasActiveOrRecentSegment(meetingStartTime, currentTime)
 }
 
+// Grace before the stale detector may retire the network path, per platform.
+//
+// Zoom: the roster doesn't arrive with the first signaling frames, and the fast
+// threshold was retiring it ~8s after admission, before it could produce
+// anything. The interceptor runs its own self-check at 45s.
+//
+// Teams: slower still. Per-participant audio levels are unavailable there (the
+// interceptor's diag reports csrc levels of 0 throughout), so the only speaking
+// signal is the dominant-speaker history on the data channel, which trickles in
+// — observed still at its first entry fifteen seconds in and only at its third
+// by ~90s. Retiring the path at ~10s hands the meeting to a UI observer that
+// delivers speakers through an exposeFunction binding the page cannot always
+// see under CloakBrowser, which is how Teams bots finished with an empty
+// diarization.jsonl and a transcript full of "Speaker 1"/"Speaker 2".
+//
+// Meet has no dwell: its per-participant audio levels arrive immediately, so
+// silence there really does mean the network path is dead.
+const NETWORK_MIN_DWELL_MS: Record<string, number> = {
+  zoom: 45_000,
+  teams: 90_000
+}
+
+/**
+ * How long the network diarization path is protected from the stale detector
+ * after recording starts. 0 means it may be retired as soon as the stale
+ * threshold is reached.
+ * @param platform - Meeting platform ("meet" | "teams" | "zoom")
+ */
+export function networkMinDwellMs(platform: string): number {
+  return NETWORK_MIN_DWELL_MS[platform] ?? 0
+}
+
 /**
  * Log health status with appropriate message.
  * @param status - Health status from diarization tracker


### PR DESCRIPTION
## Summary

Two reasons bots finish with speakers named "Unknown", or with a diarization file that never gets written at all.

**Late rosters lost the opening of the meeting.** Audio beats the roster: the first CSRC often resolves to a device whose name has not been decoded yet, so the opening segments were written under the "Unknown" placeholder. The previous repair only fixed the *open* segment, and only the first time a device got a name — but segments are flushed on every speaker update, so by the time the roster landed the mislabelled ones were already on disk. It also matched by name rather than by device, which could hand speech to the wrong participant. The tracker now buffers every segment with its device id, and at finalize it relabels each one still marked "Unknown" against the participant that device belongs to, then rewrites the file. A device the roster never named stays "Unknown" rather than being guessed at.

**Teams lost its speaker signal before it arrived.** When network diarization has never produced a segment, two stale health events (~10s of sound) retire it and fall back to the UI observer. Zoom has a 45s dwell guard against exactly this; Teams never did, and Teams is the slower of the two — per-participant audio levels are unavailable there, so the only speaking signal is the dominant-speaker history on the data channel, observed still at its first entry fifteen seconds in and only at its third by ~90s. Retiring it at ~10s hands the meeting to a UI observer that delivers speakers through an `exposeFunction` binding the page cannot always see under CloakBrowser, which is how Teams bots finished with an empty `diarization.jsonl`. The Zoom constant is now a per-platform table: Zoom 45s, Teams 90s, Meet 0 (Meet's levels arrive immediately, so silence there really does mean the path is dead).

Applies to `audio_only` as well — that mode changes recording and artifacts, not the diarization paths.

## Testing

- `src/diarization-tracker.test.ts` (new): a segment flushed to disk before the roster resolved gets repaired; matching is by device and never by name, so speech is not handed to the wrong person; a device the roster never named stays "Unknown"; segments that already had a real name are left alone.
- `src/utils/diarization-monitor.test.ts` (new): the Teams dwell is long enough for the dominant-speaker signal, Zoom stays aligned with the interceptor's own 45s self-check, Meet is unprotected, and an unknown platform is unprotected rather than throwing.
- `tsc --noEmit` clean. Full suite: 168 passed. The 17 failures in `meeting-state-detector.test.ts` are pre-existing and fail identically on `v2-improvements`.
- Verified locally against Meet; the Teams path was diagnosed from preprod and production pod logs.

## Release notes

Speaker names now resolve correctly when a meeting's roster arrives after the first person starts talking — previously the opening of those meetings was attributed to "Unknown". Microsoft Teams bots keep their network-based speaker detection long enough for Teams to report who is speaking, instead of falling back early to a UI observer that produced no speaker data at all.
