### PR TITLE
feat(storage): upload artifacts to the team's own bucket

### DIFF
--- a/src/config/storage.ts
+++ b/src/config/storage.ts
@@ -1,0 +1,115 @@
+import { S3Client } from "@aws-sdk/client-s3"
+import { GLOBAL } from "../singleton"
+import { envVars } from "./env-vars"
+
+/**
+ * Where this bot writes its artifacts.
+ *
+ * Default (and the case for every team that hasn't asked for it): the platform
+ * buckets from AWS_S3_*_BUCKET, uploaded with the pod's ambient AWS credentials —
+ * exactly the behaviour that existed before "bring your own bucket".
+ *
+ * When api-server dispatched the bot with a `storage_config` — i.e. the team has
+ * its own object storage — every bucket name and the S3 client come from that
+ * config instead, so recordings, audio chunks, screenshots and logs land in the
+ * customer's account and never touch ours.
+ *
+ * Everything here is resolved lazily through GLOBAL rather than captured at import
+ * time: modules like Logger and PathManager are constructed before the meeting
+ * params are parsed, so a module-level constant would freeze in the platform
+ * values and quietly send a customer's recording to our bucket.
+ */
+
+export interface StorageBuckets {
+  artifacts: string
+  audioChunks: string
+  logs: string
+}
+
+/** The dispatched storage config, or null before params are set / when unset. */
+function customStorage() {
+  return GLOBAL.tryGet()?.storage_config ?? null
+}
+
+export function storageBuckets(): StorageBuckets {
+  const custom = customStorage()
+  if (custom) {
+    return {
+      artifacts: custom.artifacts_bucket,
+      audioChunks: custom.audio_chunks_bucket,
+      logs: custom.logs_bucket
+    }
+  }
+  return {
+    artifacts: envVars.AWS_S3_ARTIFACTS_BUCKET,
+    audioChunks: envVars.AWS_S3_AUDIO_CHUNKS_BUCKET,
+    logs: envVars.AWS_S3_LOGS_BUCKET
+  }
+}
+
+/** True when this bot is writing into a customer-owned bucket. */
+export function usingCustomStorage(): boolean {
+  return customStorage() !== null
+}
+
+/**
+ * Whether an artifact whose S3 upload failed may be copied to MeetingBaas EFS for a
+ * reconciliation job to push later.
+ *
+ * True on platform storage — that is the long-standing safety net and the artifact is
+ * going to our bucket anyway. On customer storage it follows the team's
+ * `allow_transient_spill`, which defaults to FALSE: those teams are usually there for
+ * data residency, and this is the one path that puts a full recording (video, audio,
+ * transcripts, chunks) on our volume in our account. When it is false the upload
+ * failure is final and the artifact is reported as UPLOAD_FAILED — a deliberate trade
+ * of durability for residency.
+ */
+export function transientSpillAllowed(): boolean {
+  const custom = customStorage()
+  if (!custom) return true
+  return custom.allow_transient_spill
+}
+
+let cachedClient: S3Client | null = null
+let cachedForCustom: boolean | null = null
+
+/**
+ * The S3 client every upload should use.
+ *
+ * Built once per process. A bot handles exactly one meeting, so the config cannot
+ * change under us; the cache key still tracks whether we're on custom storage so a
+ * client built before params were parsed (e.g. by an early log upload) is not
+ * reused for the customer's bucket afterwards.
+ */
+export function storageS3Client(): S3Client {
+  const custom = customStorage()
+  const isCustom = custom !== null
+
+  if (cachedClient && cachedForCustom === isCustom) {
+    return cachedClient
+  }
+
+  cachedClient?.destroy()
+  cachedClient = custom
+    ? new S3Client({
+        endpoint: custom.endpoint,
+        region: custom.region,
+        forcePathStyle: custom.force_path_style,
+        // More attempts than the SDK default of 3. A customer bucket is off our
+        // network and may be a different provider, so transient failures are likelier
+        // here than against the platform bucket — and when transient spill is off there
+        // is no EFS safety net behind this, so a blip that exhausts the retries loses
+        // the recording outright. Still bounded by the caller's UPLOAD_TIMEOUT_MS wall
+        // clock, so this cannot extend a bot's life.
+        maxAttempts: 6,
+        credentials: {
+          accessKeyId: custom.access_key_id,
+          secretAccessKey: custom.secret_access_key
+        }
+      })
+    : // AWS SDK v3 automatically detects credentials, endpoint (AWS_ENDPOINT_URL)
+      // and region from the environment / pod IAM role.
+      new S3Client()
+  cachedForCustom = isCustom
+  return cachedClient
+}

