### PR TITLE
fix(meet): remove media join fast path; differential debounce gates all confirms

### DIFF
--- a/src/meeting/meet.test.ts
+++ b/src/meeting/meet.test.ts
@@ -364,21 +364,38 @@ describe("MeetProvider.joinMeeting — join-confirm debounce", () => {
     expect(onJoinSuccess).not.toHaveBeenCalled()
   })
 
-  it("confirms after an observed lobby→clear transition plus the debounce window", async () => {
-    // Bot sees the lobby for 3s (host admits), text clears and stays gone —
-    // the trusted transition case. Confirm should land after grace + 6s.
-    const start = Date.now()
+  it("confirms after an observed lobby→clear transition plus the 6s debounce (not the 10s no-lobby window)", async () => {
+    // Script the lobby by SAMPLE COUNT, not wall time: the pre-loop join
+    // steps advance the fake clock by several seconds before the first
+    // isWaitingRoom() poll, so a wall-clock window would already be over
+    // and the test would silently exercise the 10s no-lobby path instead.
+    // First 3 polls: lobby visible (host then admits) — clears from poll 4.
+    let waitingRoomPolls = 0
+    let lobbyClearedAt: number | null = null
     mockDetector.isInMeeting.mockResolvedValue({ count: 4, matched: true })
     mockDetector.isWaitingRoom.mockImplementation(async () => {
-      const inLobby = Date.now() - start < 3000
+      waitingRoomPolls++
+      const inLobby = waitingRoomPolls <= 3
+      if (!inLobby && lobbyClearedAt === null) lobbyClearedAt = Date.now()
       return { matched: inLobby, count: inLobby ? 3 : 0 }
     })
 
-    const onJoinSuccess = jest.fn()
+    let confirmedAt: number | null = null
+    const onJoinSuccess = jest.fn().mockImplementation(() => {
+      confirmedAt = Date.now()
+    })
+    const start = Date.now()
     const cancelCheck = () => Date.now() - start > 60000
 
     await provider.joinMeeting(createJoinLoopPage(), cancelCheck, onJoinSuccess)
 
     expect(onJoinSuccess).toHaveBeenCalledTimes(1)
+    // Confirm must land after the post-lobby grace (1s) + 6s debounce, and
+    // clearly before the 10s no-lobby window — proving the transition-
+    // observed path was taken.
+    expect(lobbyClearedAt).not.toBeNull()
+    const elapsedFromClear = (confirmedAt as unknown as number) - (lobbyClearedAt as unknown as number)
+    expect(elapsedFromClear).toBeGreaterThanOrEqual(7000)
+    expect(elapsedFromClear).toBeLessThan(10000)
   })
 })

--- a/src/meeting/meet.test.ts
+++ b/src/meeting/meet.test.ts
@@ -16,10 +16,14 @@ jest.mock("../singleton", () => ({
 }))
 
 // ── mock meeting-state-detector (prevents module-level createStateDetector call) ─
+// Shared instance so join-loop tests can script waiting-room / in-meeting state.
+const mockDetector = {
+  isDenied: jest.fn().mockResolvedValue({ matched: false, matchedText: null, pattern: null }),
+  isWaitingRoom: jest.fn().mockResolvedValue({ matched: false, count: 0 }),
+  isInMeeting: jest.fn().mockResolvedValue({ count: 0, matched: false }),
+}
 jest.mock("../utils/meeting-state-detector", () => ({
-  createStateDetector: jest.fn().mockReturnValue({
-    isDenied: jest.fn().mockResolvedValue({ matched: false, matchedText: null, pattern: null }),
-  }),
+  createStateDetector: jest.fn().mockReturnValue(mockDetector),
 }))
 
 // ── mock all other module-level dependencies that run at import time ─
