### PR TITLE
fix(meet): don't false-confirm "in meeting" while in the waiting room

### DIFF
--- a/src/meeting/meet-state-config.ts
+++ b/src/meeting/meet-state-config.ts
@@ -42,9 +42,16 @@ export const MEET_STATE_CONFIG: StateDetectionConfig = {
             'text="waiting to be let in"',
             'text="Instead of waiting to be let in"',
             'text="Please wait until a meeting host brings you into the call"',
+            // Google also renders the lobby with "admits you to the call" wording;
+            // unquoted text= does a case-insensitive substring match so it survives
+            // minor copy changes. Without this the lobby is not recognised as a
+            // waiting room and the bot can false-confirm "in meeting".
+            'text=admits you to the call',
+            'text="Please wait until a meeting host admits you to the call"',
             '[aria-label*="waiting"]',
             '[aria-label*="Please wait until"]',
             '[aria-label*="brings you into"]',
+            '[aria-label*="admits you"]',
         ],
         threshold: 1,
         checkVisibility: false,

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -359,7 +359,12 @@ export class MeetProvider implements MeetingProviderInterface {
                     !leftWaitingRoomAt ||
                     Date.now() - leftWaitingRoomAt >= GRACE_PERIOD_MS
 
-                if (gracePeriodExpired) {
+                // Never confirm "in meeting" while this sample still sees the waiting
+                // room. Otherwise, because leftWaitingRoomAt stays null until we actually
+                // leave, gracePeriodExpired is true from the first iteration and the bot
+                // can confirm against lobby DOM and start recording the waiting screen
+                // (0 media tracks captured).
+                if (!nowInWaitingRoom && gracePeriodExpired) {
                     const inMeeting = await isInMeeting(page)
                     if (inMeeting) {
                         console.log(
@@ -573,7 +578,20 @@ async function isInMeeting(page: Page): Promise<boolean> {
             return false
         }
 
-        // Check for meeting presence indicators FIRST
+        // Waiting room takes precedence — check it FIRST and short-circuit before
+        // sampling the in-meeting indicators. The Google Meet lobby renders the same
+        // call-control DOM (mic / camera / hang-up, the "Call controls" region,
+        // reactions) that satisfies the in-meeting threshold, so a threshold match
+        // alone is NOT proof we are in the meeting. If the lobby is detected we are
+        // still waiting to be admitted, regardless of any indicator count. The
+        // waiting-room patterns are specific lobby texts Google removes on
+        // admission, so they do not linger as "stale" DOM after a genuine join.
+        if (await isInWaitingRoom(page)) {
+            console.log('✗ In waiting room - not in meeting yet')
+            return false
+        }
+
+        // Not in the lobby → now evaluate the in-meeting presence indicators.
         const result = await meetStateDetector.isInMeeting(page)
         const selectorCount =
             MEET_STATE_CONFIG.inMeetingPattern.selectors.length
@@ -582,22 +600,12 @@ async function isInMeeting(page: Page): Promise<boolean> {
             `Meeting presence indicators: ${result.count}/${selectorCount} visible (threshold: ${threshold}, matched: ${result.matched})`,
         )
 
-        // If we have strong meeting indicators (threshold met), we're definitely in the meeting
-        // This overrides any stale waiting room DOM elements that might still be present
+        // Strong meeting indicators AND not in the waiting room → in the meeting.
         if (result.matched) {
             console.log(
                 `✓ Threshold reached: ${result.count} >= ${threshold} - Confirming in meeting`,
             )
             return true
-        }
-
-        // Only if meeting indicators are weak/absent, check if we're in waiting room
-        // This prevents false positives from stale waiting room elements after joining
-        if (await isInWaitingRoom(page)) {
-            console.log(
-                `✗ Threshold not met but in waiting room - Not in meeting yet`,
-            )
-            return false
         }
 
         // Not enough meeting indicators and not in waiting room


### PR DESCRIPTION
## Problem

Customer-reported "bot removed too early" failures where nobody removed the bot (examples: `414f4ad1-6dcf-4e3c-bc16-a6790ff6057f`, `0df99a22-5852-4d8a-bc8d-cd171ebe1c16`). Sequence in prod logs:

1. Bot lands in Meet's host-managed lobby ("Please wait until a meeting host brings you into the call" / "…admits you to the call").
2. The lobby renders the same call-control DOM as the live meeting → in-meeting indicator threshold passes (`Threshold reached: 4 >= 4`) → **false join confirm**, recording starts.
3. ~3s later the state detector correctly matches the lobby text → in-meeting→lobby transition is read as an ejection → `botRemoved`.
4. Recording is empty → surfaced to the customer as `botRemovedTooEarly`.

**Impact (Jul 31–Aug 7, prod):** 17 of 22 `botRemovedTooEarly` failures across 2,696 Meet bots carry this exact signature. The remaining 5 are genuine host removals / alone-timeouts.

## Fix

Reapplies `1cb000dd` (authored Jun 30, never reached `main`) adapted to main's formatting:

- `meet-state-config.ts`: add the "admits you to the call" lobby wording (substring + quoted + aria-label variants) to `waitingRoomPattern`.
- `meet.ts` `isInMeeting()`: check the waiting room FIRST and short-circuit — a threshold match alone is not proof of being in the meeting since the lobby renders call controls. The old "threshold overrides stale waiting-room DOM" rationale no longer holds; lobby texts are removed by Google on admission so they can't linger.
- `meet.ts` join loop: don't attempt in-meeting confirmation while the current sample still sees the waiting room (`!nowInWaitingRoom` gate — `gracePeriodExpired` is true from the first iteration otherwise).

Net effect: an un-admitted bot keeps waiting for admission and ends via the waiting-room timeout, instead of a false `botRemovedTooEarly` with an empty recording.

## Verification

- `tsc --noEmit` error set identical to `origin/main` baseline (only pre-existing dep-resolution noise; both touched files clean).
- Same change previously validated on the v1 port (waiting-room bots correctly hold instead of self-terminating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)