### PR TITLE
fix(proxy): requeue on Meet proxy failure + spread multi-region pin starts

### DIFF
--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -85,24 +85,6 @@ export async function establishBrowserSession(
       )
       if (proxyUrl) session.proxyUrl = proxyUrl
 
-      // Meet, no proxy, retries remain → requeue instead of joining direct.
-      // A proxyless Meet join comes from the pod's datacenter IP and flags
-      // ~94% (measured in prod during the 2026-08-10 Decodo capacity burst:
-      // 523 upstream_unreachable joins → 491 flagged) — it burns the team's
-      // reputation and the join usually fails anyway. The SQS requeue lands
-      // on a fresh pod later, when the pool has headroom. The LAST retry
-      // (branch above) still falls back to a live exit as the final resort.
-      if (!session.proxyUrl && platform === "meet" && retryCount < MAX_RETRY_COUNT) {
-        console.warn(
-          "[BrowserSession] Meet proxy unavailable — requeueing instead of a direct (datacenter-IP) join"
-        )
-        GLOBAL.setError(MeetingEndReason.ProxyUnavailable)
-        GLOBAL.setShouldRetry(true)
-        throw new Error(
-          "Residential proxy unavailable for Meet join — requeueing to retry when the pool has capacity"
-        )
-      }
-
       // Burned-ASN avoidance (Meet only). startToggleProxy already probed the
       // exit IP + ASN. If we landed on a network Google is currently flagging,
       // rotate the Decodo session to a fresh IP BEFORE spending a browser launch
@@ -214,6 +196,27 @@ export async function establishBrowserSession(
         }
       }
     }
+  }
+
+  // Meet, no proxy, retries remain → requeue instead of joining direct.
+  // A proxyless Meet join comes from the pod's datacenter IP and flags ~94%
+  // (measured in prod during the 2026-08-10 Decodo capacity burst: 523
+  // upstream_unreachable joins → 491 flagged) — it burns the team's
+  // reputation and the join usually fails anyway. The SQS requeue lands on a
+  // fresh pod later, when the pool has headroom. Checked HERE, immediately
+  // before launch, so it also covers the burned-ASN rotation paths above that
+  // clear session.proxyUrl on a failed rotation — not just the initial proxy
+  // start. The LAST retry still falls back to a live/direct exit as the
+  // final resort rather than never joining.
+  if (platform === "meet" && !session.proxyUrl && retryCount < MAX_RETRY_COUNT) {
+    console.warn(
+      "[BrowserSession] Meet proxy unavailable — requeueing instead of a direct (datacenter-IP) join"
+    )
+    GLOBAL.setError(MeetingEndReason.ProxyUnavailable)
+    GLOBAL.setShouldRetry(true)
+    throw new Error(
+      "Residential proxy unavailable for Meet join — requeueing to retry when the pool has capacity"
+    )
   }
 
   let lastError: Error | null = null

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -9,6 +9,7 @@ import {
   stopToggleProxy
 } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
+import { MeetingEndReason } from "../state-machine/types"
 import { MAX_RETRY_COUNT } from "../config/retry-config"
 import { formatError } from "../utils/Logger"
 import { openBrowser } from "./browser"
@@ -83,6 +84,24 @@ export async function establishBrowserSession(
         opts.sessionSuffix
       )
       if (proxyUrl) session.proxyUrl = proxyUrl