@@ -251,5 +255,130 @@ describe("MeetProvider.findEndMeeting", () => {
       const result = await provider.findEndMeeting(page)
       expect(result).toBe(false)
     })
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════
+// MeetProvider.joinMeeting — lobby / debounce regression tests
+//
+// Regression for the 2026-08-11 prod incident: Meet's lobby can render
+// the in-meeting DOM (indicator threshold passes) while the lobby text
+// appears seconds LATE. A join confirm that fires inside that window is
+// false, and the post-confirm lobby check then kills the bot as
+// botNotAccepted. The debounce must hold the confirm until the lobby
+// text has been absent long enough — including renders later than the
+// old 6s window (observed up to 6.4s).
+// ══════════════════════════════════════════════════════════════════
+
+describe("MeetProvider.joinMeeting — join-confirm debounce", () => {
+  let provider: MeetProvider
+
+  const { sleep } = jest.requireMock("../utils/sleep")
+
+  function createJoinLoopPage() {
+    // Permissive page mock: every UI interaction "exists but never succeeds",
+    // so the pre-loop steps (name typing, mic/camera, join click) fall
+    // through their retry paths without throwing. Timer-advancing waits keep
+    // Date.now() moving under fake timers.
+    const locatorChain: any = {}
+    Object.assign(locatorChain, {
+      first: jest.fn().mockReturnValue(locatorChain),
+      count: jest.fn().mockResolvedValue(0),
+      isVisible: jest.fn().mockResolvedValue(false),
+      isEnabled: jest.fn().mockResolvedValue(false),
+      click: jest.fn().mockRejectedValue(new Error("not clickable")),
+      fill: jest.fn().mockRejectedValue(new Error("not fillable")),
+      type: jest.fn().mockRejectedValue(new Error("not typable")),
+      waitFor: jest.fn().mockRejectedValue(new Error("never visible")),
+      evaluate: jest.fn().mockResolvedValue(undefined),
+      evaluateAll: jest.fn().mockResolvedValue([]),
+      all: jest.fn().mockResolvedValue([]),
+    })
+    return {
+      url: jest.fn().mockReturnValue("https://meet.google.com/abc-defg-hij"),
+      content: jest.fn().mockResolvedValue("<html></html>"),
+      isClosed: jest.fn().mockReturnValue(false),
+      evaluate: jest.fn().mockResolvedValue(undefined),
+      locator: jest.fn().mockReturnValue(locatorChain),
+      keyboard: { press: jest.fn().mockResolvedValue(undefined) },
+      mouse: {
+        move: jest.fn().mockResolvedValue(undefined),
+        click: jest.fn().mockResolvedValue(undefined),
+        down: jest.fn().mockResolvedValue(undefined),
+        up: jest.fn().mockResolvedValue(undefined),
+      },
+      waitForTimeout: jest.fn().mockImplementation(async (ms: number) => {
+        jest.advanceTimersByTime(ms)
+      }),
+    } as any
+  }
+
+  beforeEach(() => {
+    resetMocks()
+    jest.useFakeTimers()
+    provider = new MeetProvider()
+    mockGlobal.get.mockReturnValue({
+      bot_name: "TestBot",
+      streaming_input: undefined,
+      recording_mode: "audio_only", // skips the layout-change machinery in critical setup
+      meet_sso_config: undefined,
+      enter_message: undefined,
+    })
+    sleep.mockImplementation(async (ms: number) => {
+      jest.advanceTimersByTime(ms)
+    })
+    mockDetector.isDenied.mockResolvedValue({ matched: false, matchedText: null, pattern: null })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    sleep.mockResolvedValue(undefined)
+    mockDetector.isWaitingRoom.mockResolvedValue({ matched: false, count: 0 })
+    mockDetector.isInMeeting.mockResolvedValue({ count: 0, matched: false })
+  })
+
+  it("does NOT confirm when the lobby text renders late (8s after the first clean sample)", async () => {
+    // In-meeting indicators pass from the start (the lobby renders call
+    // controls); the lobby text only becomes detectable 8s after the first
+    // clean in-meeting sample — later than the old 6s window.
+    let firstCleanSampleAt: number | null = null
+    mockDetector.isInMeeting.mockImplementation(async () => {
+      if (firstCleanSampleAt === null) firstCleanSampleAt = Date.now()
+      return { count: 4, matched: true }
+    })
+    mockDetector.isWaitingRoom.mockImplementation(async () => {
+      const lateTextVisible =
+        firstCleanSampleAt !== null && Date.now() - firstCleanSampleAt >= 8000
+      return { matched: lateTextVisible, count: lateTextVisible ? 3 : 0 }
+    })
+
+    const onJoinSuccess = jest.fn()
+    const start = Date.now()
+    // Let the loop run 40s of virtual time, then stop it via cancelCheck.
+    const cancelCheck = () => Date.now() - start > 40000
+
+    await expect(
+      provider.joinMeeting(createJoinLoopPage(), cancelCheck, onJoinSuccess)
+    ).rejects.toThrow("API request to stop recording")
+
+    expect(onJoinSuccess).not.toHaveBeenCalled()
+  })
+
+  it("confirms after an observed lobby→clear transition plus the debounce window", async () => {
+    // Bot sees the lobby for 3s (host admits), text clears and stays gone —
+    // the trusted transition case. Confirm should land after grace + 6s.
+    const start = Date.now()
+    mockDetector.isInMeeting.mockResolvedValue({ count: 4, matched: true })
+    mockDetector.isWaitingRoom.mockImplementation(async () => {
+      const inLobby = Date.now() - start < 3000
+      return { matched: inLobby, count: inLobby ? 3 : 0 }
+    })
+
+    const onJoinSuccess = jest.fn()
+    const cancelCheck = () => Date.now() - start > 60000
+
+    await provider.joinMeeting(createJoinLoopPage(), cancelCheck, onJoinSuccess)
+
+    expect(onJoinSuccess).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -36,11 +36,10 @@ const GRACE_PERIOD_MS = 1000 // Grace period after leaving waiting room before c
 // detections prove the text can already be present at 0.3s), so 5.0s is a
 // hard upper bound on the render lag — 6s covers it plus one loop-cadence of
 // margin. Cost: 0 of 120 sampled healthy joins ever showed lobby text after
-// a genuine admission (the debounce cannot reset-loop a good join), and ~85%
-// of healthy joins have remote audio tracks registered (fast path below), so
-// only the hook-blind minority waits the full debounce. A render lag beyond
-// 6s would still be caught by the lobby check in changeLayout and ends as
-// BotNotAccepted rather than a false "removed".
+// a genuine admission (the debounce cannot reset-loop a good join), so every
+// join pays the flat ~6s. A render lag beyond 6s is still caught by the lobby
+// check in changeLayout and ends as BotNotAccepted rather than a false
+// "removed".
 const JOIN_CONFIRM_DEBOUNCE_MS = 6000
 
 /**
@@ -394,27 +393,12 @@ export class MeetProvider implements MeetingProviderInterface {
         if (!nowInWaitingRoom && gracePeriodExpired) {
           const inMeeting = await isInMeeting(page)
           if (inMeeting) {
-            // Fast path: remote audio tracks only flow after real admission —
-            // Meet's lobby never receives conference media. The audio track
-            // layer is injected before navigation, so its backlog is readable
-            // here. Absence proves nothing (the PC hook misses tracks on a
-            // large share of calls), so no-tracks just falls through to the
-            // DOM debounce below.
-            const remoteAudioTracks = await page
-              .evaluate(
-                // biome-ignore lint/suspicious/noExplicitAny: browser-side global
-                () => ((window as any).__audioTrackLayer?.seenTracks || []).length
-              )
-              .catch(() => 0)
-            if (remoteAudioTracks > 0) {
-              botWasInMeeting = true
-              console.log(
-                `✅ Successfully confirmed we are in the meeting (fast path: ${remoteAudioTracks} remote audio track(s) flowing)`
-              )
-              onJoinSuccess()
-              await performCriticalSetupActions(page, dialogObserver)
-              break
-            }
+            // NOTE: do NOT add a "remote audio tracks = admitted" fast path
+            // here. Meet's lobby/pre-join DOES receive PeerConnection audio
+            // tracks (observed in prod: 3 receiver tracks while still on the
+            // "Please wait…" screen), so a non-empty track backlog is not
+            // proof of admission and bypassing the debounce on it causes
+            // false joins that end as spurious bot_rejected.
             // Debounce the confirmation: a single clean sample can land in the
             // window where the lobby's call-control DOM is up but its text is
             // not (see JOIN_CONFIRM_DEBOUNCE_MS). Confirm only when a second

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -394,14 +394,15 @@ export class MeetProvider implements MeetingProviderInterface {
           const inMeeting = await isInMeeting(page)
           if (inMeeting) {
             // NOTE: do NOT add a "remote audio tracks = admitted" fast path
-            // here. Tracks start flowing at the moment of admission, but
-            // Meet's lobby UI can stay visibly on screen for several more
-            // seconds (observed in prod: "Please wait…" text still visible
-            // 7s after admission). Confirming on tracks while that UI
-            // lingers makes the post-confirm lobby check read the leftover
-            // UI as "never admitted" and kill a live join as bot_rejected.
-            // Waiting for the lobby UI to clear (this debounce) is the only
-            // ordering that is safe on both sides.
+            // here. Prod (2026-08-11, 12 killed joins) showed the track
+            // backlog reads exactly 3 in the lobby-adjacent state — Meet
+            // pre-allocates 3 audio transceivers, so track count is NOT
+            // admission evidence. Never-admitted lobby bots also render the
+            // full call-control DOM (Leave call included) and keep the
+            // "Please wait…" text in the DOM, so neither tracks nor
+            // in-meeting selectors can distinguish lobby from admitted.
+            // The only safe gate is this debounce: no confirm while the
+            // lobby text is detectable, sustained across samples.
             // Debounce the confirmation: a single clean sample can land in the
             // window where the lobby's call-control DOM is up but its text is
             // not (see JOIN_CONFIRM_DEBOUNCE_MS). Confirm only when a second

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -394,11 +394,14 @@ export class MeetProvider implements MeetingProviderInterface {
           const inMeeting = await isInMeeting(page)
           if (inMeeting) {
             // NOTE: do NOT add a "remote audio tracks = admitted" fast path
-            // here. Meet's lobby/pre-join DOES receive PeerConnection audio
-            // tracks (observed in prod: 3 receiver tracks while still on the
-            // "Please wait…" screen), so a non-empty track backlog is not
-            // proof of admission and bypassing the debounce on it causes
-            // false joins that end as spurious bot_rejected.
+            // here. Tracks start flowing at the moment of admission, but
+            // Meet's lobby UI can stay visibly on screen for several more
+            // seconds (observed in prod: "Please wait…" text still visible
+            // 7s after admission). Confirming on tracks while that UI
+            // lingers makes the post-confirm lobby check read the leftover
+            // UI as "never admitted" and kill a live join as bot_rejected.
+            // Waiting for the lobby UI to clear (this debounce) is the only
+            // ordering that is safe on both sides.
             // Debounce the confirmation: a single clean sample can land in the
             // window where the lobby's call-control DOM is up but its text is
             // not (see JOIN_CONFIRM_DEBOUNCE_MS). Confirm only when a second

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -254,7 +254,8 @@ export class MeetProvider implements MeetingProviderInterface {
     page: Page,
     cancelCheck: () => boolean,
     onJoinSuccess: () => void,
-    dialogObserver?: SimpleDialogObserver
+    dialogObserver?: SimpleDialogObserver,
+    onAdmissionDetected?: () => void
   ): Promise<void> {
     try {
       // Capture DOM state before starting join process
@@ -375,6 +376,11 @@ export class MeetProvider implements MeetingProviderInterface {
         if (inWaitingRoom && !nowInWaitingRoom && !leftWaitingRoomAt) {
           leftWaitingRoomAt = Date.now()
           console.log("✅ Left waiting room, giving UI 2 seconds to fully render...")
+          // Admission observed but confirmation (grace + debounce) still
+          // pending — let the caller extend its waiting-room deadline so a
+          // host admitting near the timeout doesn't get TimeoutWaitingToStart
+          // while we are mid-confirmation.
+          onAdmissionDetected?.()
         }
 
         // Only retry clicking join button if NOT in waiting room

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -41,6 +41,12 @@ const GRACE_PERIOD_MS = 1000 // Grace period after leaving waiting room before c
 // check in changeLayout and ends as BotNotAccepted rather than a false
 // "removed".
 const JOIN_CONFIRM_DEBOUNCE_MS = 6000
+// A bot that never saw the lobby cannot tell an open meeting from a lobby
+// whose text hasn't rendered yet — prod kills showed text arriving up to
+// 6.4s after the first clean sample, past the 6s window. A bot that DID see
+// the lobby and watched it clear is in the trusted case (admitted meetings
+// never re-show the text; 76/76 sampled), so it keeps the shorter window.
+const JOIN_CONFIRM_DEBOUNCE_NO_LOBBY_SEEN_MS = 10000
 
 /**
  * Checks that the page is still on meet.google.com.
@@ -407,12 +413,18 @@ export class MeetProvider implements MeetingProviderInterface {
             // window where the lobby's call-control DOM is up but its text is
             // not (see JOIN_CONFIRM_DEBOUNCE_MS). Confirm only when a second
             // clean sample arrives at least that long after the first.
+            // Observed lobby→clear transition = trusted admission signal
+            // (shorter window). Never saw the lobby = could be an open
+            // meeting OR a lobby with late-rendering text (longer window).
+            const debounceMs = leftWaitingRoomAt
+              ? JOIN_CONFIRM_DEBOUNCE_MS
+              : JOIN_CONFIRM_DEBOUNCE_NO_LOBBY_SEEN_MS
             if (firstCleanConfirmAt === null) {
               firstCleanConfirmAt = Date.now()
               console.log(
-                `⏳ In-meeting sample clean, debouncing join confirm for ${JOIN_CONFIRM_DEBOUNCE_MS}ms...`
+                `⏳ In-meeting sample clean, debouncing join confirm for ${debounceMs}ms (lobby transition ${leftWaitingRoomAt ? "observed" : "not observed"})...`
               )
-            } else if (Date.now() - firstCleanConfirmAt >= JOIN_CONFIRM_DEBOUNCE_MS) {
+            } else if (Date.now() - firstCleanConfirmAt >= debounceMs) {
               botWasInMeeting = true
               console.log(
                 `✅ Successfully confirmed we are in the meeting (debounced ${Date.now() - firstCleanConfirmAt}ms; grace period: ${!leftWaitingRoomAt ? "not in waiting room" : `expired after ${Date.now() - leftWaitingRoomAt}ms`})`

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -381,7 +381,7 @@ export class WaitingRoomState extends BaseState {
     let joinSuccessful = false // Flag indicating we joined the meeting
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      const onWaitingRoomTimeout = () => {
         if (!joinSuccessful) {
           // Trigger the timeout only if we are not in the meeting
           GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
@@ -389,7 +389,27 @@ export class WaitingRoomState extends BaseState {
           console.error("Waiting room timeout reached", timeoutError)
           reject(timeoutError)
         }
-      }, timeoutMs)
+      }
+      const deadlineAt = Date.now() + timeoutMs
+      let timeout = setTimeout(onWaitingRoomTimeout, timeoutMs)
+      // Admission can be observed seconds before the join is confirmed (Meet
+      // holds the confirmation through a grace period + debounce). If the
+      // host admits close to the deadline, guarantee the confirmation window
+      // instead of firing TimeoutWaitingToStart mid-confirmation. Extend-only.
+      const ADMISSION_CONFIRM_GRACE_MS = 30_000
+      let admissionGraceApplied = false
+      const onAdmissionDetected = () => {
+        if (admissionGraceApplied || joinSuccessful) return
+        admissionGraceApplied = true
+        const remaining = deadlineAt - Date.now()
+        if (remaining < ADMISSION_CONFIRM_GRACE_MS) {
+          console.info(
+            `Admission detected with ${remaining}ms left on the waiting-room timeout — extending to ${ADMISSION_CONFIRM_GRACE_MS}ms for join confirmation`
+          )
+          clearTimeout(timeout)
+          timeout = setTimeout(onWaitingRoomTimeout, ADMISSION_CONFIRM_GRACE_MS)
+        }
+      }
 
       const checkStopSignal = setInterval(() => {
         if (
@@ -422,7 +442,8 @@ export class WaitingRoomState extends BaseState {
             }
             setDirectMode()
           },
-          this.context.dialogObserver
+          this.context.dialogObserver,
+          onAdmissionDetected
         )
         .then(() => {
           clearInterval(checkStopSignal)

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,11 @@ export interface MeetingProviderInterface {
     page: Page,
     cancelCheck: () => boolean,
     onJoinSuccess: () => void,
-    dialogObserver?: import("./services/dialog-observer/simple-dialog-observer").SimpleDialogObserver
+    dialogObserver?: import("./services/dialog-observer/simple-dialog-observer").SimpleDialogObserver,
+    // Fired when admission is DETECTED but not yet confirmed (e.g. Meet's
+    // lobby cleared while the join-confirm debounce is still running) so the
+    // caller can keep its waiting-room deadline from expiring mid-confirmation.
+    onAdmissionDetected?: () => void
   ): Promise<void>
   findEndMeeting(page: Page, opts?: { ignoreAloneSignals?: boolean }): Promise<boolean>
   parseMeetingUrl(meeting_url: string): Promise<{ meetingId: string; password: string }>


### PR DESCRIPTION
## Prod incident + control-group verification (final analysis)

Since #282 rolled (2026-08-10), 12 Meet bots (11 production, 1 test) died in a new pattern:

```
confirm via fast path ("3 remote audio track(s) flowing")   ← always exactly 3
+3.2–6.4s: lobby text detected → "never admitted" → botNotAccepted → Bot Rejected at ~30s
```

All 12 terminal (`recording_failed`, zero recoveries). Zero such kills via debounce-confirmed joins — the fast path is the sole enabler, 12/12.

**Control-group check (48h: 20 denial bots, 106 waiting-room-timeout bots, DOM snapshots replayed against our exact selectors):** never-admitted lobby bots render the full call-control DOM (incl. "Leave call") and keep the "Please wait…" text — the identical fingerprint of the 12 kills. Meaning:

- Track count is not admission evidence: the constant `3` matches Meet pre-allocating 3 audio transceivers, present in the lobby-adjacent state.
- In-meeting DOM selectors are not admission evidence either (confirming the pre-#282 code comment about the lobby rendering call controls).
- Whether any of the 12 were genuinely admitted at kill time is indeterminate from available data — one was reported as admitted by the meeting host, but the host-side click plausibly landed as/after the bot quit.

**Both candidate stories are fixed by the same change**: with the fast path removed, the join cannot confirm while lobby text is detectable — a late-rendering lobby resets the debounce (bot keeps waiting for admission), and a genuinely admitted join confirms ~6s after the lobby text clears. The post-confirm lobby check in `changeLayout` loses its trigger population entirely (0 of 12 kills would have occurred).

## Follow-up (separate design discussion)

The `changeLayout` lobby check still *terminates* (`botNotAccepted`) rather than returning the bot to a waiting state. With the fast path gone this is near-unreachable, but resuming the wait would be strictly safer; requires re-arming the waiting-room timeout after `onJoinSuccess`.

## Validation

- `npx tsc --noEmit`: 0 errors (baseline 0).
- Prod audit: 74 `bot_rejected` bots (48h) classified; 20 genuine denials unaffected by this change; 10 transient-reject-then-recovered bots unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
