### PR TITLE
fix(diarization): shrink the leading Unknown-speaker window

### DIFF
--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -113,19 +113,22 @@ describe("DiarizationTracker backfill", () => {
 })
 
 describe("DiarizationTracker first-segment telemetry", () => {
-  it("logs the first-segment latency exactly once", () => {
+  it("logs the first-segment latency exactly once", async () => {
     const tracker = freshTracker()
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {})
 
-    tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 12.3), MEETING_START)
-    tracker.updateSpeaker(speech("dev-b", "Johnny", 20), MEETING_START)
+    try {
+      tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 12.3), MEETING_START)
+      tracker.updateSpeaker(speech("dev-b", "Johnny", 20), MEETING_START)
 
-    const latencyLogs = logSpy.mock.calls.filter(([msg]) =>
-      typeof msg === "string" && msg.includes("First speaker segment opened")
-    )
-    expect(latencyLogs).toHaveLength(1)
-    expect(latencyLogs[0][0]).toContain("+12.3s")
-
-    logSpy.mockRestore()
+      const latencyLogs = logSpy.mock.calls.filter(
+        ([msg]) => typeof msg === "string" && msg.includes("First speaker segment opened")
+      )
+      expect(latencyLogs).toHaveLength(1)
+      expect(latencyLogs[0][0]).toContain("+12.3s")
+    } finally {
+      await tracker.end(MEETING_START + 22_000, MEETING_START, () => undefined)
+      logSpy.mockRestore()
+    }
   })
 })

--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -111,3 +111,21 @@ describe("DiarizationTracker backfill", () => {
     expect(segments.map((s) => s.speaker)).toEqual(["Amr El Shimy", "Johnny"])
   })
 })
+
+describe("DiarizationTracker first-segment telemetry", () => {
+  it("logs the first-segment latency exactly once", () => {
+    const tracker = freshTracker()
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {})
+
+    tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 12.3), MEETING_START)
+    tracker.updateSpeaker(speech("dev-b", "Johnny", 20), MEETING_START)
+
+    const latencyLogs = logSpy.mock.calls.filter(([msg]) =>
+      typeof msg === "string" && msg.includes("First speaker segment opened")
+    )
+    expect(latencyLogs).toHaveLength(1)
+    expect(latencyLogs[0][0]).toContain("+12.3s")
+
+    logSpy.mockRestore()
+  })
+})

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -102,6 +102,15 @@ export class DiarizationTracker {
     }
 
     // Start new segment (keep in memory)
