### PR TITLE
fix(diarization): recover speaker detection when the audio signal is lost at the start of a call

### DIFF
--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -475,6 +475,7 @@ export function browserInterceptionLogic(schema: any[]) {
               if (!frame) continue
 
               frameCount++
+              tracksDeliveringFrames.set(track.id, Date.now())
               // Only log frame count every 1000 frames (much less frequent)
               if (frameCount % 1000 === 0) {
                 console.error(
@@ -599,6 +600,7 @@ export function browserInterceptionLogic(schema: any[]) {
             `[NetworkInterceptor] ❌ Track ${track.id} was not live before the first read: readyState=${track.readyState}, aborted=${abortSignal.aborted}`
           )
           trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
           sendFailureSignal(track, "timeout")
           return false
         }
@@ -656,6 +658,7 @@ export function browserInterceptionLogic(schema: any[]) {
           }
           // Clean up AbortController since processing failed
           trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
           sendFailureSignal(track, "timeout")
           return false
         } finally {
@@ -671,6 +674,7 @@ export function browserInterceptionLogic(schema: any[]) {
           console.error("[NetworkInterceptor] ⚠️ Audio stream ended immediately")
           // Clean up AbortController since processing failed
           trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
           sendFailureSignal(track, "immediate_failure")
           return false
         }
@@ -686,6 +690,7 @@ export function browserInterceptionLogic(schema: any[]) {
         console.error("[NetworkInterceptor] Audio Frame Processing Setup Error:", e)
         // Clean up AbortController since processing failed
         trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
         sendFailureSignal(track, "immediate_failure")
         return false
       }
@@ -712,6 +717,7 @@ export function browserInterceptionLogic(schema: any[]) {
           )
           existingController.abort()
           trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
         }
 
         // Create new AbortController for this track
@@ -723,6 +729,7 @@ export function browserInterceptionLogic(schema: any[]) {
           console.error(`[NetworkInterceptor] 🎬 Track ended: ${track.id}`)
           abortController.abort()
           trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
           activeAudioTracks.delete(track.id)
         }
 
@@ -768,6 +775,7 @@ export function browserInterceptionLogic(schema: any[]) {
             )
             // Clean up AbortController since processing failed
             trackAbortControllers.delete(track.id)
+        tracksDeliveringFrames.delete(track.id)
             sendFailureSignal(track, "immediate_failure")
           })
       } catch (e) {
@@ -788,6 +796,9 @@ export function browserInterceptionLogic(schema: any[]) {
     // Track AbortControllers for audio processing loops (one per track)
     // Allows cancelling background processing when tracks end or are replaced
     const trackAbortControllers = new Map<string, AbortController>()
+    // trackId → timestamp of the last frame actually read from that track.
+    // This is the only proof the audio pipeline is alive; registration is not.
+    const tracksDeliveringFrames = new Map<string, number>()
 
     setupRTCRtpReceiverInterceptor((receiver, contributingSources) => {
       updateContributingSources(receiverManager, receiver, contributingSources)
@@ -856,6 +867,7 @@ export function browserInterceptionLogic(schema: any[]) {
         }
       }
       trackAbortControllers.clear()
+      tracksDeliveringFrames.clear()
 
       // Set flag to prevent further callbacks
       ;(window as any).__networkInterceptorStopped = true
@@ -898,9 +910,22 @@ export function browserInterceptionLogic(schema: any[]) {
     function reportHealthCheck() {
       const audioTrackLayer = (window as any).__audioTrackLayer
       const subscribed = audioTrackLayer && typeof audioTrackLayer.subscribe === "function"
-      // Use trackAbortControllers to track active processing (tracks are added when processing starts)
-      const activeTrackCount = trackAbortControllers.size
+      // A registered track is NOT a working track. trackAbortControllers is
+      // populated before processAudioFrames() even runs, and that function can
+      // then sit waiting for the track to unmute or for a first frame that
+      // never arrives — so counting registrations reported "Audio processing
+      // active (3 tracks)" for a whole meeting that produced an empty
+      // diarization file. Report what actually happened: how many tracks have
+      // delivered at least one frame, and how long ago the last one arrived.
+      const registeredTrackCount = trackAbortControllers.size
+      const activeTrackCount = tracksDeliveringFrames.size
       const audioProcessingActive = activeTrackCount > 0
+      const now = Date.now()
+      let lastFrameAgeMs: number | null = null
+      for (const at of tracksDeliveringFrames.values()) {
+        const age = now - at
+        if (lastFrameAgeMs === null || age < lastFrameAgeMs) lastFrameAgeMs = age
+      }
 
       // Check if we had subscription errors
       let subscriptionError: string | null = null
@@ -913,6 +938,8 @@ export function browserInterceptionLogic(schema: any[]) {
       const health = {
         subscribed,
         activeTrackCount,
+        registeredTrackCount,
+        lastFrameAgeMs,
         audioProcessingActive,
         subscriptionError,
         timestamp: Date.now()

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -567,6 +567,11 @@ export function browserInterceptionLogic(schema: any[]) {
               console.error("[NetworkInterceptor] Reader Error:", readError)
             }
           } finally {
+            // The reader is finished for good here — done, error or abort — so
+            // this track is no longer delivering anything. Reporting it as
+            // healthy afterwards is the same lie the counter was added to stop.
+            releaseTrackHealth(track.id, abortSignal)
+
             // Remove abort listener
             if (abortListener) {
               abortSignal.removeEventListener("abort", abortListener)
@@ -600,7 +605,6 @@ export function browserInterceptionLogic(schema: any[]) {
             `[NetworkInterceptor] ❌ Track ${track.id} was not live before the first read: readyState=${track.readyState}, aborted=${abortSignal.aborted}`
           )
           trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
           sendFailureSignal(track, "timeout")
           return false
         }
@@ -658,7 +662,6 @@ export function browserInterceptionLogic(schema: any[]) {
           }
           // Clean up AbortController since processing failed
           trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
           sendFailureSignal(track, "timeout")
           return false
         } finally {
@@ -674,11 +677,16 @@ export function browserInterceptionLogic(schema: any[]) {
           console.error("[NetworkInterceptor] ⚠️ Audio stream ended immediately")
           // Clean up AbortController since processing failed
           trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
           sendFailureSignal(track, "immediate_failure")
           return false
         }
-        if (firstRead.value) firstRead.value.close()
+        if (firstRead.value) {
+          // The validation read is a delivered frame like any other — count it,
+          // or a track that produced its first frame here still reports zero
+          // until processFrames() happens to read another one.
+          tracksDeliveringFrames.set(track.id, Date.now())
+          firstRead.value.close()
+        }
 
         console.error(`[NetworkInterceptor] 🎬 Audio Frame Processing Started: ${track.id}`)
         // Start background processing (fire-and-forget but with proper cleanup via AbortController)
@@ -690,7 +698,6 @@ export function browserInterceptionLogic(schema: any[]) {
         console.error("[NetworkInterceptor] Audio Frame Processing Setup Error:", e)
         // Clean up AbortController since processing failed
         trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
         sendFailureSignal(track, "immediate_failure")
         return false
       }
@@ -717,7 +724,6 @@ export function browserInterceptionLogic(schema: any[]) {
           )
           existingController.abort()
           trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
         }
 
         // Create new AbortController for this track
@@ -728,8 +734,7 @@ export function browserInterceptionLogic(schema: any[]) {
         track.onended = () => {
           console.error(`[NetworkInterceptor] 🎬 Track ended: ${track.id}`)
           abortController.abort()
-          trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
+          releaseTrackHealth(track.id, abortController.signal)
           activeAudioTracks.delete(track.id)
         }
 
@@ -775,7 +780,6 @@ export function browserInterceptionLogic(schema: any[]) {
             )
             // Clean up AbortController since processing failed
             trackAbortControllers.delete(track.id)
-        tracksDeliveringFrames.delete(track.id)
             sendFailureSignal(track, "immediate_failure")
           })
       } catch (e) {
@@ -799,6 +803,17 @@ export function browserInterceptionLogic(schema: any[]) {
     // trackId → timestamp of the last frame actually read from that track.
     // This is the only proof the audio pipeline is alive; registration is not.
     const tracksDeliveringFrames = new Map<string, number>()
+
+    // Stop counting a track once its reader is finished, whichever way it
+    // finished — done, error or abort. Only the controller that still owns the
+    // id may clear it: a replacement track can register a new controller under
+    // the same id while this one is still unwinding, and clearing then would
+    // erase the live track's health.
+    function releaseTrackHealth(trackId: string, signal: AbortSignal) {
+      if (trackAbortControllers.get(trackId)?.signal !== signal) return
+      trackAbortControllers.delete(trackId)
+      tracksDeliveringFrames.delete(trackId)
+    }
 
     setupRTCRtpReceiverInterceptor((receiver, contributingSources) => {
       updateContributingSources(receiverManager, receiver, contributingSources)

--- a/src/meeting/meet/network-interception/types.ts
+++ b/src/meeting/meet/network-interception/types.ts
@@ -32,7 +32,7 @@ export type NetworkPayload = {
     subscribed: boolean
     /** Tracks that have delivered at least one audio frame. */
     activeTrackCount: number
-    /** Tracks a processor was created for, delivering or not. */
+    /** Tracks registered for monitoring, whether or not a processor exists yet. */
     registeredTrackCount?: number
     /** Age of the most recent frame across all tracks; null if none ever arrived. */
     lastFrameAgeMs?: number | null

--- a/src/meeting/meet/network-interception/types.ts
+++ b/src/meeting/meet/network-interception/types.ts
@@ -30,7 +30,12 @@ export type NetworkPayload = {
   source: "roster" | "audio" | "health_check" | "network_interception_failed"
   health?: {
     subscribed: boolean
+    /** Tracks that have delivered at least one audio frame. */
     activeTrackCount: number
+    /** Tracks a processor was created for, delivering or not. */
+    registeredTrackCount?: number
+    /** Age of the most recent frame across all tracks; null if none ever arrived. */
+    lastFrameAgeMs?: number | null
     audioProcessingActive: boolean
     subscriptionError: string | null
     timestamp: number

--- a/src/meeting/shared/audio-capture.test.ts
+++ b/src/meeting/shared/audio-capture.test.ts
@@ -137,6 +137,36 @@ describe("audio track layer", () => {
     expect(received).toEqual(["track-repeat"])
   })
 
+  it("announces a track once to an already-registered subscriber", () => {
+    // Registering the same track twice would have the diarization open two
+    // readers on one participant.
+    const { window: win, emitTrack } = runLayer()
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    const track = { id: "track-live", kind: "audio", readyState: "live" }
+    emitTrack(track)
+    emitTrack(track)
+
+    expect(received).toEqual(["track-live"])
+  })
+
+  it("does not announce an ended track to an already-registered subscriber", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    emitTrack({ id: "track-dead", kind: "audio", readyState: "ended" })
+
+    expect(received).toEqual([])
+  })
+
   it("ignores video tracks", () => {
     const { window: win, emitTrack } = runLayer()
 

--- a/src/meeting/shared/audio-capture.test.ts
+++ b/src/meeting/shared/audio-capture.test.ts
@@ -7,9 +7,32 @@ import { generateAudioCaptureScript } from "./audio-capture"
  * the whole reason speaker detection can come up empty on a healthy-looking bot.
  */
 
-type FakeTrack = { id: string; kind: string; readyState: string }
+type FakeTrack = {
+  id: string
+  kind: string
+  readyState: string
+  addEventListener: (type: string, handler: () => void) => void
+  end: () => void
+}
 
 type Listener = (event: { track: FakeTrack }) => void
+
+/** A media track the layer can watch for its own end, as the browser gives it. */
+function makeTrack(id: string, kind = "audio", readyState = "live"): FakeTrack {
+  const endHandlers: Array<() => void> = []
+  return {
+    id,
+    kind,
+    readyState,
+    addEventListener(type: string, handler: () => void) {
+      if (type === "ended") endHandlers.push(handler)
+    },
+    end() {
+      this.readyState = "ended"
+      for (const handler of endHandlers) handler()
+    }
+  }
+}
 
 type TrackSubscriber = { onTrack: (track: FakeTrack) => void }
 
@@ -24,6 +47,7 @@ type LayerWindow = {
   AudioContext: new () => unknown
   addEventListener: () => void
   __audioTrackLayer: AudioTrackLayer
+  __meetAudioStop: () => Promise<void>
 }
 
 interface FakePeerConnection {
@@ -86,7 +110,7 @@ describe("audio track layer", () => {
     const { window: win, emitTrack } = runLayer()
 
     // The call sets up audio while the bot is still being admitted.
-    emitTrack({ id: "track-early", kind: "audio", readyState: "live" })
+    emitTrack(makeTrack("track-early"))
 
     const received: string[] = []
     win.__audioTrackLayer.subscribe({
@@ -104,7 +128,7 @@ describe("audio track layer", () => {
       onTrack: (track: FakeTrack) => received.push(track.id)
     })
 
-    emitTrack({ id: "track-late", kind: "audio", readyState: "live" })
+    emitTrack(makeTrack("track-late"))
 
     expect(received).toEqual(["track-late"])
   })
@@ -112,7 +136,7 @@ describe("audio track layer", () => {
   it("does not replay a track that has already ended", () => {
     const { window: win, emitTrack } = runLayer()
 
-    emitTrack({ id: "track-dead", kind: "audio", readyState: "ended" })
+    emitTrack(makeTrack("track-dead", "audio", "ended"))
 
     const received: string[] = []
     win.__audioTrackLayer.subscribe({
@@ -125,7 +149,7 @@ describe("audio track layer", () => {
   it("replays each track once, however many times it was announced", () => {
     const { window: win, emitTrack } = runLayer()
 
-    const track = { id: "track-repeat", kind: "audio", readyState: "live" }
+    const track = makeTrack("track-repeat")
     emitTrack(track)
     emitTrack(track)
 
@@ -147,7 +171,7 @@ describe("audio track layer", () => {
       onTrack: (track: FakeTrack) => received.push(track.id)
     })
 
-    const track = { id: "track-live", kind: "audio", readyState: "live" }
+    const track = makeTrack("track-live")
     emitTrack(track)
     emitTrack(track)
 
@@ -162,15 +186,63 @@ describe("audio track layer", () => {
       onTrack: (track: FakeTrack) => received.push(track.id)
     })
 
-    emitTrack({ id: "track-dead", kind: "audio", readyState: "ended" })
+    emitTrack(makeTrack("track-dead", "audio", "ended"))
 
     expect(received).toEqual([])
+  })
+
+  it("forgets a track once it ends", () => {
+    // The backlog holds live media objects; a call that renegotiates often
+    // would otherwise accumulate every track it ever had.
+    const { window: win, emitTrack } = runLayer()
+
+    const track = makeTrack("track-gone")
+    emitTrack(track)
+    expect(win.__audioTrackLayer.seenTracks).toHaveLength(1)
+
+    track.end()
+
+    expect(win.__audioTrackLayer.seenTracks).toHaveLength(0)
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (t: FakeTrack) => received.push(t.id)
+    })
+
+    expect(received).toEqual([])
+  })
+
+  it("keeps the tracks that are still live when another one ends", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    const leaving = makeTrack("track-leaving")
+    emitTrack(leaving)
+    emitTrack(makeTrack("track-staying"))
+
+    leaving.end()
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    expect(received).toEqual(["track-staying"])
+  })
+
+  it("drops the backlog when audio capture stops", async () => {
+    const { window: win, emitTrack } = runLayer()
+
+    emitTrack(makeTrack("track-open"))
+
+    await win.__meetAudioStop()
+
+    expect(win.__audioTrackLayer.seenTracks).toEqual([])
   })
 
   it("ignores video tracks", () => {
     const { window: win, emitTrack } = runLayer()
 
-    emitTrack({ id: "track-video", kind: "video", readyState: "live" })
+    emitTrack(makeTrack("track-video", "video"))
 
     const received: string[] = []
     win.__audioTrackLayer.subscribe({

--- a/src/meeting/shared/audio-capture.test.ts
+++ b/src/meeting/shared/audio-capture.test.ts
@@ -1,0 +1,152 @@
+import { generateAudioCaptureScript } from "./audio-capture"
+
+/**
+ * The audio track layer is a script string injected into the page, so these
+ * tests run it for real against a minimal fake window: a track that arrives
+ * before the diarization interceptor subscribes must still reach it, which is
+ * the whole reason speaker detection can come up empty on a healthy-looking bot.
+ */
+
+type FakeTrack = { id: string; kind: string; readyState: string }
+
+type Listener = (event: { track: FakeTrack }) => void
+
+type TrackSubscriber = { onTrack: (track: FakeTrack) => void }
+
+type AudioTrackLayer = {
+  subscribers: TrackSubscriber[]
+  seenTracks: Array<{ track: FakeTrack }>
+  subscribe: (callbacks: TrackSubscriber) => void
+}
+
+type LayerWindow = {
+  RTCPeerConnection: new () => FakePeerConnection
+  AudioContext: new () => unknown
+  addEventListener: () => void
+  __audioTrackLayer: AudioTrackLayer
+}
+
+interface FakePeerConnection {
+  addEventListener(type: string, listener: Listener): void
+  getReceivers(): Array<{ track: FakeTrack }>
+  registerReceiver(track: FakeTrack): void
+}
+
+function runLayer(): {
+  window: LayerWindow
+  emitTrack: (track: FakeTrack) => void
+} {
+  const listeners: Listener[] = []
+
+  class FakePeerConnectionImpl implements FakePeerConnection {
+    private readonly receivers: Array<{ track: FakeTrack }> = []
+    addEventListener(type: string, listener: Listener) {
+      if (type === "track") listeners.push(listener)
+    }
+    getReceivers() {
+      return this.receivers
+    }
+    registerReceiver(track: FakeTrack) {
+      this.receivers.push({ track })
+    }
+  }
+
+  const win = {
+    RTCPeerConnection: FakePeerConnectionImpl,
+    AudioContext: class {},
+    addEventListener: () => {}
+  } as unknown as LayerWindow
+
+  const script = generateAudioCaptureScript({
+    provider: "Meet",
+    logPrefix: "[MeetAudio]",
+    stopFunctionName: "__meetAudioStop",
+    enablePeriodicScanning: false
+  })
+
+  // The script is written against globals; give it a window and a console.
+  new Function("window", "console", script)(win, {
+    log: () => {},
+    error: () => {}
+  })
+
+  const pc = new win.RTCPeerConnection()
+
+  return {
+    window: win,
+    emitTrack: (track: FakeTrack) => {
+      pc.registerReceiver(track)
+      for (const listener of listeners) listener({ track })
+    }
+  }
+}
+
+describe("audio track layer", () => {
+  it("delivers a track that arrived before the subscriber did", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    // The call sets up audio while the bot is still being admitted.
+    emitTrack({ id: "track-early", kind: "audio", readyState: "live" })
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    expect(received).toEqual(["track-early"])
+  })
+
+  it("still delivers tracks that arrive after subscribing", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    emitTrack({ id: "track-late", kind: "audio", readyState: "live" })
+
+    expect(received).toEqual(["track-late"])
+  })
+
+  it("does not replay a track that has already ended", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    emitTrack({ id: "track-dead", kind: "audio", readyState: "ended" })
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    expect(received).toEqual([])
+  })
+
+  it("replays each track once, however many times it was announced", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    const track = { id: "track-repeat", kind: "audio", readyState: "live" }
+    emitTrack(track)
+    emitTrack(track)
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (t: FakeTrack) => received.push(t.id)
+    })
+
+    expect(received).toEqual(["track-repeat"])
+  })
+
+  it("ignores video tracks", () => {
+    const { window: win, emitTrack } = runLayer()
+
+    emitTrack({ id: "track-video", kind: "video", readyState: "live" })
+
+    const received: string[] = []
+    win.__audioTrackLayer.subscribe({
+      onTrack: (track: FakeTrack) => received.push(track.id)
+    })
+
+    expect(received).toEqual([])
+  })
+})

--- a/src/meeting/shared/audio-capture.ts
+++ b/src/meeting/shared/audio-capture.ts
@@ -42,7 +42,7 @@ const TEAMS_CONFIG: AudioCaptureConfig = {
  * Creates __audioTrackLayer and intercepts RTCPeerConnection to detect audio tracks.
  * Track subscribers (e.g. network diarization) are notified via __audioTrackLayer.subscribe().
  */
-function generateAudioCaptureScript(config: AudioCaptureConfig): string {
+export function generateAudioCaptureScript(config: AudioCaptureConfig): string {
   const { logPrefix, stopFunctionName, enablePeriodicScanning } = config
 
   return `
@@ -56,9 +56,27 @@ function generateAudioCaptureScript(config: AudioCaptureConfig): string {
 
                     window.__audioTrackLayer = {
                         subscribers: [],
+                        // Tracks seen before anyone subscribed. This layer is installed
+                        // before navigation, while the diarization interceptor only
+                        // subscribes once the bot is admitted — so every track the call
+                        // set up in between used to be delivered to nobody and was never
+                        // mentioned again. A subscriber that arrives late gets them now.
+                        seenTracks: [],
                         subscribe: (callbacks) => {
                             window.__audioTrackLayer.subscribers.push(callbacks)
                             console.log("${logPrefix} Track subscriber registered")
+                            const backlog = window.__audioTrackLayer.seenTracks || []
+                            if (backlog.length && callbacks && typeof callbacks.onTrack === "function") {
+                                console.log("${logPrefix} Replaying " + backlog.length + " already-detected track(s) to new subscriber")
+                                backlog.forEach(entry => {
+                                    if (entry.track.readyState === "ended") return
+                                    try {
+                                        callbacks.onTrack(entry.track, entry.receiver, entry.pc)
+                                    } catch (e) {
+                                        console.error("${logPrefix} Error replaying track to subscriber:", e)
+                                    }
+                                })
+                            }
                         },
                         audioCtx: audioCtx
                     }
@@ -92,6 +110,11 @@ function generateAudioCaptureScript(config: AudioCaptureConfig): string {
 
                 // Notify all subscribers when a track is detected
                 function notifyTrackSubscribers(track, receiver, pc) {
+                    // Remember it for subscribers that are not here yet.
+                    const seen = window.__audioTrackLayer.seenTracks || (window.__audioTrackLayer.seenTracks = [])
+                    if (!seen.some(entry => entry.track.id === track.id)) {
+                        seen.push({ track: track, receiver: receiver, pc: pc })
+                    }
                     trackSubscribers.forEach(listener => {
                         try {
                             if (listener && typeof listener.onTrack === "function") {

--- a/src/meeting/shared/audio-capture.ts
+++ b/src/meeting/shared/audio-capture.ts
@@ -110,11 +110,15 @@ export function generateAudioCaptureScript(config: AudioCaptureConfig): string {
 
                 // Notify all subscribers when a track is detected
                 function notifyTrackSubscribers(track, receiver, pc) {
-                    // Remember it for subscribers that are not here yet.
+                    // Remember it for subscribers that are not here yet. A track
+                    // that already ended, or one being announced a second time,
+                    // is dropped here rather than passed on: replaying it would
+                    // register the same diarization track twice.
                     const seen = window.__audioTrackLayer.seenTracks || (window.__audioTrackLayer.seenTracks = [])
-                    if (!seen.some(entry => entry.track.id === track.id)) {
-                        seen.push({ track: track, receiver: receiver, pc: pc })
+                    if (track.readyState === "ended" || seen.some(entry => entry.track.id === track.id)) {
+                        return
                     }
+                    seen.push({ track: track, receiver: receiver, pc: pc })
                     trackSubscribers.forEach(listener => {
                         try {
                             if (listener && typeof listener.onTrack === "function") {

--- a/src/meeting/shared/audio-capture.ts
+++ b/src/meeting/shared/audio-capture.ts
@@ -97,6 +97,11 @@ export function generateAudioCaptureScript(config: AudioCaptureConfig): string {
                     if (stopPeriodicScanningFn) {
                         stopPeriodicScanningFn()
                     }
+                    // Nobody will subscribe again, so drop the backlog rather than
+                    // keep tracks, receivers and peer connections reachable.
+                    if (window.__audioTrackLayer) {
+                        window.__audioTrackLayer.seenTracks = []
+                    }
                     console.log("${logPrefix} Audio capture stopped")
                 }
 
@@ -119,6 +124,23 @@ export function generateAudioCaptureScript(config: AudioCaptureConfig): string {
                         return
                     }
                     seen.push({ track: track, receiver: receiver, pc: pc })
+
+                    // The backlog holds live media objects, so an entry lives only
+                    // as long as its track: a call that renegotiates repeatedly
+                    // would otherwise keep every track it ever had reachable and
+                    // make each replay scan longer. Dropping the entry costs no
+                    // deduplication — an ended track is refused above, and ended
+                    // is terminal.
+                    if (typeof track.addEventListener === "function") {
+                        track.addEventListener("ended", () => {
+                            const backlog = window.__audioTrackLayer.seenTracks || []
+                            const index = backlog.findIndex(entry => entry.track === track)
+                            if (index !== -1) {
+                                backlog.splice(index, 1)
+                            }
+                        }, { once: true })
+                    }
+
                     trackSubscribers.forEach(listener => {
                         try {
                             if (listener && typeof listener.onTrack === "function") {

--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -1,0 +1,103 @@
+import type { NetworkUser } from "./meeting/meet/network-interception/types"
+import type { Participant } from "./types"
+
+/**
+ * The global speaker registry is append-only and ends up in the final payload,
+ * so who gets written into it is a decision the network path has to make
+ * correctly the first time. These tests drive the real network update with the
+ * surrounding services stubbed out.
+ */
+
+const registeredSpeakers: string[] = []
+const registeredParticipants: string[] = []
+let params: Record<string, unknown> = {}
+
+// The real registries are append-once and never remove, which is the whole
+// reason the bot has to be kept out of them in the first place.
+function addOnce(registry: string[], name: string) {
+  if (!registry.includes(name)) registry.push(name)
+}
+
+jest.mock("./singleton", () => ({
+  GLOBAL: {
+    get: () => params,
+    addParticipantIfNotExists: (participant: Participant) =>
+      addOnce(registeredParticipants, participant.name),
+    addSpeakerIfNotExists: (participant: Participant) =>
+      addOnce(registeredSpeakers, participant.name)
+  }
+}))
+
+jest.mock("./streaming", () => ({ Streaming: { instance: null } }))
+
+jest.mock("./state-machine/machine", () => ({
+  MeetingStateMachine: {
+    instance: {
+      getStartTime: () => 1785941000000,
+      getContext: () => ({ noSpeakerDetectedTime: null }),
+      updateParticipantState: () => {}
+    }
+  }
+}))
+
+jest.mock("./browser/page-logger", () => ({ enablePrintPageLogs: () => {} }))
+
+jest.mock("./utils/PathManager", () => ({
+  PathManager: { getInstance: () => ({ getSpeakerLogPath: () => "/dev/null" }) }
+}))
+
+jest.mock("./utils/PiiRedactor", () => ({
+  PiiRedactor: { registerSpeaker: () => {}, redact: (input: string) => input }
+}))
+
+import { SpeakerManager } from "./speaker-manager"
+
+function networkUser(name: string, isSpeaking: boolean, deviceId: string): NetworkUser {
+  return { name, fullName: name, isSpeaking, deviceId } as NetworkUser
+}
+
+describe("SpeakerManager network speaker registration", () => {
+  beforeEach(() => {
+    registeredSpeakers.length = 0
+    registeredParticipants.length = 0
+    params = { bot_name: "SPEAKER SEP Test", streaming_input: undefined }
+    // Each test gets its own manager: the singleton carries speaker state.
+    ;(SpeakerManager as unknown as { instance: SpeakerManager | null }).instance = null
+    jest.spyOn(console, "table").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("never registers a recording bot as a speaker", async () => {
+    await SpeakerManager.getInstance().handleNetworkSpeakerUpdate(
+      [networkUser("SPEAKER SEP Test", true, "device-bot"), networkUser("Amr El Shimy", true, "device-1")],
+      1785941000000
+    )
+
+    expect(registeredSpeakers).toEqual(["Amr El Shimy"])
+    // Still a participant: the bot belongs in the roster, just not on the floor.
+    expect(registeredParticipants).toContain("SPEAKER SEP Test")
+  })
+
+  it("registers a bot that streams audio into the meeting", async () => {
+    params = { bot_name: "Voice Agent", streaming_input: "wss://example.test/audio" }
+
+    await SpeakerManager.getInstance().handleNetworkSpeakerUpdate(
+      [networkUser("Voice Agent", true, "device-bot")],
+      1785941000000
+    )
+
+    expect(registeredSpeakers).toEqual(["Voice Agent"])
+  })
+
+  it("registers humans who share nothing with the bot name", async () => {
+    await SpeakerManager.getInstance().handleNetworkSpeakerUpdate(
+      [networkUser("Johnny", true, "device-2"), networkUser("Silent Sam", false, "device-3")],
+      1785941000000
+    )
+
+    expect(registeredSpeakers).toEqual(["Johnny"])
+  })
+})

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -9,7 +9,7 @@ import { Streaming } from "./streaming"
 import { type Participant, type SpeakerData, UNKNOWN_SPEAKER } from "./types"
 import { PathManager } from "./utils/PathManager"
 import { PiiRedactor } from "./utils/PiiRedactor"
-import { silenceBotSpeaker } from "./utils/speaker-attribution"
+import { isBotName, silenceBotSpeaker } from "./utils/speaker-attribution"
 import { createSequentialIdManager, generateStableUserId } from "./utils/speaker-id"
 
 
@@ -121,9 +121,11 @@ export class SpeakerManager {
 
   public async handleSpeakerUpdate(observed: SpeakerData[]): Promise<void> {
     try {
-      // The bot stays in the roster but can never hold the floor — see
-      // silenceBotSpeaker for what happens to a meeting when it does.
-      const speakers = silenceBotSpeaker(observed, GLOBAL.get().bot_name)
+      // A recording bot stays in the roster but can never hold the floor — see
+      // silenceBotSpeaker for what happens to a meeting when it does. A bot that
+      // streams audio in does speak, and keeps its turns.
+      const params = GLOBAL.get()
+      const speakers = silenceBotSpeaker(observed, params.bot_name, Boolean(params.streaming_input))
 
       // Update singleton with participants and speakers
       this.updateSingletonParticipants(speakers)
@@ -161,6 +163,10 @@ export class SpeakerManager {
     timestamp: number
   ): Promise<void> {
     try {
+      const params = GLOBAL.get()
+      const botName = params.bot_name
+      const botCanSpeak = Boolean(params.streaming_input)
+
       // Convert network users to SpeakerData format
       const speakers: SpeakerData[] = networkUsers.map((user) => {
         // Use fullName as stable identifier, fallback to name (displayName)
@@ -181,8 +187,16 @@ export class SpeakerManager {
         // Add all participants (whether speaking or not)
         GLOBAL.addParticipantIfNotExists(participant)
 
+        // A recording bot is never a speaker, and that has to be decided here
+        // rather than downstream: the global speaker registry is append-only, so
+        // a bot added once stays in the final payload no matter what the
+        // diarization path does with it afterwards. A bot streaming audio in is
+        // a real speaker and passes through untouched.
+        const isSpeaking =
+          user.isSpeaking === true && (botCanSpeak || !isBotName(stableName, botName))
+
         // Add speakers who are currently speaking
-        if (user.isSpeaking === true) {
+        if (isSpeaking) {
           GLOBAL.addSpeakerIfNotExists(participant)
         }
 
@@ -204,7 +218,7 @@ export class SpeakerManager {
           id: sequentialId,
           timestamp,
           deviceId: user.deviceId,
-          isSpeaking: user.isSpeaking === true
+          isSpeaking
         }
       })
 

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -9,6 +9,7 @@ import { Streaming } from "./streaming"
 import { type Participant, type SpeakerData, UNKNOWN_SPEAKER } from "./types"
 import { PathManager } from "./utils/PathManager"
 import { PiiRedactor } from "./utils/PiiRedactor"
+import { silenceBotSpeaker } from "./utils/speaker-attribution"
 import { createSequentialIdManager, generateStableUserId } from "./utils/speaker-id"
 
 
@@ -118,8 +119,12 @@ export class SpeakerManager {
     return this.sequentialIdManager.getSequentialId(generateStableUserId(name, profilePicture))
   }
 
-  public async handleSpeakerUpdate(speakers: SpeakerData[]): Promise<void> {
+  public async handleSpeakerUpdate(observed: SpeakerData[]): Promise<void> {
     try {
+      // The bot stays in the roster but can never hold the floor — see
+      // silenceBotSpeaker for what happens to a meeting when it does.
+      const speakers = silenceBotSpeaker(observed, GLOBAL.get().bot_name)
+
       // Update singleton with participants and speakers
       this.updateSingletonParticipants(speakers)
 

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -324,8 +324,14 @@ export class InCallState extends BaseState {
 
           // Handle health check reports
           if (payload.source === "health_check" && payload.health) {
-            const { subscribed, activeTrackCount, audioProcessingActive, subscriptionError } =
-              payload.health
+            const {
+              subscribed,
+              activeTrackCount,
+              registeredTrackCount,
+              lastFrameAgeMs,
+              audioProcessingActive,
+              subscriptionError
+            } = payload.health
 
             if (subscriptionError) {
               console.warn(`[NetworkInterceptor] ⚠️ Health Check: ${subscriptionError}`)
@@ -335,19 +341,26 @@ export class InCallState extends BaseState {
               console.warn(
                 "[NetworkInterceptor] ⚠️ Health Check: Not subscribed to audio track layer"
               )
+            } else if (activeTrackCount === 0 && (registeredTrackCount ?? 0) > 0) {
+              // Registered but silent: the processors exist and are reading, but
+              // not one frame has come out of them. This is the state that used
+              // to be reported as healthy.
+              console.warn(
+                `[NetworkInterceptor] ⚠️ Health Check: ${registeredTrackCount} track(s) registered but none delivering audio frames`
+              )
             } else if (activeTrackCount === 0) {
               console.log(
-                `[NetworkInterceptor] ℹ️ Health Check: Subscribed but no audio tracks detected yet (${activeTrackCount} tracks)`
+                "[NetworkInterceptor] ℹ️ Health Check: Subscribed but no audio tracks detected yet (0 tracks)"
               )
             } else {
               console.log(
-                `[NetworkInterceptor] ✅ Health Check: Audio processing active (${activeTrackCount} track(s) being monitored)`
+                `[NetworkInterceptor] ✅ Health Check: Audio processing active (${activeTrackCount} track(s) delivering frames)`
               )
             }
 
             // Log detailed health status at info level
             console.log(
-              `[NetworkInterceptor] Health Status: subscribed=${subscribed}, tracks=${activeTrackCount}, processing=${audioProcessingActive}`
+              `[NetworkInterceptor] Health Status: subscribed=${subscribed}, delivering=${activeTrackCount}, registered=${registeredTrackCount ?? "n/a"}, lastFrameAgeMs=${lastFrameAgeMs ?? "never"}, processing=${audioProcessingActive}`
             )
 
             return // Don't process as speaker update

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -342,9 +342,10 @@ export class InCallState extends BaseState {
                 "[NetworkInterceptor] ⚠️ Health Check: Not subscribed to audio track layer"
               )
             } else if (activeTrackCount === 0 && (registeredTrackCount ?? 0) > 0) {
-              // Registered but silent: the processors exist and are reading, but
-              // not one frame has come out of them. This is the state that used
-              // to be reported as healthy.
+              // Registered but silent: tracks are registered for monitoring and
+              // not one frame has come out of them. Whether a processor exists
+              // yet is unknown from here — a muted track waits before one is
+              // created. This is the state that used to be reported as healthy.
               console.warn(
                 `[NetworkInterceptor] ⚠️ Health Check: ${registeredTrackCount} track(s) registered but none delivering audio frames`
               )

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -280,6 +280,19 @@ export class RecordingState extends BaseState {
           )
         }
 
+        // Speaker detection is judged during grace too. The health check below
+        // used to live only past this early return, so with the default 300s
+        // grace period nothing evaluated diarization for the first five minutes
+        // — and a meeting shorter than the grace period was never evaluated at
+        // all. A Meet bot could run its whole call with a dead speaker signal,
+        // never fall back to the UI observer, and finish with an empty
+        // diarization file, which is exactly what the grace period is meant to
+        // protect against: giving up on a meeting before it gets going.
+        const soundLevel = SoundLevelMonitor.peekInstance()?.getCurrentSoundLevel() ?? 0
+        if (soundLevel > SOUND_LEVEL_ACTIVITY_THRESHOLD) {
+          await this.checkDiarizationHealthThrottled(now)
+        }
+
         this.lastSoundActivity = now
         return { shouldEnd: false }
       }
@@ -342,11 +355,7 @@ export class RecordingState extends BaseState {
         // Reset the silence timer (this is the critical timer for automatic leave)
         this.lastSoundActivity = now
 
-        // Check diarization health (throttled to every 5 seconds)
-        if (now - this.lastDiarizationHealthCheckTime >= 5000) {
-          this.lastDiarizationHealthCheckTime = now
-          await this.checkDiarizationHealth(now)
-        }
+        await this.checkDiarizationHealthThrottled(now)
       }
 
       // Check if we're still in the noone_joined_period
@@ -419,6 +428,13 @@ export class RecordingState extends BaseState {
       // For other errors, don't assume bot was removed - just retry next iteration
       return { shouldEnd: false }
     }
+  }
+
+  /** Diarization health check, at most once every 5s. */
+  private async checkDiarizationHealthThrottled(now: number): Promise<void> {
+    if (now - this.lastDiarizationHealthCheckTime < 5000) return
+    this.lastDiarizationHealthCheckTime = now
+    await this.checkDiarizationHealth(now)
   }
 
   /**

--- a/src/utils/speaker-attribution.test.ts
+++ b/src/utils/speaker-attribution.test.ts
@@ -14,20 +14,29 @@ describe("silenceBotSpeaker", () => {
     // speaker again for the rest of the meeting.
     const result = silenceBotSpeaker(
       [speaker("SPEAKER SEP Test", true), speaker("Amr El Shimy", true)],
-      "SPEAKER SEP Test"
+      "SPEAKER SEP Test",
+      false
     )
 
     expect(result.map((s) => s.isSpeaking)).toEqual([false, true])
   })
 
   it("keeps the bot in the roster rather than dropping it", () => {
-    const result = silenceBotSpeaker([speaker("Notetaker", true), speaker("Johnny", false)], "Notetaker")
+    const result = silenceBotSpeaker(
+      [speaker("Notetaker", true), speaker("Johnny", false)],
+      "Notetaker",
+      false
+    )
 
     expect(result.map((s) => s.name)).toEqual(["Notetaker", "Johnny"])
   })
 
   it("matches the bot regardless of case and surrounding whitespace", () => {
-    const result = silenceBotSpeaker([speaker("  MeetingBaas Bot ", true)], "meetingbaas bot")
+    const result = silenceBotSpeaker(
+      [speaker("  MeetingBaas Bot ", true)],
+      "meetingbaas bot",
+      false
+    )
 
     expect(result[0].isSpeaking).toBe(false)
   })
@@ -35,18 +44,30 @@ describe("silenceBotSpeaker", () => {
   it("leaves every human speaker untouched", () => {
     const humans = [speaker("Amr El Shimy", true), speaker("Johnny", true)]
 
-    expect(silenceBotSpeaker(humans, "SPEAKER SEP Test")).toEqual(humans)
+    expect(silenceBotSpeaker(humans, "SPEAKER SEP Test", false)).toEqual(humans)
   })
 
   it("returns the input untouched when the bot name is unknown", () => {
     const speakers = [speaker("Amr El Shimy", true)]
 
-    expect(silenceBotSpeaker(speakers, undefined)).toBe(speakers)
-    expect(silenceBotSpeaker(speakers, "   ")).toBe(speakers)
+    expect(silenceBotSpeaker(speakers, undefined, false)).toBe(speakers)
+    expect(silenceBotSpeaker(speakers, "   ", false)).toBe(speakers)
+  })
+
+  it("leaves a bot that streams audio into the meeting speaking", () => {
+    // A voice agent holds the floor for real: silencing it would delete its own
+    // half of the conversation from the transcript.
+    const result = silenceBotSpeaker(
+      [speaker("Voice Agent", true), speaker("Amr El Shimy", false)],
+      "Voice Agent",
+      true
+    )
+
+    expect(result.map((s) => s.isSpeaking)).toEqual([true, false])
   })
 
   it("does not resurrect a bot that was already silent", () => {
-    const result = silenceBotSpeaker([speaker("Bot", false)], "Bot")
+    const result = silenceBotSpeaker([speaker("Bot", false)], "Bot", false)
 
     expect(result[0].isSpeaking).toBe(false)
   })

--- a/src/utils/speaker-attribution.test.ts
+++ b/src/utils/speaker-attribution.test.ts
@@ -1,0 +1,53 @@
+import type { SpeakerData } from "../types"
+import { silenceBotSpeaker } from "./speaker-attribution"
+
+const at = 1785941000000
+
+function speaker(name: string, isSpeaking: boolean): SpeakerData {
+  return { name, id: 0, timestamp: at, isSpeaking }
+}
+
+describe("silenceBotSpeaker", () => {
+  it("never lets the bot hold the floor", () => {
+    // The production failure: the bot's own row read as speaking on every
+    // callback, so the diarization opened one segment for it and never changed
+    // speaker again for the rest of the meeting.
+    const result = silenceBotSpeaker(
+      [speaker("SPEAKER SEP Test", true), speaker("Amr El Shimy", true)],
+      "SPEAKER SEP Test"
+    )
+
+    expect(result.map((s) => s.isSpeaking)).toEqual([false, true])
+  })
+
+  it("keeps the bot in the roster rather than dropping it", () => {
+    const result = silenceBotSpeaker([speaker("Notetaker", true), speaker("Johnny", false)], "Notetaker")
+
+    expect(result.map((s) => s.name)).toEqual(["Notetaker", "Johnny"])
+  })
+
+  it("matches the bot regardless of case and surrounding whitespace", () => {
+    const result = silenceBotSpeaker([speaker("  MeetingBaas Bot ", true)], "meetingbaas bot")
+
+    expect(result[0].isSpeaking).toBe(false)
+  })
+
+  it("leaves every human speaker untouched", () => {
+    const humans = [speaker("Amr El Shimy", true), speaker("Johnny", true)]
+
+    expect(silenceBotSpeaker(humans, "SPEAKER SEP Test")).toEqual(humans)
+  })
+
+  it("returns the input untouched when the bot name is unknown", () => {
+    const speakers = [speaker("Amr El Shimy", true)]
+
+    expect(silenceBotSpeaker(speakers, undefined)).toBe(speakers)
+    expect(silenceBotSpeaker(speakers, "   ")).toBe(speakers)
+  })
+
+  it("does not resurrect a bot that was already silent", () => {
+    const result = silenceBotSpeaker([speaker("Bot", false)], "Bot")
+
+    expect(result[0].isSpeaking).toBe(false)
+  })
+})

--- a/src/utils/speaker-attribution.ts
+++ b/src/utils/speaker-attribution.ts
@@ -1,0 +1,33 @@
+import type { SpeakerData } from "../types"
+
+/**
+ * The bot is a participant, never a speaker.
+ *
+ * Its own row in the meeting UI can read as permanently talking: a production
+ * Meet bot ran a whole 14-minute call with its own row flagged speaking on every
+ * single observer callback. The diarization opened one segment for the bot at
+ * the first callback and never saw a speaker change again, so the meeting
+ * finished with exactly one segment carrying the bot's name — and downstream
+ * that is either a transcript in the bot's name or, when the provider disagrees,
+ * anonymous "Speaker N" labels.
+ *
+ * The bot's microphone is deactivated before it joins, so a speaking reading for
+ * it is always a UI artifact rather than audio.
+ *
+ * Matching is by name because that is all the UI observer knows about identity.
+ * A human who happens to share the bot's name is silenced too; that costs one
+ * participant's attribution, where the bug it prevents costs the whole meeting.
+ *
+ * @param speakers - Speaker states as observed
+ * @param botName - The bot's display name in this meeting
+ */
+export function silenceBotSpeaker(speakers: SpeakerData[], botName: string | undefined): SpeakerData[] {
+  const normalizedBotName = botName?.trim().toLowerCase()
+  if (!normalizedBotName) return speakers
+
+  return speakers.map((speaker) =>
+    speaker.isSpeaking && speaker.name?.trim().toLowerCase() === normalizedBotName
+      ? { ...speaker, isSpeaking: false }
+      : speaker
+  )
+}

--- a/src/utils/speaker-attribution.ts
+++ b/src/utils/speaker-attribution.ts
@@ -1,7 +1,7 @@
 import type { SpeakerData } from "../types"
 
 /**
- * The bot is a participant, never a speaker.
+ * A recording bot is a participant, never a speaker.
  *
  * Its own row in the meeting UI can read as permanently talking: a production
  * Meet bot ran a whole 14-minute call with its own row flagged speaking on every
@@ -11,8 +11,11 @@ import type { SpeakerData } from "../types"
  * that is either a transcript in the bot's name or, when the provider disagrees,
  * anonymous "Speaker N" labels.
  *
- * The bot's microphone is deactivated before it joins, so a speaking reading for
- * it is always a UI artifact rather than audio.
+ * A recording bot's microphone is deactivated before it joins, so a speaking
+ * reading for it is always a UI artifact rather than audio. That is exactly what
+ * botCanSpeak decides: a bot streaming audio into the meeting genuinely holds
+ * the floor, and silencing it would delete the agent's own turns from the
+ * transcript — the half of the conversation those bots exist to record.
  *
  * Matching is by name because that is all the UI observer knows about identity.
  * A human who happens to share the bot's name is silenced too; that costs one
@@ -20,14 +23,36 @@ import type { SpeakerData } from "../types"
  *
  * @param speakers - Speaker states as observed
  * @param botName - The bot's display name in this meeting
+ * @param botCanSpeak - Whether this bot streams audio into the meeting
  */
-export function silenceBotSpeaker(speakers: SpeakerData[], botName: string | undefined): SpeakerData[] {
-  const normalizedBotName = botName?.trim().toLowerCase()
-  if (!normalizedBotName) return speakers
+export function silenceBotSpeaker(
+  speakers: SpeakerData[],
+  botName: string | undefined,
+  botCanSpeak: boolean
+): SpeakerData[] {
+  if (botCanSpeak || !botName?.trim()) return speakers
 
   return speakers.map((speaker) =>
-    speaker.isSpeaking && speaker.name?.trim().toLowerCase() === normalizedBotName
+    speaker.isSpeaking && isBotName(speaker.name, botName)
       ? { ...speaker, isSpeaking: false }
       : speaker
   )
+}
+
+/**
+ * Whether an observed participant is the bot itself.
+ *
+ * Callers that register speakers somewhere silenceBotSpeaker cannot reach —
+ * the global speaker registry is append-only — must consult this first, or the
+ * bot lands in the final payload as a speaker and no later pass can take it
+ * back out.
+ *
+ * @param name - Observed participant name
+ * @param botName - The bot's display name in this meeting
+ */
+export function isBotName(name: string | undefined, botName: string | undefined): boolean {
+  const normalizedBotName = botName?.trim().toLowerCase()
+  if (!normalizedBotName) return false
+
+  return name?.trim().toLowerCase() === normalizedBotName
 }


### PR DESCRIPTION
## Summary

A preprod Meet bot in `audio_only` finished a 2.5 minute call with an empty `diarization.jsonl` and every speaker table row reading `isSpeaking: false`, while its own logs claimed the audio pipeline was healthy. A production Meet `audio_only` bot from a customer report failed differently: its fallback fired, and then the whole meeting was attributed to the bot itself. Four separate defects are involved, none of them specific to `audio_only` or to Meet — the mode audit below explains why these runs are simply where they became visible.

**1. The grace period blindfolded speaker detection.** `checkEndConditions` returns early while the grace period is active, and the diarization health check lived *after* that return. With the default 300s grace, nothing evaluated the speaker signal for the first five minutes of any meeting — and a meeting shorter than the grace period was never evaluated at all. The bot ran its entire call with a dead speaker signal, never fell back to the UI observer, and wrote nothing: the pod log contains not a single `[DiarizationHealth]` line. The check now also runs inside the grace branch, throttled the same way, so a dead network path is retired within ~10s of sound whether or not the meeting is young.

**2. The health check reported registrations, not audio.** `activeTrackCount` was `trackAbortControllers.size`, and a track is registered there *before* `processAudioFrames()` runs — which can then sit waiting for the track to unmute or for a first frame that never arrives. So the log said "✅ Audio processing active (3 track(s) being monitored)" eleven times across a meeting that produced zero segments. The count is now the number of tracks that have actually delivered a frame; registrations and the age of the most recent frame are reported alongside, and "registered but nothing delivering" logs as a warning instead of a tick.

**3. Audio tracks that arrived before the interceptor subscribed were dropped.** The shared audio track layer is injected before navigation, but the diarization interceptor only subscribes once the bot is admitted — in this run, 37 seconds later. `subscribe()` had no backlog: any track the call announced in that window went to no one and was never mentioned again. The layer now remembers detected tracks and replays them to late subscribers, skipping ended tracks and never replaying the same track twice.

**4. The bot held the floor for the entire meeting.** A production Meet `audio_only` bot fell back to the UI observer as designed — and then every single observer callback for the next fourteen minutes reported the bot's own row as speaking. The speaker manager keeps the current speaker while it is still talking, so the diarization opened one segment for the bot at the first callback and never saw a speaker change again: one segment, the bot's name, the whole call. Downstream that is either a transcript attributed to the bot or, when the provider disagrees, anonymous "Speaker N" labels. The bot's microphone is deactivated before it joins, so a speaking reading for it is a UI artifact, never audio. The bot now stays in the roster but can never hold the floor.

Together: 3 removes a way to lose the signal, 2 makes the loss visible instead of green, 1 guarantees recovery via the UI observer when it happens anyway, and 4 makes that recovery produce real speakers.

## Mode and platform audit

Checked every `recording_mode` gate that touches speaker detection, across Meet, Teams and Zoom:

- `meet.ts` skips the layout change in `audio_only` — cosmetic, the network path does not depend on it.
- `meet/ui-observer.ts` pre-opens the People panel except in `gallery_view`, but the Meet observer opens the panel itself, so the fallback is intact in every mode.
- `meet/speakersObserver.ts` picks a different mutation root for `gallery_view`; `teams.ts` and `meet/htmlCleaner.ts` gate panel handling the same way. None of these affect network diarization.
- Zoom has no `recording_mode` gates in its speaker path at all.

So no mode disables speaker separation by itself. The defects above are mode- and platform-independent: 1 and 4 affect every bot on every platform, 2 and 3 affect Meet and Teams (both use the shared audio track layer).

## Testing

- `src/meeting/shared/audio-capture.test.ts` (new, 7 tests): the layer script is executed for real against a fake window and peer connection. A track announced before `subscribe()` is delivered on subscribe (fails on the old code), tracks arriving after still work, ended tracks are never announced or replayed, a track announced twice reaches a subscriber once whether that subscriber registered before or after, and video tracks are ignored.
- `src/utils/speaker-attribution.test.ts` (new, 6 tests): the bot never holds the floor (the production case above), it stays in the roster rather than being dropped, matching survives case and whitespace, human speakers are untouched, an unknown bot name is a no-op, and an already-silent bot is not resurrected.
- `tsc --noEmit` clean; lint clean on every changed file.
- Full suite: 188 passed. The 17 failures in `meeting-state-detector.test.ts` are pre-existing and fail identically on `v2-improvements`.
- The grace-period and health-count changes are exercised by the existing diarization suites; both were diagnosed from the pod log of the failing bot rather than reproduced locally, since reproducing needs a live multi-participant call.

## Review

First round, all three CodeRabbit findings applied: the audio track layer now returns before notifying subscribers for ended or duplicate announcements (with regressions for a subscriber registered first), the validation read counts as a delivered frame and track health is released when the reader finishes by any path — guarded so a replacement controller for the same track id is never cleared — and `registeredTrackCount` is documented and logged as registration rather than processor activity.

Second round, both findings applied:

- **The backlog held media objects for the whole call.** An entry now lives exactly as long as its track: the layer watches each track for its own `ended` event and drops the entry, and `stopAudioCapture()` clears what is left. Deduplication loses nothing — an ended track is refused on announcement and `ended` is terminal, so no separate id set is needed. Three regressions cover it: a track forgotten on end, the live tracks around it left alone, and the backlog emptied on teardown.
- **The bot could reach the speaker registry through the network path.** `handleNetworkSpeakerUpdate` registers speakers itself, before the diarization path runs, and that registry is append-only — so `silenceBotSpeaker` could never take the entry back out and the bot stayed in the final payload. The bot is now excluded at registration, which also makes its `isSpeaking` flag consistent with what downstream receives.

**Speaking bots keep their turns.** Suppression is gated on `streaming_input`: a bot streaming audio into the meeting genuinely holds the floor, and silencing it would delete the agent's own half of the conversation from the transcript. Only recording bots — mic deactivated before joining, so a speaking reading is necessarily a UI artifact — are silenced. Covered on both paths: `silenceBotSpeaker` leaves a streaming bot speaking, and `src/speaker-manager.test.ts` (new, 3 tests) drives the real network update and asserts a recording bot never lands in the speaker registry while a streaming bot does.

## Release notes

Fixes meetings that finished with no speaker names, or with every line attributed to the meeting bot instead of the people talking. Most visible on short meetings and audio-only recordings, where the bot could lose its speaker signal at the start of the call and never recover.