--- a/src/recording/ScreenRecorder.ts
+++ b/src/recording/ScreenRecorder.ts
@@ -1,10 +1,11 @@
 import { type ChildProcess, exec, execSync, spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
 import * as fs from "node:fs"
-import { promisify } from "node:util"
 import * as path from "node:path"
+import { promisify } from "node:util"
 import type { Page } from "@playwright/test"
 import { envVars } from "../config/env-vars"
+import { storageBuckets } from "../config/storage"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
 import { MeetingStateMachine } from "../state-machine/machine"
@@ -188,14 +189,22 @@ export class ScreenRecorder extends EventEmitter {
       // xrun/click at recording start (especially on new pods where the
       // sink was just created and no audio has flowed yet).
       try {
-        const primeFfmpeg = spawn("ffmpeg", [
-          "-f", "lavfi",
-          "-i", "anullsrc=r=48000:cl=mono",
-          "-t", "0.3",
-          "-f", "pulse",
-          VIRTUAL_SPEAKER,
-          "-y"
-        ], { stdio: "ignore", timeout: 5000 })
+        const primeFfmpeg = spawn(
+          "ffmpeg",
+          [
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=48000:cl=mono",
+            "-t",
+            "0.3",
+            "-f",
+            "pulse",
+            VIRTUAL_SPEAKER,
+            "-y"
+          ],
+          { stdio: "ignore", timeout: 5000 }
+        )
         await new Promise<void>((resolve, reject) => {
           primeFfmpeg.on("close", (code, signal) => {
             if (code === 0 && !signal) return resolve()
@@ -205,7 +214,10 @@ export class ScreenRecorder extends EventEmitter {
         })
       } catch (_e) {
         // best-effort — recording still works even if priming fails
-        console.warn("[ScreenRecorder] audio buffer priming failed — initial capture may have xrun", _e)
+        console.warn(
+          "[ScreenRecorder] audio buffer priming failed — initial capture may have xrun",
+          _e
+        )
       }
 
       const ffmpegArgs = this.buildNativeFFmpegArgs()
@@ -420,7 +432,7 @@ export class ScreenRecorder extends EventEmitter {
       "-video_size",
       `${res.width}x${res.captureHeight}`,
       "-thread_queue_size",
-      "1024",   // 1024 packets — ~34 s at 30 fps, generous without memory bloat
+      "1024", // 1024 packets — ~34 s at 30 fps, generous without memory bloat
       "-framerate",
       "30",
       "-i",
@@ -644,15 +656,15 @@ export class ScreenRecorder extends EventEmitter {
           // Log system resources for diagnostics
           void this.logSystemResources()
 
-            // Emit a critical error event
-            ; (this as EventEmitter).emit("error", {
-              type: "fileWriteError",
-              message: "FFmpeg file write error detected",
-              error: output.trim(),
-              recordingDuration: recordingDurationSeconds,
-              currentFileSize,
-              timestamp: now
-            })
+          // Emit a critical error event
+          ;(this as EventEmitter).emit("error", {
+            type: "fileWriteError",
+            message: "FFmpeg file write error detected",
+            error: output.trim(),
+            recordingDuration: recordingDurationSeconds,
+            currentFileSize,
+            timestamp: now
+          })
         }
         // Check for specific PulseAudio errors that indicate audio input failure
         else if (
@@ -968,11 +980,7 @@ export class ScreenRecorder extends EventEmitter {
           const s3Key = `${botUuid}/${filename}`
           console.log(`📤 Uploading chunk: ${filename} (${stats.size} bytes)`)
 
-          await S3Uploader.getInstance().uploadFile(
-            chunkPath,
-            envVars.AWS_S3_AUDIO_CHUNKS_BUCKET,
-            s3Key
-          )
+          await S3Uploader.getInstance().uploadFile(chunkPath, storageBuckets().audioChunks, s3Key)
           GLOBAL.addAudioChunk({
             s3Key,
             filePath: chunkPath,
@@ -1029,9 +1037,7 @@ export class ScreenRecorder extends EventEmitter {
         const recordingDurationSeconds =
           this.recordingStartTime > 0 ? (Date.now() - this.recordingStartTime) / 1000 : 0
 
-        console.log(
-          `📤 Uploading FLAC audio to artifacts bucket: ${envVars.AWS_S3_ARTIFACTS_BUCKET}`
-        )
+        console.log(`📤 Uploading FLAC audio to artifacts bucket: ${storageBuckets().artifacts}`)
         console.log(
           `📊 Audio file size before upload: ${sizeMB} MB (${sizeBytes} bytes) | Recording duration: ${recordingDurationSeconds.toFixed(1)}s`
         )
@@ -1039,7 +1045,7 @@ export class ScreenRecorder extends EventEmitter {
         const s3Key = `${identifier}/output.flac`
         await S3Uploader.getInstance().uploadFile(
           this.audioOutputPath,
-          envVars.AWS_S3_ARTIFACTS_BUCKET,
+          storageBuckets().artifacts,
           s3Key
         )
         GLOBAL.addArtifactKey({
@@ -1088,12 +1094,12 @@ export class ScreenRecorder extends EventEmitter {
           const sizeMB = (stats.size / (1024 * 1024)).toFixed(2)
           const sizeBytes = stats.size
 
-          console.log(`📤 Uploading MP4 to artifacts bucket: ${envVars.AWS_S3_ARTIFACTS_BUCKET}`)
+          console.log(`📤 Uploading MP4 to artifacts bucket: ${storageBuckets().artifacts}`)
           console.log(`📊 Video file size before upload: ${sizeMB} MB (${sizeBytes} bytes)`)
           const s3Key = `${identifier}/output.mp4`
           await S3Uploader.getInstance().uploadFile(
             this.outputPath,
-            envVars.AWS_S3_ARTIFACTS_BUCKET,
+            storageBuckets().artifacts,
             s3Key
           )
           GLOBAL.addArtifactKey({
@@ -1174,11 +1180,11 @@ export class ScreenRecorder extends EventEmitter {
             errorMessage: `Diarization file is empty: ${diarizationPath}. Size: ${stats.size} bytes`
           })
         } else {
-          console.log(`Uploading diarization file to S3: ${envVars.AWS_S3_ARTIFACTS_BUCKET}`)
+          console.log(`Uploading diarization file to S3: ${storageBuckets().artifacts}`)
           const s3Key = `${identifier}/diarization.jsonl`
           await S3Uploader.getInstance().uploadFile(
             diarizationPath,
-            envVars.AWS_S3_ARTIFACTS_BUCKET,
+            storageBuckets().artifacts,
             s3Key
           )
           GLOBAL.addArtifactKey({
@@ -1354,10 +1360,9 @@ export class ScreenRecorder extends EventEmitter {
 
       // Log file descriptor count if available (best-effort).
       try {
-        const { stdout: fdOut } = await execAsync(
-          `lsof -p ${process.pid} | wc -l`,
-          { timeout: 3000 }
-        )
+        const { stdout: fdOut } = await execAsync(`lsof -p ${process.pid} | wc -l`, {
+          timeout: 3000
+        })
         console.warn(`   📁 File descriptors: ${fdOut.trim()}`)
       } catch (_e) {
         // lsof not available
@@ -1463,19 +1468,22 @@ export class ScreenRecorder extends EventEmitter {
     // 1. Calculate A/V stream offset using the exact timestamp of the sync signal.
     //    syncSignalTimestamp is set in startRecording() just before generateSyncSignal fires,
     //    so this is exact — no guesswork about when it happened.
-    const expectedSyncSec = this.syncSignalTimestamp > 0
-      ? (this.syncSignalTimestamp - this.recordingStartTime) / 1000
-      : FLASH_SCREEN_SLEEP_TIME / 1000 // fallback: should never happen in normal operation
+    const expectedSyncSec =
+      this.syncSignalTimestamp > 0
+        ? (this.syncSignalTimestamp - this.recordingStartTime) / 1000
+        : FLASH_SCREEN_SLEEP_TIME / 1000 // fallback: should never happen in normal operation
     // Per-signal anchors: both signals ride the page.evaluate queue and can
     // fire seconds after syncSignalTimestamp under load. Anchoring each
     // detection window on its own real emission time — and subtracting the
     // emission gap in the offset math — isolates pure capture-start skew.
-    const expectedAudioSyncSec = this.audioBeepWallMs > 0
-      ? (this.audioBeepWallMs - this.recordingStartTime) / 1000
-      : expectedSyncSec
-    const expectedVideoSyncSec = this.videoFlashWallMs > 0
-      ? (this.videoFlashWallMs - this.recordingStartTime) / 1000
-      : expectedSyncSec
+    const expectedAudioSyncSec =
+      this.audioBeepWallMs > 0
+        ? (this.audioBeepWallMs - this.recordingStartTime) / 1000
+        : expectedSyncSec
+    const expectedVideoSyncSec =
+      this.videoFlashWallMs > 0
+        ? (this.videoFlashWallMs - this.recordingStartTime) / 1000
+        : expectedSyncSec
     console.log(
       `🎯 Sync signal fired at ${expectedSyncSec.toFixed(3)}s into recording (beep started ${expectedAudioSyncSec.toFixed(3)}s, flash painted ${expectedVideoSyncSec.toFixed(3)}s)`
     )
@@ -1493,8 +1501,8 @@ export class ScreenRecorder extends EventEmitter {
       // SYNC_CONFIDENCE_LOW in bot logs.
       console.warn(
         `⚠️ SYNC_CONFIDENCE_LOW confidence=${syncResult.confidence.toFixed(2)} ` +
-        `audioTs=${syncResult.audioTimestamp.toFixed(3)} videoTs=${syncResult.videoTimestamp.toFixed(3)} ` +
-        `expected=${expectedSyncSec.toFixed(3)} — proceeding without measured correction`
+          `audioTs=${syncResult.audioTimestamp.toFixed(3)} videoTs=${syncResult.videoTimestamp.toFixed(3)} ` +
+          `expected=${expectedSyncSec.toFixed(3)} — proceeding without measured correction`
       )
     }
     const hasMeetingStartTime = this.meetingStartTime > 0
@@ -1558,7 +1566,9 @@ export class ScreenRecorder extends EventEmitter {
     console.log(`   meetingStartTime: ${this.meetingStartTime}`)
     console.log(`   recordingStartTime: ${this.recordingStartTime}`)
     console.log(`   capture startup delay: ${startupDelaySec.toFixed(3)}s`)
-    console.log(`   calcOffsetVideo (raw): ${rawCalcOffsetVideo.toFixed(3)}s → clamped: ${calcOffsetVideo.toFixed(3)}s`)
+    console.log(
+      `   calcOffsetVideo (raw): ${rawCalcOffsetVideo.toFixed(3)}s → clamped: ${calcOffsetVideo.toFixed(3)}s`
+    )
     if (rawCalcOffsetVideo < 0) {
       console.warn(
         `⚠️ Meeting start precedes media t=0 by ${(-rawCalcOffsetVideo).toFixed(3)}s (authenticated bot fast-join and/or capture startup delay). Trimming from t=0.`
@@ -1632,12 +1642,9 @@ export class ScreenRecorder extends EventEmitter {
         console.log(`📊 Raw video file size: ${sizeMB} MB (${sizeBytes} bytes)`)
 
         const s3Key = `${identifier}/raw_video.mp4`
-        await S3Uploader.getInstance()!.uploadFile(
-          rawVideoPath,
-          envVars.AWS_S3_LOGS_BUCKET,
-          s3Key,
-          { raw_upload: "true" }
-        )
+        await S3Uploader.getInstance()!.uploadFile(rawVideoPath, storageBuckets().logs, s3Key, {
+          raw_upload: "true"
+        })
 
         console.log(`✅ Raw video uploaded to logs bucket: ${s3Key} (tagged with raw_upload=true)`)
       } catch (error) {
@@ -1920,7 +1927,7 @@ file '${absoluteInputPath}'`
       // the whole recording during finalization.
       console.warn(
         `⚠️ getKeyframePositions failed for ${videoPath}; continuing without keyframe snapping (non-fatal):`,
-        formatError(error),
+        formatError(error)
       )
       return []
     }
@@ -1972,8 +1979,10 @@ file '${absoluteInputPath}'`
       }
 
       console.log(
-        `🎯 Pause window snapped: [${((w.start - meetingStartTime) / 1000).toFixed(3)}s, ${w.end !== null ? `${((w.end - meetingStartTime) / 1000).toFixed(3)}s` : "end"
-        }] → [${((snappedStart - meetingStartTime) / 1000).toFixed(3)}s, ${snappedEnd !== null ? `${((snappedEnd - meetingStartTime) / 1000).toFixed(3)}s` : "end"
+        `🎯 Pause window snapped: [${((w.start - meetingStartTime) / 1000).toFixed(3)}s, ${
+          w.end !== null ? `${((w.end - meetingStartTime) / 1000).toFixed(3)}s` : "end"
+        }] → [${((snappedStart - meetingStartTime) / 1000).toFixed(3)}s, ${
+          snappedEnd !== null ? `${((snappedEnd - meetingStartTime) / 1000).toFixed(3)}s` : "end"
         }]`
       )
 
@@ -1984,7 +1993,8 @@ file '${absoluteInputPath}'`
         console.warn(
           `⚠️ Dropping post-snap zero-length pause window at ${(
             (snappedStart - meetingStartTime) / 1000
-          ).toFixed(3)}s (pre-snap duration: ${w.end !== null ? ((w.end - w.start) / 1000).toFixed(3) : "∞"
+          ).toFixed(3)}s (pre-snap duration: ${
+            w.end !== null ? ((w.end - w.start) / 1000).toFixed(3) : "∞"
           }s)`
         )
         continue
@@ -2139,7 +2149,7 @@ file '${absoluteInputPath}'`
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
-      let segment: { start_time: number; end_time: number;[key: string]: unknown }
+      let segment: { start_time: number; end_time: number; [key: string]: unknown }
       try {
         segment = JSON.parse(line)
       } catch (err) {
@@ -2148,7 +2158,8 @@ file '${absoluteInputPath}'`
         // with pre-trim wall-clock timestamps. Skip and keep going.
         parseFailures++
         console.warn(
-          `⚠️ Diarization line ${i} in ${diarizationPath} is malformed, skipping: ${err instanceof Error ? err.message : String(err)
+          `⚠️ Diarization line ${i} in ${diarizationPath} is malformed, skipping: ${
+            err instanceof Error ? err.message : String(err)
           }`
         )
         continue
@@ -2173,7 +2184,8 @@ file '${absoluteInputPath}'`
       "utf8"
     )
     console.log(
-      `✂️ Diarization adjusted: ${lines.length} segments → ${adjusted.length} segments (${lines.length - adjusted.length
+      `✂️ Diarization adjusted: ${lines.length} segments → ${adjusted.length} segments (${
+        lines.length - adjusted.length
       } removed${parseFailures > 0 ? `, of which ${parseFailures} malformed` : ""})`
     )
   }
@@ -2333,7 +2345,7 @@ file '${absoluteInputPath}'`
       fileSizeMB = Math.round((stats.size / (1024 * 1024)) * 10) / 10
     } catch {
       console.warn(
-        `⚠️ Could not stat file for getDuration timeout calculation: ${filePath}, using base timeout`,
+        `⚠️ Could not stat file for getDuration timeout calculation: ${filePath}, using base timeout`
       )
     }
 
@@ -2421,14 +2433,11 @@ file '${absoluteInputPath}'`
     })
   }
 
-  private async runFFprobe(
-    args: string[],
-    fileSizeMB?: number,
-  ): Promise<string> {
+  private async runFFprobe(args: string[], fileSizeMB?: number): Promise<string> {
     const timeout = calculateFFmpegTimeout("getDuration", fileSizeMB)
 
     console.log(
-      `⏱️ FFprobe getDuration: timeout set to ${timeout / 1000}s${fileSizeMB ? ` (estimated file size: ${fileSizeMB}MB)` : ""}`,
+      `⏱️ FFprobe getDuration: timeout set to ${timeout / 1000}s${fileSizeMB ? ` (estimated file size: ${fileSizeMB}MB)` : ""}`
     )
 
     return new Promise((resolve, reject) => {
@@ -2453,7 +2462,7 @@ file '${absoluteInputPath}'`
 
       const timeoutId = setTimeout(() => {
         console.error(
-          `❌ FFprobe timeout after ${timeout / 1000}s for getDuration, killing process`,
+          `❌ FFprobe timeout after ${timeout / 1000}s for getDuration, killing process`
         )
         process.kill("SIGKILL")
         reject(new Error("FFprobe timeout"))

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -79,6 +79,17 @@ class Global {
     console.log(`🤖 Bot ${meetingParams.bot_uuid} initialized with validated parameters`)
   }
 
+  /**
+   * Meeting params if they've been parsed, otherwise null.
+   *
+   * Unlike `get()` this never throws, for the modules that run before stdin is
+   * parsed (Logger, PathManager) and must fall back to env-var defaults rather
+   * than crash. See config/storage.ts.
+   */
+  public tryGet(): MeetingParams | null {
+    return this.meetingParams
+  }
+
   public get(): MeetingParams {
     if (this.meetingParams === null) {
       throw new Error("Meeting params are not set")

--- a/src/state-machine/states/cleanup-state.ts
+++ b/src/state-machine/states/cleanup-state.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import { ChatManager } from "../../chat-manager"
-import { envVars } from "../../config/env-vars"
+import { storageBuckets } from "../../config/storage"
 import { SoundContext, VideoContext } from "../../media_context"
 import { stopToggleProxy } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
@@ -174,7 +174,7 @@ export class CleanupState extends BaseState {
 
       const botUuid = GLOBAL.get().bot_uuid
       const s3Key = `${botUuid}/chat_messages.json`
-      const bucket = envVars.AWS_S3_ARTIFACTS_BUCKET
+      const bucket = storageBuckets().artifacts
 
       console.log(`Uploading ${chatMessages.length} chat messages to S3: ${s3Key}`)
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -4,6 +4,7 @@ import { Transform } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import winston from "winston"
 import { envVars } from "../config/env-vars"
+import { storageBuckets } from "../config/storage"
 import { GLOBAL } from "../singleton"
 import { PathManager } from "./PathManager"
 import { PiiRedactor } from "./PiiRedactor"
@@ -13,11 +14,11 @@ import { S3Uploader, s3cp } from "./S3Uploader"
  * Error information extracted safely with type checking
  */
 export interface ErrorInfo {
-    error: unknown
-    message: string
-    stack?: string
-    name?: string
-    errorType?: string
+  error: unknown
+  message: string
+  stack?: string
+  name?: string
+  errorType?: string
 }
 
 /**
@@ -27,18 +28,18 @@ export interface ErrorInfo {
  * @returns Structured error information with stack trace
  */
 export function formatError(
-    error: unknown,
-    additionalContext?: Record<string, unknown>,
+  error: unknown,
+  additionalContext?: Record<string, unknown>
 ): ErrorInfo & Record<string, unknown> {
-    const errorInfo: ErrorInfo = {
-        error,
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        name: error instanceof Error ? error.name : undefined,
-        errorType: error?.constructor?.name,
-    }
+  const errorInfo: ErrorInfo = {
+    error,
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+    name: error instanceof Error ? error.name : undefined,
+    errorType: error?.constructor?.name
+  }
 
-    return { ...errorInfo, ...additionalContext }
+  return { ...errorInfo, ...additionalContext }
 }
 
 // Reference to current bot log file
@@ -167,14 +168,14 @@ let fileLoggingSetup = false
 export function setupFileLogging(): void {
   // Only setup once
   if (fileLoggingSetup) return
-  
+
   try {
     // Only enable file logging in local/serverless mode
     // In preprod/prod mode, the SQS process orchestrator will handle logging
     if (envVars.SERVERLESS || envVars.ENVIRON === "local") {
       const pathManager = PathManager.getInstance()
       const logFilePath = path.join(pathManager.getBasePath(), "bot.log")
-      
+
       // Ensure the directory exists
       const logDir = path.dirname(logFilePath)
       if (!fs.existsSync(logDir)) {
@@ -259,7 +260,7 @@ export async function uploadScreenshotsToS3(): Promise<void> {
         try {
           await S3Uploader.getInstance()?.uploadDirectory(
             screenshotsPath,
-            envVars.AWS_S3_ARTIFACTS_BUCKET, // Screenshots are considered artifacts, storing them in the artifacts bucket
+            storageBuckets().artifacts, // Screenshots are considered artifacts, storing them in the artifacts bucket
             s3ScreenshotsPath,
             // Screenshots are debug-grade artifacts. Skip EFS fallback to avoid
             // burning EFS storage and per-file fallback log noise on transient
@@ -442,7 +443,7 @@ export async function uploadLogsToS3(): Promise<void> {
         try {
           await S3Uploader.getInstance()?.uploadDirectory(
             htmlSnapshotsPath,
-            envVars.AWS_S3_LOGS_BUCKET,
+            storageBuckets().logs,
             s3HtmlSnapshotsPath,
             // HTML snapshots are debug-grade artifacts. Skip EFS fallback to
             // avoid burning EFS storage and per-file fallback log noise on

--- a/src/utils/PathManager.ts
+++ b/src/utils/PathManager.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
 import { envVars } from "../config/env-vars"
+import { storageBuckets } from "../config/storage"
 import { GLOBAL } from "../singleton"
 
 const EFS_MOUNT_POINT = envVars.EFS_MOUNT_POINT
@@ -119,7 +120,7 @@ export class PathManager {
   public getS3Paths(): { bucketName: string; s3Path: string } {
     const identifier = this.getIdentifier()
     return {
-      bucketName: envVars.AWS_S3_ARTIFACTS_BUCKET,
+      bucketName: storageBuckets().artifacts,
       s3Path: `${identifier}`
     }
   }

--- a/src/utils/S3Uploader.ts
+++ b/src/utils/S3Uploader.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { S3Client, type Tag } from "@aws-sdk/client-s3"
+import type { Tag } from "@aws-sdk/client-s3"
 import { Upload } from "@aws-sdk/lib-storage"
 import { envVars } from "../config/env-vars"
+import { storageBuckets, storageS3Client, transientSpillAllowed } from "../config/storage"
 import { GLOBAL } from "../singleton"
 import type { ArtifactType } from "../types"
 import { PathManager } from "./PathManager"
@@ -21,15 +22,12 @@ const MAX_CONCURRENT_UPLOADS = 100 // Limit concurrent uploads
 const UPLOAD_TIMEOUT_MS = 25 * 60 * 1000 // 25 minutes
 
 export class S3Uploader {
-  private s3Client: S3Client
-
-  private constructor() {
-    // AWS SDK v3 automatically detects:
-    // - Credentials from environment variables, IAM roles, AWS config files, etc.
-    // - Endpoints from AWS_ENDPOINT_URL, AWS_ENDPOINT_URL_S3, etc.
-    // - Regions from AWS_REGION, AWS_DEFAULT_REGION, etc.
-    this.s3Client = new S3Client()
-  }
+  // No cached client field on purpose. This singleton can be constructed before the
+  // meeting params are parsed (an early log upload does exactly that), and a client
+  // captured at that point would be the platform one — every later upload for a
+  // customer-storage bot would then land in OUR bucket. storageS3Client() resolves
+  // per call and rebuilds once the customer's config is known. See config/storage.ts.
+  private constructor() {}
 
   public static getInstance(): S3Uploader {
     if (GLOBAL.isServerless()) {
@@ -90,7 +88,7 @@ export class S3Uploader {
       // enforced out-of-band (e.g. GCS-native Object Lifecycle Management on
       // the bucket, configured at deploy time to match the product's policy).
       const upload = new Upload({
-        client: this.s3Client,
+        client: storageS3Client(),
         params: {
           Bucket: bucketName,
           Key: s3Path,
@@ -123,6 +121,14 @@ export class S3Uploader {
         // Caller (e.g. screenshots) opted out of EFS preservation. These
         // artifacts are debug-grade and not worth the EFS storage / log noise.
         console.warn(`❌ S3 upload failed (no EFS fallback): ${s3Path} — ${error}`)
+      } else if (!transientSpillAllowed()) {
+        // The team's own storage with transient spill off: this artifact is not
+        // allowed to rest on our volume, so the failure is final. Say so plainly —
+        // the recording is gone, and a log line that reads like the EFS path ran
+        // would send whoever investigates looking for a file that was never written.
+        console.error(
+          `❌ S3 upload failed and transient spill is disabled for this team — artifact abandoned: ${s3Path} — ${error}`
+        )
       } else {
         console.warn(`❌ S3 upload failed, falling back to EFS: ${error}`)
         // Best-effort EFS mirror so a later reconciliation job can push to S3.
@@ -143,7 +149,7 @@ export class S3Uploader {
       return
     }
 
-    const bucket = envVars.AWS_S3_LOGS_BUCKET
+    const bucket = storageBuckets().logs
     if (!bucket) {
       console.warn("Skipping S3 upload - aws_s3_log_bucket not configured")
       return
@@ -251,6 +257,8 @@ export class S3Uploader {
   private async copyToEFS(filePath: string, bucketName: string, s3Path: string): Promise<void> {
     try {
       if (GLOBAL.isServerless()) return
+      // Second gate, in case a future caller reaches this without the check above.
+      if (!transientSpillAllowed()) return
       const env = envVars.ENVIRON
       if (env === "local") {
         console.warn(`⚠️ EFS not available in ${env} environment - file will remain on local disk`)
@@ -297,6 +305,15 @@ export class S3Uploader {
   public async copyDirToEFS(localDir: string): Promise<void> {
     try {
       if (GLOBAL.isServerless()) return
+      // Same residency gate as copyToEFS. Without it the cleanup-timeout safety net
+      // would quietly undo the guarantee the per-file path just honoured, mirroring
+      // output.mp4 / output.flac / diarization / chunks onto our volume.
+      if (!transientSpillAllowed()) {
+        console.warn(
+          "⚠️ Cleanup timeout with un-uploaded outputs, but transient spill is disabled for this team — not mirroring to EFS"
+        )
+        return
+      }
       const env = envVars.ENVIRON
       if (env === "local") {
         console.warn(`⚠️ EFS not available in ${env} environment - skipping dir copy`)
@@ -309,7 +326,7 @@ export class S3Uploader {
 
       const pm = PathManager.getInstance()
       const outputBase = pm.getOutputPath()
-      const artifactsBucket = envVars.AWS_S3_ARTIFACTS_BUCKET
+      const artifactsBucket = storageBuckets().artifacts
 
       // Named final outputs → artifacts bucket (key <uuid>/<name>, matching the
       // bot's real S3 keys).
@@ -345,7 +362,7 @@ export class S3Uploader {
       if (fs.existsSync(chunksDir)) {
         for (const filename of fs.readdirSync(chunksDir)) {
           const src = path.join(chunksDir, filename)
-          if (await this.mirrorFileToEFS(src, envVars.AWS_S3_AUDIO_CHUNKS_BUCKET, filename)) {
+          if (await this.mirrorFileToEFS(src, storageBuckets().audioChunks, filename)) {
             this.recordPendingChunk(src, filename)
           }
         }

--- a/src/utils/meeting-params-schema.test.ts
+++ b/src/utils/meeting-params-schema.test.ts
@@ -1,0 +1,58 @@
+const storageConfig = {
+  endpoint: "https://storage.example.com",
+  region: "us-east-1",
+  access_key_id: "access-key",
+  secret_access_key: "secret-key",
+  artifacts_bucket: "artifacts",
+  audio_chunks_bucket: "audio-chunks",
+  logs_bucket: "logs"
+}
+
+describe("StorageConfigSchema", () => {
+  const originalEnviron = process.env.ENVIRON
+
+  afterEach(() => {
+    process.env.ENVIRON = originalEnviron
+    jest.resetModules()
+  })
+
+  const schemaFor = (environ: "local" | "preprod" | "prod") => {
+    process.env.ENVIRON = environ
+    jest.resetModules()
+    return require("./meeting-params-schema").StorageConfigSchema
+  }
+
+  it("accepts HTTPS in prod", () => {
+    expect(schemaFor("prod").safeParse(storageConfig).success).toBe(true)
+  })
+
+  it("rejects HTTP in prod", () => {
+    expect(
+      schemaFor("prod").safeParse({ ...storageConfig, endpoint: "http://storage.example.com" })
+        .success
+    ).toBe(false)
+  })
+
+  it("accepts HTTP outside prod", () => {
+    expect(
+      schemaFor("preprod").safeParse({ ...storageConfig, endpoint: "http://storage.example.com" })
+        .success
+    ).toBe(true)
+  })
+
+  it.each(["s3://storage.example.com", "file:///tmp/storage"])(
+    "rejects unsupported endpoint %s",
+    (endpoint) => {
+      expect(schemaFor("local").safeParse({ ...storageConfig, endpoint }).success).toBe(false)
+    }
+  )
+
+  it.each(["", ".", "..", "bucket/name", "bucket\\name"])(
+    "rejects unsafe bucket name %s",
+    (artifacts_bucket) => {
+      expect(schemaFor("local").safeParse({ ...storageConfig, artifacts_bucket }).success).toBe(
+        false
+      )
+    }
+  )
+})

--- a/src/utils/meeting-params-schema.test.ts
+++ b/src/utils/meeting-params-schema.test.ts
@@ -12,7 +12,11 @@ describe("StorageConfigSchema", () => {
   const originalEnviron = process.env.ENVIRON
 
   afterEach(() => {
-    process.env.ENVIRON = originalEnviron
+    if (originalEnviron === undefined) {
+      delete process.env.ENVIRON
+    } else {
+      process.env.ENVIRON = originalEnviron
+    }
     jest.resetModules()
   })
 
@@ -53,6 +57,13 @@ describe("StorageConfigSchema", () => {
       expect(schemaFor("local").safeParse({ ...storageConfig, artifacts_bucket }).success).toBe(
         false
       )
+    }
+  )
+
+  it.each(["region", "access_key_id", "secret_access_key"] as const)(
+    "rejects an empty %s",
+    (field) => {
+      expect(schemaFor("local").safeParse({ ...storageConfig, [field]: "" }).success).toBe(false)
     }
   )
 })

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -12,6 +12,31 @@ import {
   enum as zodEnum,
   unknown as zodUnknown
 } from "zod"
+import { envVars } from "../config/env-vars"
+
+const storageBucketSchema = string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/)
+
+export const StorageConfigSchema = object({
+  endpoint: url().refine(
+    (endpoint) => {
+      const protocol = new URL(endpoint).protocol
+      return protocol === "https:" || (protocol === "http:" && envVars.ENVIRON !== "prod")
+    },
+    { message: "customer storage endpoint must use HTTPS" }
+  ),
+  region: string(),
+  force_path_style: boolean().default(false),
+  access_key_id: string(),
+  secret_access_key: string(),
+  artifacts_bucket: storageBucketSchema,
+  audio_chunks_bucket: storageBucketSchema,
+  logs_bucket: storageBucketSchema,
+  // When false (the default for a team on its own storage) a failed upload must
+  // NOT be parked on MeetingBaas EFS — the recording is given up on instead.
+  // These teams are usually on their own bucket for data residency, and the EFS
+  // fallback is the one path that puts a full recording on our volume.
+  allow_transient_spill: boolean().default(false)
+})
 
 export const RecordingModeSchema = zodEnum(["speaker_view", "audio_only", "gallery_view"])
 export const SpeechToTextProviderSchema = zodEnum([
@@ -88,23 +113,7 @@ export const BotMessageSchema = object({
   // would then write a customer's recording into OUR bucket while the api-server
   // looks for it in theirs.
   storage_config: optional(
-    nullable(
-      object({
-        endpoint: url(),
-        region: string(),
-        force_path_style: boolean().default(false),
-        access_key_id: string(),
-        secret_access_key: string(),
-        artifacts_bucket: string(),
-        audio_chunks_bucket: string(),
-        logs_bucket: string(),
-        // When false (the default for a team on its own storage) a failed upload must
-        // NOT be parked on MeetingBaas EFS — the recording is given up on instead.
-        // These teams are usually on their own bucket for data residency, and the EFS
-        // fallback is the one path that puts a full recording on our volume.
-        allow_transient_spill: boolean().default(false)
-      })
-    )
+    nullable(StorageConfigSchema)
   ).default(null),
 
   // Teams authenticated bot config — present when api-server assigned a teams_login.

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -1,5 +1,6 @@
 import {
   array,
+  boolean,
   nullable,
   number,
   object,
@@ -37,7 +38,9 @@ export const BotMessageSchema = object({
   bot_image_config: object({
     loop_mode: zodEnum(["auto", "bot_status"]),
     image_duration: number().int().min(10).max(120)
-  }).nullable().default(null),
+  })
+    .nullable()
+    .default(null),
   meeting_url: url(),
   transformed_meeting_url: url().nullable(),
   meeting_platform: MeetingPlatformSchema,
@@ -71,6 +74,35 @@ export const BotMessageSchema = object({
         login_email: string().email(),
         set_cookie_url: url(),
         fallback: zodEnum(["fail", "anonymous"]).default("anonymous")
+      })
+    )
+  ).default(null),
+
+  // The team's own object storage ("bring your own bucket"), when it has configured
+  // one. Absent/null — the default — means the bot uploads to the platform buckets
+  // from AWS_S3_*_BUCKET using the pod's ambient credentials, exactly as before.
+  //
+  // MUST stay in sync with StorageConfigMessage in api-server and the schema in
+  // sqs-consumer: zod .parse() strips unknown keys, so a field missing from any of
+  // the three is silently dropped between SQS and the bot's stdin — and the bot
+  // would then write a customer's recording into OUR bucket while the api-server
+  // looks for it in theirs.
+  storage_config: optional(
+    nullable(
+      object({
+        endpoint: url(),
+        region: string(),
+        force_path_style: boolean().default(false),
+        access_key_id: string(),
+        secret_access_key: string(),
+        artifacts_bucket: string(),
+        audio_chunks_bucket: string(),
+        logs_bucket: string(),
+        // When false (the default for a team on its own storage) a failed upload must
+        // NOT be parked on MeetingBaas EFS — the recording is given up on instead.
+        // These teams are usually on their own bucket for data residency, and the EFS
+        // fallback is the one path that puts a full recording on our volume.
+        allow_transient_spill: boolean().default(false)
       })
     )
   ).default(null),

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -24,10 +24,10 @@ export const StorageConfigSchema = object({
     },
     { message: "customer storage endpoint must use HTTPS" }
   ),
-  region: string(),
+  region: string().min(1),
   force_path_style: boolean().default(false),
-  access_key_id: string(),
-  secret_access_key: string(),
+  access_key_id: string().min(1),
+  secret_access_key: string().min(1),
   artifacts_bucket: storageBucketSchema,
   audio_chunks_bucket: storageBucketSchema,
   logs_bucket: storageBucketSchema,


### PR DESCRIPTION
## Summary

This PR adds support for **Bring Your Own S3-compatible Storage (BYO storage)** at the bot level.

When a team provides a `storage_config`, the bot routes meeting data directly to the team's configured object storage instead of the default Meeting BaaS buckets. Teams without a custom storage configuration continue using the existing platform storage behavior.

### Changes

- Added `storage_config` to the bot meeting parameters schema, including:
  - Custom S3-compatible endpoint
  - Region
  - Path-style addressing support
  - Access key and secret key credentials
  - Separate buckets for artifacts, audio chunks, and logs
  - `allow_transient_spill` configuration

- Added centralized storage resolution through `src/config/storage.ts`.
  - Storage configuration is resolved lazily after meeting parameters are available.
  - Prevents modules initialized before meeting parameters are parsed from accidentally retaining the platform S3 configuration.
  - Falls back to the existing `AWS_S3_*_BUCKET` configuration when no custom storage is provided.

- Added customer-specific S3 client creation.
  - Uses the configured endpoint, region, credentials, and `force_path_style` setting.
  - Uses up to 6 S3 attempts for custom storage to provide additional resilience for external/S3-compatible providers.
  - Existing platform storage continues using the pod's ambient AWS credentials.

- Updated storage routing for:
  - MP4 recordings
  - FLAC recordings
  - Diarization files
  - Audio chunks
  - Chat messages
  - Screenshots
  - HTML snapshots
  - Raw video/debug uploads
  - Log uploads and generated S3 paths

- Added `GLOBAL.tryGet()` so storage-dependent modules that initialize before meeting parameters are parsed can safely fall back to platform configuration without throwing.

- Updated EFS fallback behavior for data residency:
  - Platform storage keeps the existing EFS fallback behavior.
  - BYO storage can explicitly allow EFS fallback through `allow_transient_spill`.
  - When `allow_transient_spill` is disabled, failed uploads are **not copied to Meeting BaaS EFS**.
  - The same restriction is applied to both individual upload failures and cleanup-time directory mirroring.
  - In this mode, an exhausted upload failure is treated as final rather than temporarily storing customer data on Meeting BaaS infrastructure.

## Testing

The following scenarios should be validated as part of the `preprod` rollout:

- [ ] Bot without `storage_config` continues uploading to the existing Meeting BaaS artifacts, audio chunks, and logs buckets.
- [ ] Existing platform-storage EFS fallback behavior remains unchanged.
- [ ] Bot with `storage_config` uploads recordings, audio chunks, diarization, chat messages, screenshots, HTML snapshots, raw video, and logs to the configured customer buckets.
- [ ] Custom endpoint, region, credentials, and path-style configuration are correctly used by the S3 client.
- [ ] BYO storage with `allow_transient_spill: false` does not copy failed uploads to Meeting BaaS EFS.
- [ ] Cleanup-time fallback also skips EFS when transient spill is disabled.
- [ ] BYO storage with `allow_transient_spill: true` retains the existing EFS recovery path on upload failure.
- [ ] Upload failures are surfaced correctly when transient spill is disabled and the artifact cannot be uploaded.

## Release Notes

Adds support for team-owned S3-compatible object storage for meeting recordings and related bot artifacts.

Teams configured for BYO storage can keep recordings, audio chunks, logs, and other meeting artifacts directly within their own storage infrastructure. BYO storage also supports strict data-residency behavior by disabling temporary EFS fallback through `allow_transient_spill`.

There is **no behavior change for teams that do not have BYO storage configured**.