+    if (!this.hasTrackedAnySegment) {
+      // Speech recorded before this point has no diarization to name it and
+      // surfaces as a leading "Unknown" run in the transcript, so this latency
+      // is the direct size of that window. Greppable across bot logs to track
+      // the boot gap in production (target: single-digit seconds).
+      console.log(
+        `[DiarizationTracker] First speaker segment opened at +${relativeTime.toFixed(1)}s after meeting start`
+      )
+    }
     this.currentSegment = {
       speaker: speaker.name,
       startTime: relativeTime,

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -101,9 +101,6 @@ export class InCallState extends BaseState {
       this.context.startTime = startTime
       ScreenRecorderManager.getInstance().setMeetingStartTime(startTime)
       console.log(`Meeting start time set to: ${startTime} (${new Date(startTime).toISOString()})`)
-
-      // Start HTML cleanup first to clean the interface
-      await this.startHtmlCleaning()
     } catch (error) {
       console.error(
         "Error in setupBrowserComponents:",
@@ -117,13 +114,32 @@ export class InCallState extends BaseState {
       throw new Error(`Browser component setup failed: ${error as Error}`)
     }
 
-    // Start speakers observation in all cases
-    // Speakers observation is independent of video recording
+    // Start speakers observation BEFORE HTML cleanup: the recording is trimmed to
+    // startTime, so every second spent cleaning before the speaker signal is live
+    // is speech transcribed with no diarization to name it — it surfaces as a
+    // leading "Unknown" speaker run at the start of the transcript. The cleanup
+    // is cosmetic and can wait; the speaker timeline cannot.
     try {
       await this.startSpeakersObservation()
     } catch (error) {
       console.error("Failed to start speakers observation:", formatError(error))
       // Continue even if speakers observation fails
+    }
+
+    // HTML cleanup after the speaker signal is live
+    try {
+      await this.startHtmlCleaning()
+    } catch (error) {
+      console.error(
+        "Error in setupBrowserComponents:",
+        formatError(error, {
+          hasPlaywrightPage: !!this.context.playwrightPage,
+          recordingMode: GLOBAL.get().recording_mode,
+          meetingPlatform: GLOBAL.get().meeting_platform,
+          botName: GLOBAL.get().bot_name
+        })
+      )
+      throw new Error(`Browser component setup failed: ${error as Error}`)
     }
 
     // Start chat observation + entry message (non-critical, non-blocking)

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -288,8 +288,14 @@ export class RecordingState extends BaseState {
         // never fall back to the UI observer, and finish with an empty
         // diarization file, which is exactly what the grace period is meant to
         // protect against: giving up on a meeting before it gets going.
-        const soundLevel = SoundLevelMonitor.peekInstance()?.getCurrentSoundLevel() ?? 0
-        if (soundLevel > SOUND_LEVEL_ACTIVITY_THRESHOLD) {
+        // A dead sound monitor reads 0 forever, which is indistinguishable from
+        // silence — and health checks gated on sound would then never run, so a
+        // dead speaker signal could ride out the whole meeting unnoticed. When
+        // the monitor itself is down, check health anyway: the worst case is an
+        // unnecessary fallback to the UI observer, which still names speakers.
+        const graceMonitor = SoundLevelMonitor.peekInstance()
+        const soundLevel = graceMonitor?.getCurrentSoundLevel() ?? 0
+        if (soundLevel > SOUND_LEVEL_ACTIVITY_THRESHOLD || !graceMonitor?.getIsActive()) {
           await this.checkDiarizationHealthThrottled(now)
         }
 
@@ -355,6 +361,11 @@ export class RecordingState extends BaseState {
         // Reset the silence timer (this is the critical timer for automatic leave)
         this.lastSoundActivity = now
 
+        await this.checkDiarizationHealthThrottled(now)
+      } else if (!monitor?.getIsActive()) {
+        // Same monitor-down escape hatch as the grace-period branch: a dead
+        // monitor reads 0 forever, and health checks gated on sound would
+        // never run again for the rest of the meeting.
         await this.checkDiarizationHealthThrottled(now)
       }
 
@@ -468,10 +479,18 @@ export class RecordingState extends BaseState {
 
         // Check if we should trigger fallback (Meet, Teams or Zoom, network
         // diarization active).
+        //
+        // The dwell hold exists so a slow-but-alive network path is not retired
+        // while its first speaker signal is still arriving. It does not apply
+        // when the path has NEVER produced a segment despite sound activity:
+        // holding a dead source for the full dwell window just converts the
+        // hold into a guaranteed leading-"Unknown" run of the same length
+        // (prod Meet transcripts showed exactly ~30s Unknown heads from this).
         const minDwellMs = networkMinDwellMs(meetingPlatform)
         const dwellElapsed = Date.now() - this.enteredAt
         if (
           this.consecutiveStaleCount >= threshold &&
+          !neverProduced &&
           dwellElapsed < minDwellMs &&
           !GLOBAL.hasNetworkInterceptionSetupFailed() &&
           !GLOBAL.hasDiarizationFallbackTriggered()


### PR DESCRIPTION
## Context

Prod transcripts still open with a leading "Unknown" speaker run (customer-reported, e.g. Aiclos). Audio is trimmed to `startTime`, but the speaker signal goes live seconds later — everything said in between has no diarization segment and surfaces as "Unknown". 30-day prod data: ~29% of Meet meetings still show a leading run; most are a few-second blip, but the tail includes ~30s heads and one bot (`bfdc49a2`) with **no segment until +934s** (451 Unknown utterances).

## Fixes (bot-side only)

1. **Start speaker observation before HTML cleanup** (`in-call-state.ts`): cleanup ran first and its latency added directly to the unnamed window. Cleanup is cosmetic; the speaker timeline is data. Order swapped, error semantics preserved (observation failure still non-fatal, cleanup failure still fatal).

2. **Skip the network-path dwell hold when it has never produced a segment** (`recording-state.ts`): the stale monitor held a dead network path for the full 30s (Meet) / 60s (Teams/Zoom) dwell before falling back to the UI observer — a guaranteed Unknown head of the same length. Prod residuals cluster exactly at ~30s on Meet. A never-produced path is dead, not flapping; fall back on the fast threshold without the hold.

3. **Run diarization health checks when the sound monitor is down** (`recording-state.ts`, both grace and normal branches): checks were gated on `soundLevel > threshold`, and a dead monitor reads 0 forever — so a dead speaker signal was never rescued for the whole meeting (the `bfdc49a2` failure mode). Worst case of checking anyway is an unnecessary fallback to the UI observer, which still names speakers.

4. **Telemetry** (`diarization-tracker.ts`): log `First speaker segment opened at +X.Xs after meeting start` once per meeting — makes the boot gap greppable/trackable in prod (target single-digit seconds).

## Testing

- `tsc --noEmit -p tsconfig.release.json` clean (Node 20).
- `jest src/diarization-tracker.test.ts` — 5/5 incl. new telemetry test.
- Full suite: only pre-existing failure is `src/utils/meeting-state-detector.test.ts` (17 failures, identical on clean `v2-improvements`).

## Complements

api-server PR #362 (`findNearestUISpeaker`) names the residual small gap; this PR shrinks the gap itself and unblocks the long-tail cases #362's long-silence guard correctly refuses to bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)