+
+      // Meet, no proxy, retries remain → requeue instead of joining direct.
+      // A proxyless Meet join comes from the pod's datacenter IP and flags
+      // ~94% (measured in prod during the 2026-08-10 Decodo capacity burst:
+      // 523 upstream_unreachable joins → 491 flagged) — it burns the team's
+      // reputation and the join usually fails anyway. The SQS requeue lands
+      // on a fresh pod later, when the pool has headroom. The LAST retry
+      // (branch above) still falls back to a live exit as the final resort.
+      if (!session.proxyUrl && platform === "meet" && retryCount < MAX_RETRY_COUNT) {
+        console.warn(
+          "[BrowserSession] Meet proxy unavailable — requeueing instead of a direct (datacenter-IP) join"
+        )
+        GLOBAL.setError(MeetingEndReason.ProxyUnavailable)
+        GLOBAL.setShouldRetry(true)
+        throw new Error(
+          "Residential proxy unavailable for Meet join — requeueing to retry when the pool has capacity"
+        )
+      }
 
       // Burned-ASN avoidance (Meet only). startToggleProxy already probed the
       // exit IP + ASN. If we landed on a network Google is currently flagging,

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -130,9 +130,30 @@ export function resolveProxyCountries(): string[] {
   const valid = list
     .filter((c): c is string => typeof c === "string" && /^[a-z]{2}$/i.test(c.trim()))
     .map((c) => c.trim().toLowerCase())
-  if (valid.length > 0) return [...new Set(valid)]
+  if (valid.length > 0) return rotateByBot([...new Set(valid)])
   const envC = envVars.RESIDENTIAL_PROXY_COUNTRY
   return /^[a-z]{2}$/i.test(envC) ? [envC.toLowerCase()] : []
+}
+
+/**
+ * Spread a multi-region pin across the team's selected regions instead of
+ * funneling every bot through the first entry. When a customer batch-launches
+ * hundreds of bots, all starting on regions[0] concentrates them on one
+ * country's dominant carrier and Google burns it live (2026-08-10: ~1100 bots
+ * on one BR ASN in two hours took it from 0% to 43% flagged mid-burst).
+ * Keyed on bot_uuid: stable within a bot (every resolve call agrees, including
+ * SQS retries of the same bot) and uniform across a batch. Cyclic rotation
+ * preserves the user's fallthrough sequence.
+ */
+function rotateByBot(countries: string[]): string[] {
+  if (countries.length <= 1) return countries
+  const uuid = GLOBAL.get().bot_uuid ?? ""
+  let hash = 0
+  for (let i = 0; i < uuid.length; i++) {
+    hash = (hash * 31 + uuid.charCodeAt(i)) >>> 0
+  }
+  const offset = hash % countries.length
+  return [...countries.slice(offset), ...countries.slice(0, offset)]
 }
 
 /** First selected region not yet tried this attempt, or "" if none remain. */

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -56,6 +56,10 @@ export enum MeetingEndReason {
   TeamsLoginFailedCaptcha = "teamsLoginFailedCaptcha",
   TeamsLoginFailedMfaRequired = "teamsLoginFailedMfaRequired",
   TeamsLoginFailedTimeout = "teamsLoginFailedTimeout",
+  // Residential proxy could not be established (e.g. Decodo pool at capacity
+  // during a launch burst). Retryable: a requeued attempt lands later when the
+  // pool has headroom, instead of joining direct from a datacenter IP.
+  ProxyUnavailable = "proxyUnavailable",
   Internal = "internalError"
 }
 
@@ -88,6 +92,8 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "Invalid meeting URL provided."
     case MeetingEndReason.StreamingSetupFailed:
       return "Failed to set up streaming audio."
+    case MeetingEndReason.ProxyUnavailable:
+      return "Residential proxy unavailable (pool at capacity or unreachable)."
     case MeetingEndReason.LoginRequired:
       return "Login required to access the meeting."
     case MeetingEndReason.MeetLoginFailedSamlRejected:


### PR DESCRIPTION
Burst-resilience fixes from a 2026-08-10 customer batch-launch incident (~1,800 bots launched in 3h → 1,008 flags in one day). Companion api-server mapping PR on meeting-baas-v2 (preprod).

## 1. Stop failing open to a datacenter-IP join on Meet

When the Decodo pool is at capacity, `startToggleProxy` returns null (`upstream_unreachable`) and the bot joined **direct from the pod's datacenter IP**. Measured during the burst: 523 such joins → **491 flagged (94%)** — the join usually fails AND burns the team's reputation.

Now: Meet + no proxy + retries remaining → new `ProxyUnavailable` end reason, `setShouldRetry(true)`, throw → SQS requeue lands on a fresh pod later when the pool has headroom. The **last** retry keeps the existing skipGeoPin live-exit fallback as the absolute final resort, so a bot never loops forever.

## 2. Spread multi-region pin starts (bot_uuid-keyed rotation)

Every bot started on `regions[0]`. During the burst, ~1,100 bots funneled through one BR carrier (AS10753) in two hours and Google burned it live — 13:00 wave 0% flagged, 14:00 wave 43%+. `resolveProxyCountries()` now cyclically rotates the team's selected list by a bot_uuid hash: stable within a bot (all resolve calls + SQS retries agree), uniform across a batch, and the user's fallthrough sequence is preserved (cyclic order unchanged).

Note: region order was previously documented as strict preference — with >1 region selected it now means "preferred set, load-spread". Single-region pins unchanged.

## Verification

- tsc clean (Node 20).
- api-server drift guard requires the `proxyUnavailable` wire-code mapping — included in the companion preprod PR (which also maps `zoomWebinarRegistrationRequired`, an unmapped code the guard just caught in the wild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
