### PR TITLE
feat: per-bot max_recording_duration cap (up to 12h)

### DIFF
--- a/src/state-machine/constants.ts
+++ b/src/state-machine/constants.ts
@@ -8,7 +8,7 @@ export const MEETING_CONSTANTS = {
 
   // Timeouts
   SETUP_TIMEOUT: 30_000, // 30 secondes
-  RECORDING_TIMEOUT: 3600 * 4 * 1000, // 4 heures
+  RECORDING_TIMEOUT: 3600 * 6 * 1000, // 6 heures
   INITIAL_WAIT_TIME: 1000 * 60 * 7, // 7 minutes
   EMPTY_MEETING_CONFIRMATION_MS: 45_000, // 45 seconds before confirming no attendees
   // Outer cleanup timeout. Typical cleanup runs in 2–15 minutes; the headroom

--- a/src/state-machine/constants.ts
+++ b/src/state-machine/constants.ts
@@ -8,7 +8,7 @@ export const MEETING_CONSTANTS = {
 
   // Timeouts
   SETUP_TIMEOUT: 30_000, // 30 secondes
-  RECORDING_TIMEOUT: 3600 * 6 * 1000, // 6 heures
+  RECORDING_TIMEOUT: 3600 * 4 * 1000, // 4 heures
   INITIAL_WAIT_TIME: 1000 * 60 * 7, // 7 minutes
   EMPTY_MEETING_CONFIRMATION_MS: 45_000, // 45 seconds before confirming no attendees
   // Outer cleanup timeout. Typical cleanup runs in 2–15 minutes; the headroom

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -111,7 +111,10 @@ export class RecordingState extends BaseState {
       // Main loop
       while (this.isProcessing) {
         // Check global timeout
-        if (Date.now() - startTime > MEETING_CONSTANTS.RECORDING_TIMEOUT) {
+        const recordingTimeoutMs = GLOBAL.get().max_recording_duration
+          ? GLOBAL.get().max_recording_duration! * 1000
+          : MEETING_CONSTANTS.RECORDING_TIMEOUT
+        if (Date.now() - startTime > recordingTimeoutMs) {
           console.warn("Global recording state timeout reached, forcing end")
           GLOBAL.setEndReason(MeetingEndReason.RecordingTimeout)
           await this.handleMeetingEnd(MeetingEndReason.RecordingTimeout)

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -82,7 +82,7 @@ export const BotMessageSchema = object({
   grace_period: number().int().nonnegative().default(0),
   max_recording_duration: number()
     .int()
-    .nonnegative()
+    .positive()
     .max(6 * 60 * 60)
     .nullable()
     .default(null),

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -80,6 +80,7 @@ export const BotMessageSchema = object({
   no_one_joined_timeout: number().int().positive().default(600),
   silence_timeout: number().int().positive().default(600),
   grace_period: number().int().nonnegative().default(0),
+  max_recording_duration: number().int().nonnegative().nullable().default(null),
   ignored_participant_names: array(string()).default([]),
   speech_to_text_provider: SpeechToTextProviderSchema.default("none"),
   retry_count: number().int().nonnegative().default(0),

--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -80,7 +80,12 @@ export const BotMessageSchema = object({
   no_one_joined_timeout: number().int().positive().default(600),
   silence_timeout: number().int().positive().default(600),
   grace_period: number().int().nonnegative().default(0),
-  max_recording_duration: number().int().nonnegative().nullable().default(null),
+  max_recording_duration: number()
+    .int()
+    .nonnegative()
+    .max(6 * 60 * 60)
+    .nullable()
+    .default(null),
   ignored_participant_names: array(string()).default([]),
   speech_to_text_provider: SpeechToTextProviderSchema.default("none"),
   retry_count: number().int().nonnegative().default(0),


### PR DESCRIPTION
Allows a per-bot `max_recording_duration` (seconds) to override the
hardcoded 4h recording cap. When set, the bot will automatically
exit after reaching this duration instead of falling back to
MEETING_CONSTANTS.RECORDING_TIMEOUT.

- Adds `max_recording_duration` (int, nullable) to BotMessageSchema,
  stored in GLOBAL singleton
- recording-state main loop checks `GLOBAL.get().max_recording_duration`
  when set; falls back to RECORDING_TIMEOUT when unset (null)