### PR TITLE
chore: drop deviceId from the speaker console table

### DIFF
--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -249,8 +249,11 @@ export class SpeakerManager {
       // Check if this speaker's name matches the bot name
       const isPotentialBot =
         botName && speaker.name && speaker.name.toLowerCase() === botName.toLowerCase()
+      // deviceId exists to match segments back to participants at finalize; it
+      // is noise in the console table and belongs to no column a reader wants.
+      const { deviceId: _deviceId, ...rest } = speaker
       return {
-        ...speaker,
+        ...rest,
         name: isPotentialBot ? `Speaker ${index + 1} (Bot)` : `Speaker ${index + 1}`
       }
     })


### PR DESCRIPTION
## Summary

The speaker console table gained a `deviceId` column when that field was added to `SpeakerData` to match diarization segments back to participants at finalize. It belongs to the repair path, not to a table a human reads while following a meeting — every row now carries an opaque network identifier next to the masked speaker names. Dropped from the table only; the field itself and the JSON written to the speaker log are unchanged, so the backfill and any post-hoc debugging keep working.

## Testing

- `tsc --noEmit` clean, lint clean.
- Diarization suites pass unchanged (8 tests across `diarization-tracker` and `diarization-monitor`).

## Release notes

None — logging only.
