### PR TITLE
fix(state-machine): don't emit meeting_error for API-requested pre-recording stop

### DIFF
--- a/src/state-machine/states/error-state.ts
+++ b/src/state-machine/states/error-state.ts
@@ -113,6 +113,18 @@ export class ErrorState extends BaseState {
             console.log("Notifying API request stop")
             await Events.apiRequestStop()
             break
+          case MeetingEndReason.ExitingMeetingBeforeRecord:
+            // Customer-requested stop (stop-bot API) while the bot was still
+            // joining / in the waiting room. Nothing errored — suppress the
+            // meeting_error status so the dashboard doesn't show "Meeting
+            // Error" for a stop the customer asked for. The terminal
+            // recording_failed (EXITING_MEETING_BEFORE_RECORD) emitted later by
+            // handleFailedRecording is what the api-server maps to the
+            // standardized "stopped before recording" description.
+            console.log(
+              "Stop requested before recording started — suppressing meeting_error status"
+            )
+            break
           default:
             console.log(`Unhandled error reason: ${endReason}`)
             await Events.meetingError(new Error(errorMessage || "Unknown error"))


### PR DESCRIPTION
## Bug

Customer-reported (prod, 2026-08-10 20:22 UTC, bot `8f3385e4-2022-47a4-b6b6-e6b0a00988ff`): the stop-bot API was called while the bot sat in the Google Meet waiting room, and the dashboard showed a **Meeting Error** status even though nothing errored.

```
20:21:58 info waiting-room-state:23: Entering waiting room state
20:22:02 info machine:104: Stop meeting requested with reason: apiRequest
20:22:02 info singleton:102: End reason set to: exitingMeetingBeforeRecord
20:22:03 error waiting-room-state:105: Error in waiting room state: {...}
20:22:03 error base-state:32: Error in state waitingRoom: {...}
20:22:03 info machine:50: Current state: error
20:22:03 error error-state:43: Meeting error occurred: {"reason":"exitingMeetingBeforeRecord"}
20:22:03 info error-state:86: Unhandled error reason: exitingMeetingBeforeRecord
```

## Root cause

For a pre-recording stop, `stopMeeting` rewrites `ApiRequest` → `ExitingMeetingBeforeRecord` (machine.ts) and the waiting-room state unwinds through `ErrorState`. `ErrorState.notifyError`'s switch has cases for `BotNotAccepted`, `ApiRequest`, etc., but **no case for `ExitingMeetingBeforeRecord`** — it fell into the `default` branch ("Unhandled error reason") and emitted `Events.meetingError(...)`, i.e. a `meeting_error` status to the customer dashboard, before the terminal `recording_failed`.

## Fix

Add an explicit `ExitingMeetingBeforeRecord` case in `ErrorState.notifyError` that suppresses the `meeting_error` event (mirroring the adjacent `ApiRequest` case's intent). This reason is only ever set on user/API-initiated stops — `stopMeeting`'s pre-recording rewrite, the startup stop-request check in main.ts, and the providers' `cancelCheck()` sites — so no genuine error path loses its event.

The state machine still transitions to Cleanup and the existing terminal `recording_failed` (`EXITING_MEETING_BEFORE_RECORD`) flow in `handleFailedRecording` runs unchanged; the api-server already maps that to the standardized "stopped before recording" description.

Not affected:
- **Genuine errors**: every other reason keeps its existing case/default behavior.
- **Mid-recording API stop**: never enters `ErrorState` at all (`ApiRequest` is in `NORMAL_END_REASONS`, so `wasRecordingSuccessful()` is true) — that path already worked and is untouched.

## Validation

`npx tsc --noEmit`: **0 errors** on this branch, identical to a clean `origin/v2-improvements` baseline (also 0 errors). (`pnpm build` is Node-gated ≤20 locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)