### PR TITLE
feat(meet): network speaker detection via the dcrpc datachannel (NetEq sessions)

### DIFF
--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -1197,6 +1197,14 @@ export function browserInterceptionLogic(schema: any[]) {
           }
 
           try {
+            // CollectionEvents are always zlib/gzip framed (magic 0x1f8b or
+            // 0x78). Since createDataChannel now wraps every locally-created
+            // channel, this branch also sees channels that never carry
+            // CollectionEvents — skip those instead of inflating and logging a
+            // decode error per message for the whole session.
+            if (rawData.length < 2 || (rawData[0] !== 0x1f && rawData[0] !== 0x78)) {
+              return
+            }
             // Defensive check for pako availability
             if (
               typeof (window as any).pako === "undefined" ||

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -126,7 +126,12 @@ export function browserInterceptionLogic(schema: any[]) {
     function createReceiverManager() {
       return {
         receiverMap: new Map(),
-        receiverToTrackMap: new Map()
+        receiverToTrackMap: new Map(),
+        // performance.now() when we last mirrored each receiver's sources. The
+        // CSRC entries carry their own `timestamp`, but on a different clock
+        // (not performance.now()), so gating freshness on it filtered out every
+        // live source. Stamp arrival ourselves and gate on that instead.
+        sourceStamp: new Map()
       }
     }
 
@@ -144,6 +149,7 @@ export function browserInterceptionLogic(schema: any[]) {
       contributingSources: any
     ) {
       receiverManager.receiverMap.set(receiver, contributingSources)
+      receiverManager.sourceStamp.set(receiver, performance.now())
     }
 
     function getContributingSources(receiverManager: any, receiver: any) {
@@ -151,6 +157,9 @@ export function browserInterceptionLogic(schema: any[]) {
     }
 
     function linkReceiverToTrack(receiverManager: any, receiver: any, trackId: any) {
+      // Tapped tracks (NetEq destination) arrive with no receiver — linking
+      // them under a shared null key would just overwrite each other.
+      if (!receiver) return
       receiverManager.receiverToTrackMap.set(receiver, trackId)
     }
 
@@ -222,8 +231,12 @@ export function browserInterceptionLogic(schema: any[]) {
       const originalGetContributingSources = OriginalRTCRtpReceiver.prototype.getContributingSources
       OriginalRTCRtpReceiver.prototype.getContributingSources = function (...args: any[]) {
         const result = originalGetContributingSources.apply(this, args)
-        if (onGetContributingSources && result && result.length > 0) {
-          onGetContributingSources(this, result)
+        // Mirror EVERY call, including empty results: an empty array is Meet
+        // telling us the previous speaker went quiet, and skipping it would
+        // leave a stale non-empty array in the mirror for the CSRC sampler to
+        // read (its freshness gate catches most of this, clearing is exact).
+        if (onGetContributingSources) {
+          onGetContributingSources(this, result || [])
         }
         return result
       }
@@ -371,6 +384,61 @@ export function browserInterceptionLogic(schema: any[]) {
         users,
         timestamp: Date.now(),
         source
+      })
+    }
+
+    // Emit a speaker update derived from the dcrpc datachannel (NetEq sessions).
+    // Uses the same NetworkUser[] shape and "audio" source as the CSRC path, so
+    // it flows through SpeakerManager.handleNetworkSpeakerUpdate identically.
+    // Speaking device ids with no roster entry yet are still emitted (name
+    // "Unknown", real deviceId) so the opening seconds are not dropped — the
+    // finalize step relabels those segments by device once the roster resolves.
+    // The `dcrpc: true` marker lets the node side note that the network path is
+    // alive on NetEq without changing how the update is processed.
+    function broadcastDcrpcSpeakers(userManager: any, speakingIds: string[]): void {
+      if ((window as any).__networkInterceptorStopped) return
+      if (typeof (window as any).onNetworkSpeakerUpdate !== "function") return
+
+      const speakingSet = new Set(speakingIds)
+      const filteredUsers = filterActiveUsers(getAllUsers(userManager))
+      const seen = new Set<string>()
+      const users = filteredUsers.map((user: any) => {
+        seen.add(user.deviceId)
+        const isSpeaking = speakingSet.has(user.deviceId)
+        return {
+          deviceId: user.deviceId,
+          name: decodeUserName(user),
+          isCurrentUser: user.isCurrentUserString === "true" || user.isCurrentUserString === "1",
+          isSpeaking,
+          status: user.status,
+          isHost: user.isHost === 1,
+          audioLevel: isSpeaking ? 1 : 0,
+          fullName: decodeFullName(user),
+          displayName: user.displayName,
+          profilePicture: user.profilePicture
+        }
+      })
+      for (const deviceId of speakingIds) {
+        if (seen.has(deviceId)) continue
+        users.push({
+          deviceId,
+          name: "Unknown",
+          isCurrentUser: false,
+          isSpeaking: true,
+          status: 1,
+          isHost: false,
+          audioLevel: 1,
+          fullName: undefined,
+          displayName: undefined,
+          profilePicture: undefined
+        })
+      }
+
+      ;(window as any).onNetworkSpeakerUpdate({
+        users,
+        timestamp: Date.now(),
+        source: "audio",
+        dcrpc: true
       })
     }
 
@@ -797,6 +865,9 @@ export function browserInterceptionLogic(schema: any[]) {
     const speakingState = new Map<string, boolean>()
     // Track last broadcasted speaker to avoid duplicate broadcasts
     let lastBroadcastedSpeakerId: string | null = null
+    // Last set of speaking device ids emitted from the dcrpc path (sorted,
+    // joined). dcrpc only drives an update when this set changes.
+    let lastDcrpcSpeakingKey: string | null = null
     // Track AbortControllers for audio processing loops (one per track)
     // Allows cancelling background processing when tracks end or are replaced
     const trackAbortControllers = new Map<string, AbortController>()
@@ -815,9 +886,59 @@ export function browserInterceptionLogic(schema: any[]) {
       tracksDeliveringFrames.delete(trackId)
     }
 
-    setupRTCRtpReceiverInterceptor((receiver, contributingSources) => {
+    setupRTCRtpReceiverInterceptor((receiver: any, contributingSources: any) => {
       updateContributingSources(receiverManager, receiver, contributingSources)
     })
+
+    // Frame-independent CSRC speaker sampling. The frame loop only consults
+    // contributing sources while audio frames flow, but prod shows sessions
+    // where frames stall while Meet's own client keeps polling
+    // getContributingSources (mirrored into receiverManager above, with real
+    // audioLevel values). Sample the mirror on a timer and drive the same
+    // speaker state the frame loop uses; the shared lastBroadcastedSpeakerId
+    // makes the two paths dedupe against each other.
+    //
+    // Freshness gate uses OUR arrival stamp (see sourceStamp): a receiver we
+    // mirrored in the last 2s is live; the CSRC entry's own `timestamp` is on a
+    // different clock and gating on it dropped every source.
+    const csrcSampleInterval = setInterval(() => {
+      if ((window as any).__networkInterceptorStopped) return
+      try {
+        const freshSources: any[] = []
+        const now = performance.now()
+        for (const [receiver, sources] of receiverManager.receiverMap) {
+          const stamp = receiverManager.sourceStamp.get(receiver)
+          if (stamp === undefined || now - stamp >= 2000) continue
+          for (const s of sources || []) {
+            if (s) freshSources.push(s)
+          }
+        }
+        if (freshSources.length === 0) return
+
+        const usersWithAudioLevels = getUsersWithAudio(freshSources, userManager)
+        const loudestSpeaker = usersWithAudioLevels[0]
+        if (loudestSpeaker?.user) {
+          const currentSpeakerId = loudestSpeaker.user.deviceId
+          if (currentSpeakerId !== lastBroadcastedSpeakerId) {
+            console.error(
+              `[NetworkInterceptor] 🎤 Speaker changed (csrc sample): ${lastBroadcastedSpeakerId || "none"} → ${currentSpeakerId} (audioLevel: ${loudestSpeaker.audioLevel})`
+            )
+            lastBroadcastedSpeakerId = currentSpeakerId
+            speakingState.clear()
+            speakingState.set(currentSpeakerId, true)
+            broadcastSpeakerUpdate(userManager, currentSpeakerId, loudestSpeaker.audioLevel, "audio")
+          }
+        } else if (lastBroadcastedSpeakerId !== null) {
+          // Fresh packets but nobody above the audio-level threshold — mirrors
+          // the frame loop's clearing rule for active audio with no speaker.
+          lastBroadcastedSpeakerId = null
+          speakingState.clear()
+          broadcastSpeakerUpdate(userManager, null, 0, "audio")
+        }
+      } catch {
+        // Sampling must never break the interceptor.
+      }
+    }, 500)
 
     const broadcastCurrentState = () => {
       try {
@@ -886,6 +1007,7 @@ export function browserInterceptionLogic(schema: any[]) {
 
       // Set flag to prevent further callbacks
       ;(window as any).__networkInterceptorStopped = true
+      clearInterval(csrcSampleInterval)
 
       console.error("[NetworkInterceptor] ✅ Network interception stopped")
     }
@@ -1013,6 +1135,131 @@ export function browserInterceptionLogic(schema: any[]) {
       reportHealthCheck()
     }, 10000)
 
+    // Decode the active-speaker state carried on the dcrpc datachannel (NetEq
+    // sessions). Returns the sorted set of speaking device ids for dedupe, or
+    // null when the frame is a keepalive / not a state frame.
+    function handleDcrpcFrame(rawData: Uint8Array): void {
+      const decode = (window as any).__decodeDcrpcFrame
+      const pako = (window as any).pako
+      if (typeof decode !== "function" || !pako || typeof pako.inflate !== "function") {
+        return
+      }
+      let participants: Array<{ deviceId: string; speaking: boolean }> | null
+      try {
+        participants = decode(rawData, pako.inflate)
+      } catch {
+        return
+      }
+      if (participants === null) return // keepalive / non-state frame
+
+      const speakingIds: string[] = []
+      for (const p of participants) {
+        if (p.speaking) speakingIds.push(p.deviceId)
+      }
+      speakingIds.sort()
+      const key = speakingIds.join("|")
+      if (key === lastDcrpcSpeakingKey) return
+      lastDcrpcSpeakingKey = key
+      broadcastDcrpcSpeakers(userManager, speakingIds)
+    }
+
+    // Decode one datachannel message. Shared by every path a channel can reach
+    // us — the passive "datachannel" event (remote-created channels) AND
+    // createDataChannel (channels Meet builds locally, which the event never
+    // fires for; missing those meant no roster/chat/speaker data at all on those
+    // sessions). Deduped via a WeakSet so a channel is only wired once.
+    const handledChannels = new WeakSet<any>()
+    function attachDcHandler(channel: any, label: string) {
+      if (!channel || handledChannels.has(channel)) return
+      handledChannels.add(channel)
+      allDataChannels.set(label, channel)
+
+      console.error(`[NetworkInterceptor] 🔌 DataChannel attached: "${label}"`)
+
+      if (label === "meet_messages") {
+        meetMessagesDataChannel = channel
+        console.error("[NetworkInterceptor] 💬 Chat channel ready")
+      }
+      channel.addEventListener("message", (msg: any) => {
+        try {
+          const rawData = new Uint8Array(msg.data)
+
+          // dcrpc carries the live active-speaker signal on NetEq sessions. Its
+          // frames are gzip'd per-participant state, not CollectionEvents, so
+          // they never reach the collections decode below — handle them here.
+          if (label === "dcrpc") {
+            try {
+              handleDcrpcFrame(rawData)
+            } catch (e) {
+              console.error("[NetworkInterceptor] dcrpc decode error:", e)
+            }
+            return
+          }
+
+          try {
+            // Defensive check for pako availability
+            if (
+              typeof (window as any).pako === "undefined" ||
+              typeof (window as any).pako.inflate !== "function"
+            ) {
+              console.error(
+                "[NetworkInterceptor] ⚠️ CRITICAL: pako library or pako.inflate function is not available"
+              )
+              console.warn(
+                "[NetworkInterceptor] ⚠️ Cannot decode message - pako is required for decompression"
+              )
+              throw new Error("pako.inflate is not available")
+            }
+            const inflated = (window as any).pako.inflate(rawData)
+            const eventData = messageDecoders["CollectionEvent"](inflated)
+            const body = eventData.body
+            if (body) {
+              const wrapper = body.userInfoListWrapperAndChatWrapperWrapper
+              if (wrapper?.deviceInfoWrapper?.deviceOutputInfoList) {
+                const deviceOutputs = wrapper.deviceInfoWrapper.deviceOutputInfoList
+                updateDeviceOutputs(userManager, deviceOutputs)
+              }
+              if (wrapper?.userInfoListWrapperAndChatWrapper?.userInfoListWrapper?.userInfoList) {
+                const users =
+                  wrapper.userInfoListWrapperAndChatWrapper.userInfoListWrapper.userInfoList
+                updateUsers(userManager, users)
+                console.error(`[NetworkInterceptor] 👥 Updated ${users.length} users`)
+              }
+
+              // Extract chat messages
+              const chatMessages = wrapper?.userInfoListWrapperAndChatWrapper?.chatMessageWrapper
+              if (chatMessages && chatMessages.length > 0) {
+                for (const chatMsgWrapper of chatMessages) {
+                  const chatMsg = chatMsgWrapper.chatMessage
+                  if (chatMsg && chatMsg.chatMessageContent?.text) {
+                    const senderUser = userManager.allUsersMap.get(chatMsg.deviceId)
+                    const senderName = senderUser ? decodeUserName(senderUser) : "Unknown"
+
+                    if (typeof (window as any).onChatMessageReceived === "function") {
+                      ;(window as any).onChatMessageReceived({
+                        messageId: chatMsg.messageId,
+                        deviceId: chatMsg.deviceId,
+                        timestamp: chatMsg.timestamp,
+                        text: chatMsg.chatMessageContent.text,
+                        senderName: senderName
+                      })
+                    }
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            console.error(
+              `[NetworkInterceptor] ⚠️ Failed to decode collections message on "${label}":`,
+              e
+            )
+          }
+        } catch (e) {
+          console.error("[NetworkInterceptor] Critical Message Error:", e)
+        }
+      })
+    }
+
     // Intercept RTCPeerConnection for datachannel only (track handling now centralized)
     if (typeof (window as any).RTCPeerConnection !== "undefined") {
       const OriginalPC = (window as any).RTCPeerConnection
@@ -1023,84 +1270,24 @@ export function browserInterceptionLogic(schema: any[]) {
         // Track whether we"ve attempted proactive creation for this PC instance
         let hasAttemptedProactiveCreation = false
 
-        // Only handle dataChannel - tracks are handled by centralized layer
-        pc.addEventListener("datachannel", (event: any) => {
-          const label = event.channel.label
-          allDataChannels.set(label, event.channel)
-
-          console.error(`[NetworkInterceptor] 🔌 DataChannel attached: "${label}"`)
-
-          if (label === "meet_messages") {
-            meetMessagesDataChannel = event.channel
-            console.error("[NetworkInterceptor] 💬 Chat channel ready")
+        // Locally-created channels (Meet builds meet_messages and dcrpc itself
+        // in many sessions) never fire the "datachannel" event — catch them at
+        // the source so roster/chat/speaker data flows on every session.
+        const originalCreateDataChannel = pc.createDataChannel.bind(pc)
+        pc.createDataChannel = (dcLabel: string, dcOpts: any) => {
+          const channel = originalCreateDataChannel(dcLabel, dcOpts)
+          try {
+            console.error(`[NetworkInterceptor] 🔌 DataChannel created locally: "${dcLabel}"`)
+            attachDcHandler(channel, dcLabel)
+          } catch (e) {
+            console.error("[NetworkInterceptor] Error attaching to created channel:", e)
           }
-          event.channel.addEventListener("message", (msg: any) => {
-            try {
-              const rawData = new Uint8Array(msg.data)
-              try {
-                // Defensive check for pako availability
-                if (
-                  typeof (window as any).pako === "undefined" ||
-                  typeof (window as any).pako.inflate !== "function"
-                ) {
-                  console.error(
-                    "[NetworkInterceptor] ⚠️ CRITICAL: pako library or pako.inflate function is not available"
-                  )
-                  console.warn(
-                    "[NetworkInterceptor] ⚠️ Cannot decode message - pako is required for decompression"
-                  )
-                  throw new Error("pako.inflate is not available")
-                }
-                const inflated = (window as any).pako.inflate(rawData)
-                const eventData = messageDecoders["CollectionEvent"](inflated)
-                const body = eventData.body
-                if (body) {
-                  const wrapper = body.userInfoListWrapperAndChatWrapperWrapper
-                  if (wrapper?.deviceInfoWrapper?.deviceOutputInfoList) {
-                    const deviceOutputs = wrapper.deviceInfoWrapper.deviceOutputInfoList
-                    updateDeviceOutputs(userManager, deviceOutputs)
-                  }
-                  if (
-                    wrapper?.userInfoListWrapperAndChatWrapper?.userInfoListWrapper?.userInfoList
-                  ) {
-                    const users =
-                      wrapper.userInfoListWrapperAndChatWrapper.userInfoListWrapper.userInfoList
-                    updateUsers(userManager, users)
-                    console.error(`[NetworkInterceptor] 👥 Updated ${users.length} users`)
-                  }
+          return channel
+        }
 
-                  // Extract chat messages
-                  const chatMessages = wrapper?.userInfoListWrapperAndChatWrapper?.chatMessageWrapper
-                  if (chatMessages && chatMessages.length > 0) {
-                    for (const chatMsgWrapper of chatMessages) {
-                      const chatMsg = chatMsgWrapper.chatMessage
-                      if (chatMsg && chatMsg.chatMessageContent?.text) {
-                        const senderUser = userManager.allUsersMap.get(chatMsg.deviceId)
-                        const senderName = senderUser ? decodeUserName(senderUser) : "Unknown"
-
-                        if (typeof (window as any).onChatMessageReceived === "function") {
-                          ;(window as any).onChatMessageReceived({
-                            messageId: chatMsg.messageId,
-                            deviceId: chatMsg.deviceId,
-                            timestamp: chatMsg.timestamp,
-                            text: chatMsg.chatMessageContent.text,
-                            senderName: senderName,
-                          })
-                        }
-                      }
-                    }
-                  }
-                }
-              } catch (e) {
-                console.error(
-                  `[NetworkInterceptor] ⚠️ Failed to decode collections message on "${label}":`,
-                  e
-                )
-              }
-            } catch (e) {
-              console.error("[NetworkInterceptor] Critical Message Error:", e)
-            }
-          })
+        // Passive path: remotely-created channels.
+        pc.addEventListener("datachannel", (event: any) => {
+          attachDcHandler(event.channel, event.channel.label)
         })
 
         // Proactive channel creation (disabled by default)
@@ -1266,6 +1453,7 @@ export function browserInterceptionLogic(schema: any[]) {
     window.addEventListener("beforeunload", () => {
       clearInterval(broadcastIntervalId)
       clearTimeout(broadcastTimeoutId)
+      clearInterval(csrcSampleInterval)
       if (healthCheckInterval !== null) {
         clearInterval(healthCheckInterval)
       }

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -1197,12 +1197,19 @@ export function browserInterceptionLogic(schema: any[]) {
           }
 
           try {
-            // CollectionEvents are always zlib/gzip framed (magic 0x1f8b or
-            // 0x78). Since createDataChannel now wraps every locally-created
-            // channel, this branch also sees channels that never carry
-            // CollectionEvents — skip those instead of inflating and logging a
-            // decode error per message for the whole session.
-            if (rawData.length < 2 || (rawData[0] !== 0x1f && rawData[0] !== 0x78)) {
+            // CollectionEvents are always zlib/gzip framed. Since
+            // createDataChannel now wraps every locally-created channel, this
+            // branch also sees channels that never carry CollectionEvents — skip
+            // those instead of inflating and logging a decode error per message
+            // for the whole session. Match the full gzip signature (0x1f 0x8b),
+            // not just the first byte, and validate the zlib header checksum.
+            const isGzip =
+              rawData.length >= 2 && rawData[0] === 0x1f && rawData[1] === 0x8b
+            const isZlib =
+              rawData.length >= 2 &&
+              rawData[0] === 0x78 &&
+              (((rawData[0] << 8) | rawData[1]) % 31 === 0)
+            if (!isGzip && !isZlib) {
               return
             }
             // Defensive check for pako availability

--- a/src/meeting/meet/network-interception/dcrpc-decoder.test.ts
+++ b/src/meeting/meet/network-interception/dcrpc-decoder.test.ts
@@ -1,0 +1,113 @@
+import pako from "pako"
+import protobuf from "protobufjs"
+import { decodeDcrpcFrame } from "./dcrpc-decoder"
+
+// Wire-format helpers built with protobufjs so the fixture is a real, byte-exact
+// dcrpc frame rather than a hand-typed byte array.
+
+function tag(fieldNumber: number, wireType: number): number {
+  return (fieldNumber << 3) | wireType
+}
+
+/** "active" message: presence of field 2 (varint) means speaking. */
+function activeMessage(): Uint8Array {
+  const w = protobuf.Writer.create()
+  w.uint32(tag(2, 0)).uint32(1)
+  return w.finish()
+}
+
+/** One participant record: field 4 = device id, field 9 = active (optional). */
+function participant(deviceId: string, speaking: boolean): Uint8Array {
+  const w = protobuf.Writer.create()
+  w.uint32(tag(4, 2)).string(deviceId)
+  if (speaking) {
+    w.uint32(tag(9, 2)).bytes(activeMessage())
+  }
+  return w.finish()
+}
+
+/** Wrap a payload as a single length-delimited field. */
+function wrapField(fieldNumber: number, payload: Uint8Array): Uint8Array {
+  const w = protobuf.Writer.create()
+  w.uint32(tag(fieldNumber, 2)).bytes(payload)
+  return w.finish()
+}
+
+/**
+ * Build the inflated state snapshot:
+ *   field 2 { field 2 { field 4(repeated participant) } }
+ */
+function buildInflatedSnapshot(participants: Uint8Array[]): Uint8Array {
+  const inner = protobuf.Writer.create()
+  for (const p of participants) {
+    inner.uint32(tag(4, 2)).bytes(p)
+  }
+  const participantsBlock = inner.finish()
+  const body = wrapField(2, participantsBlock) // field 2 -> participants block
+  return wrapField(2, body) // field 2 -> body
+}
+
+/** Build a full dcrpc state frame: field 2 = gzip(inflated snapshot). */
+function buildStateFrame(participants: Uint8Array[]): Uint8Array {
+  const inflated = buildInflatedSnapshot(participants)
+  const gzipped = pako.gzip(inflated)
+  expect(gzipped[0]).toBe(0x1f)
+  expect(gzipped[1]).toBe(0x8b)
+  return wrapField(2, gzipped)
+}
+
+describe("decodeDcrpcFrame", () => {
+  it("decodes speaking state from a gzip'd protobuf state frame", () => {
+    const frame = buildStateFrame([
+      participant("device-aaa", true),
+      participant("device-bbb", false)
+    ])
+
+    const result = decodeDcrpcFrame(frame, pako.inflate)
+
+    expect(result).toEqual([
+      { deviceId: "device-aaa", speaking: true },
+      { deviceId: "device-bbb", speaking: false }
+    ])
+  })
+
+  it("returns null for a keepalive frame (field 1 only)", () => {
+    const w = protobuf.Writer.create()
+    w.uint32(tag(1, 0)).uint32(42)
+    const keepalive = w.finish()
+
+    expect(decodeDcrpcFrame(keepalive, pako.inflate)).toBeNull()
+  })
+
+  it("returns an empty array when the snapshot carries no participants", () => {
+    const frame = buildStateFrame([])
+    expect(decodeDcrpcFrame(frame, pako.inflate)).toEqual([])
+  })
+
+  it("tolerates an uncompressed (non-gzip) field-2 blob", () => {
+    const inflated = buildInflatedSnapshot([participant("device-ccc", true)])
+    const frame = wrapField(2, inflated) // no gzip
+    const inflate = jest.fn(() => {
+      throw new Error("inflate should not be called for non-gzip blobs")
+    })
+
+    const result = decodeDcrpcFrame(frame, inflate as unknown as (b: Uint8Array) => Uint8Array)
+
+    expect(inflate).not.toHaveBeenCalled()
+    expect(result).toEqual([{ deviceId: "device-ccc", speaking: true }])
+  })
+
+  it("finds participants even with an extra wrapper level (defensive walk)", () => {
+    // field 2 { field 2 { field 2 { field 4(participant) } } } — one level deeper
+    // than the common layout, to prove the walk is not depth-locked.
+    const inner = protobuf.Writer.create()
+    inner.uint32(tag(4, 2)).bytes(participant("device-ddd", true))
+    const deep = wrapField(2, wrapField(2, wrapField(2, inner.finish())))
+    const gzipped = pako.gzip(deep)
+    const frame = wrapField(2, gzipped)
+
+    expect(decodeDcrpcFrame(frame, pako.inflate)).toEqual([
+      { deviceId: "device-ddd", speaking: true }
+    ])
+  })
+})

--- a/src/meeting/meet/network-interception/dcrpc-decoder.ts
+++ b/src/meeting/meet/network-interception/dcrpc-decoder.ts
@@ -185,7 +185,12 @@ export function decodeDcrpcFrame(
     let inflated = entry.bytes
     if (inflated.length >= 2 && inflated[0] === 0x1f && inflated[1] === 0x8b) {
       try {
-        inflated = inflate(inflated)
+        // pako.inflate can return undefined (not throw) for a truncated payload
+        // with a valid gzip header. Skipping keeps the never-throws contract and
+        // lets the remaining field2 entries decode.
+        const result = inflate(inflated)
+        if (!result || result.length === 0) continue
+        inflated = result
       } catch {
         continue
       }

--- a/src/meeting/meet/network-interception/dcrpc-decoder.ts
+++ b/src/meeting/meet/network-interception/dcrpc-decoder.ts
@@ -1,0 +1,196 @@
+// Decoder for Google Meet's `dcrpc` datachannel frames.
+//
+// On the NetEq media stack (server-side mixed audio, no per-participant WebRTC
+// tracks) the classic CSRC/audioLevel speaker path is blind. The live
+// active-speaker signal instead rides the `dcrpc` datachannel: each state frame
+// carries a per-participant record with a "speaking" flag. Joined with the
+// roster (deviceId -> name, decoded from the `collections` channel) this yields
+// named active speakers from the network on sessions where nothing else can.
+//
+// Wire format (one top-level field per frame):
+//   field 1        -> keepalive counter (ignore)
+//   field 2        -> GZIP-compressed (magic 1f 8b) protobuf state snapshot
+//     After inflation, participant records live under a small chain of
+//     length-delimited wrappers, each a repeated record with:
+//       field 4 (string) -> device id
+//       field 8 (varint) -> numeric device id (unused here)
+//       field 9 (message)-> "active"; presence of its field 2 (varint) => SPEAKING
+//
+// The exact wrapper depth around the participant list has shifted between Meet
+// rollouts, so the walk is defensive: it looks for participant records at every
+// nesting level (descending through field-2 wrappers) and stops at the first
+// level that yields them, rather than hard-coding a fixed path. A record only
+// counts as a participant when its field 4 decodes as strict UTF-8, which
+// cleanly rejects binary sub-messages mis-read as strings.
+//
+// IMPORTANT: this function is self-contained (no imports, no closed-over
+// module state, only standard globals). It is stringified via
+// `decodeDcrpcFrame.toString()` and injected into the page as
+// `window.__decodeDcrpcFrame`, so it must keep working both in Node (tests) and
+// in the browser. All helpers are nested inside it for that reason.
+
+export type DcrpcParticipant = {
+  deviceId: string
+  speaking: boolean
+}
+
+/**
+ * Decode a raw `dcrpc` datachannel frame into per-participant speaking state.
+ *
+ * @param frame   the raw datachannel message bytes
+ * @param inflate gzip inflate (browser: `window.pako.inflate`, Node: `pako.inflate`)
+ * @returns array of participant records (possibly empty) for a state frame, or
+ *          `null` for a keepalive / non-state frame that should be ignored.
+ */
+export function decodeDcrpcFrame(
+  frame: Uint8Array,
+  inflate: (bytes: Uint8Array) => Uint8Array
+): DcrpcParticipant[] | null {
+  // --- minimal protobuf wire reader (varint + length-delimited only) ---
+  function readVarint(buf: Uint8Array, state: { pos: number }): number {
+    let result = 0
+    let shift = 0
+    let byte: number
+    do {
+      if (state.pos >= buf.length) throw new Error("varint past end of buffer")
+      byte = buf[state.pos++]
+      result += (byte & 0x7f) * 2 ** shift
+      shift += 7
+      // Guard against pathological length-prefixed garbage.
+      if (shift > 70) throw new Error("varint too long")
+    } while (byte & 0x80)
+    return result
+  }
+
+  type Field = { wt: number; val?: number; bytes?: Uint8Array }
+
+  // Parse one message into fieldNumber -> list of entries. Never throws:
+  // a malformed tail just ends parsing early.
+  function parseFields(buf: Uint8Array): { [field: number]: Field[] } {
+    const state = { pos: 0 }
+    const fields: { [field: number]: Field[] } = {}
+    while (state.pos < buf.length) {
+      let tag: number
+      try {
+        tag = readVarint(buf, state)
+      } catch {
+        break
+      }
+      const field = Math.floor(tag / 8)
+      const wt = tag % 8
+      let entry: Field | null = null
+      if (wt === 0) {
+        try {
+          entry = { wt, val: readVarint(buf, state) }
+        } catch {
+          break
+        }
+      } else if (wt === 2) {
+        let len: number
+        try {
+          len = readVarint(buf, state)
+        } catch {
+          break
+        }
+        if (len < 0 || state.pos + len > buf.length) break
+        entry = { wt, bytes: buf.subarray(state.pos, state.pos + len) }
+        state.pos += len
+      } else if (wt === 1) {
+        if (state.pos + 8 > buf.length) break
+        state.pos += 8
+        entry = { wt }
+      } else if (wt === 5) {
+        if (state.pos + 4 > buf.length) break
+        state.pos += 4
+        entry = { wt }
+      } else {
+        // Unknown / unsupported wire type (3, 4 groups) — stop, can't resync.
+        break
+      }
+      if (entry) {
+        if (!fields[field]) fields[field] = []
+        fields[field].push(entry)
+      }
+    }
+    return fields
+  }
+
+  const strictDecoder = new TextDecoder("utf-8", { fatal: true })
+
+  // A participant record has a device-id string at field 4 and, when speaking,
+  // a non-empty "active" message at field 9 (its field 2 varint present).
+  function tryParseParticipant(bytes: Uint8Array): DcrpcParticipant | null {
+    const fields = parseFields(bytes)
+    const f4 = fields[4]
+    if (!f4 || f4.length === 0 || f4[0].wt !== 2 || !f4[0].bytes || f4[0].bytes.length === 0) {
+      return null
+    }
+    let deviceId: string
+    try {
+      // Strict decode: real device ids are ASCII; binary sub-messages throw here
+      // and are rejected, which is how a wrapper level is told apart from a
+      // participant level.
+      deviceId = strictDecoder.decode(f4[0].bytes)
+    } catch {
+      return null
+    }
+    if (!deviceId) return null
+
+    let speaking = false
+    const f9 = fields[9]
+    if (f9 && f9.length > 0 && f9[0].wt === 2 && f9[0].bytes) {
+      const active = parseFields(f9[0].bytes)
+      if (active[2] && active[2].length > 0) speaking = true
+    }
+    return { deviceId, speaking }
+  }
+
+  // Descend through field-2 wrappers, stopping at the first level whose field-4
+  // entries parse as participant records.
+  function collectParticipants(bytes: Uint8Array, depth: number, out: DcrpcParticipant[]): void {
+    if (depth > 8) return
+    const fields = parseFields(bytes)
+
+    let found = false
+    const f4 = fields[4] || []
+    for (const entry of f4) {
+      if (entry.wt !== 2 || !entry.bytes) continue
+      const participant = tryParseParticipant(entry.bytes)
+      if (participant) {
+        out.push(participant)
+        found = true
+      }
+    }
+    if (found) return
+
+    const f2 = fields[2] || []
+    for (const entry of f2) {
+      if (entry.wt === 2 && entry.bytes && entry.bytes.length > 0) {
+        collectParticipants(entry.bytes, depth + 1, out)
+      }
+    }
+  }
+
+  // --- frame level ---
+  const top = parseFields(frame)
+  const field2 = top[2]
+  if (!field2 || field2.length === 0) {
+    // No state blob — keepalive (field 1) or unrecognised frame. Ignore.
+    return null
+  }
+
+  const results: DcrpcParticipant[] = []
+  for (const entry of field2) {
+    if (entry.wt !== 2 || !entry.bytes || entry.bytes.length === 0) continue
+    let inflated = entry.bytes
+    if (inflated.length >= 2 && inflated[0] === 0x1f && inflated[1] === 0x8b) {
+      try {
+        inflated = inflate(inflated)
+      } catch {
+        continue
+      }
+    }
+    collectParticipants(inflated, 0, results)
+  }
+  return results
+}

--- a/src/meeting/meet/network-interception/index.ts
+++ b/src/meeting/meet/network-interception/index.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 import type { Page } from "@playwright/test"
 import protobuf from "protobufjs"
 import { browserInterceptionLogic } from "./browser-bundle"
+import { decodeDcrpcFrame } from "./dcrpc-decoder"
 import { PROTO_SCHEMA } from "./schema"
 
 // Node-side reflection for the single field we read off Meet's
@@ -37,6 +38,10 @@ declare global {
     __networkInterceptorMain?: boolean
     protobuf?: unknown
     pako?: unknown
+    __decodeDcrpcFrame?: (
+      frame: Uint8Array,
+      inflate: (bytes: Uint8Array) => Uint8Array
+    ) => Array<{ deviceId: string; speaking: boolean }> | null
     onNetworkSpeakerUpdate?: (payload: {
       users: unknown[]
       timestamp: number
@@ -77,6 +82,12 @@ export async function setupNetworkInterceptionScripts(page: Page): Promise<boole
                     console.error("[NetworkInterceptor] Dependencies not loaded");
                     return;
                 }
+
+                // Expose the dcrpc speaker decoder in the page scope. It is a
+                // self-contained function (no imports/closures), so stringifying
+                // it here keeps a single implementation shared with the Node
+                // unit test.
+                window.__decodeDcrpcFrame = (${decodeDcrpcFrame.toString()});
 
                 // Execute browser interception logic with schema
                 (${browserInterceptionLogic.toString()})(${JSON.stringify(PROTO_SCHEMA)});

--- a/src/meeting/meet/network-interception/types.ts
+++ b/src/meeting/meet/network-interception/types.ts
@@ -28,6 +28,12 @@ export type NetworkPayload = {
   users: NetworkUser[]
   timestamp: number
   source: "roster" | "audio" | "health_check" | "network_interception_failed"
+  /**
+   * True when this "audio" update was produced by the dcrpc datachannel decoder
+   * (NetEq sessions) rather than the CSRC path. Lets the node side note that the
+   * network path is alive on NetEq without changing how the update is processed.
+   */
+  dcrpc?: boolean
   health?: {
     subscribed: boolean
     /** Tracks that have delivered at least one audio frame. */
@@ -53,6 +59,8 @@ export type NetworkPayload = {
 export type ReceiverManager = {
   receiverMap: Map<unknown, unknown>
   receiverToTrackMap: Map<unknown, unknown>
+  /** performance.now() when each receiver's contributing sources were last mirrored. */
+  sourceStamp: Map<unknown, number>
 }
 
 // Raw device output from protobuf (before processing)

--- a/src/meeting/shared/audio-capture.ts
+++ b/src/meeting/shared/audio-capture.ts
@@ -152,6 +152,51 @@ export function generateAudioCaptureScript(config: AudioCaptureConfig): string {
                     })
                 }
 
+                // NetEq decoder tap. In roughly half of Meet sessions (server-side
+                // experiment) audio never arrives as WebRTC tracks: it is decoded
+                // by a "neteq-processor" AudioWorklet node and wired into a
+                // MediaStreamAudioDestinationNode for playback. That destination
+                // node exposes a real MediaStreamTrack — hand it to the same track
+                // layer the WebRTC path uses, and the downstream frame pipeline
+                // (activity detection, health checks) works unchanged. The tap
+                // fires on connect(), so ordering between node and destination
+                // creation does not matter, and notifyTrackSubscribers dedupes by
+                // track id if Meet reconnects the graph.
+                if (typeof window.AudioWorkletNode === "function") {
+                    const OriginalAWN = window.AudioWorkletNode
+                    const WrappedAWN = function (...args) {
+                        const processorName = typeof args[1] === "string" ? args[1] : ""
+                        const node = Reflect.construct(OriginalAWN, args, new.target || WrappedAWN)
+                        if (processorName.toLowerCase().indexOf("neteq") !== -1) {
+                            try {
+                                const originalConnect = node.connect.bind(node)
+                                node.connect = function (...connectArgs) {
+                                    const result = originalConnect(...connectArgs)
+                                    try {
+                                        const dest = connectArgs[0]
+                                        if (dest && dest.stream && typeof dest.stream.getAudioTracks === "function") {
+                                            const tapped = dest.stream.getAudioTracks()[0]
+                                            if (tapped) {
+                                                console.log("${logPrefix} NetEq decoder output tapped: track " + tapped.id)
+                                                notifyTrackSubscribers(tapped, null, null)
+                                            }
+                                        }
+                                    } catch (tapError) {
+                                        console.error("${logPrefix} NetEq tap error:", tapError)
+                                    }
+                                    return result
+                                }
+                            } catch (wrapError) {
+                                console.error("${logPrefix} NetEq connect wrap failed:", wrapError)
+                            }
+                        }
+                        return node
+                    }
+                    WrappedAWN.prototype = OriginalAWN.prototype
+                    Object.setPrototypeOf(WrappedAWN, OriginalAWN)
+                    window.AudioWorkletNode = WrappedAWN
+                }
+
                 // Intercept RTCPeerConnection to capture audio tracks
                 if (typeof window.RTCPeerConnection !== "undefined") {
                     const OriginalPC = window.RTCPeerConnection

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -21,6 +21,7 @@ class Global {
   private networkInterceptionSetupFailed = false // Track if network interception scripts failed to load
   private networkDiarizationActive = false // Track if network diarization is actually active and working
   private hasTriggeredDiarizationFallback = false // Track if diarization fallback has been triggered
+  private lastDcrpcSpeakerAt = 0 // Date.now() of the last active speaker decoded from the dcrpc datachannel (NetEq)
 
   /**
    * Normalizes recording mode values to snake_case format.
@@ -404,6 +405,24 @@ class Global {
    */
   public isNetworkDiarizationActive(): boolean {
     return this.networkDiarizationActive
+  }
+
+  /**
+   * Record that the dcrpc datachannel just decoded an active speaker (NetEq
+   * sessions). Used to hold the network path against the stale-diarization
+   * fallback while the dcrpc signal is live.
+   */
+  public markDcrpcSpeaker(): void {
+    this.lastDcrpcSpeakerAt = Date.now()
+  }
+
+  /**
+   * Milliseconds since the last dcrpc-decoded active speaker, or Infinity if
+   * dcrpc has never produced one.
+   */
+  public msSinceLastDcrpcSpeaker(): number {
+    if (this.lastDcrpcSpeakerAt === 0) return Number.POSITIVE_INFINITY
+    return Date.now() - this.lastDcrpcSpeakerAt
   }
 
   /**

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -161,7 +161,7 @@ export class SpeakerManager {
 
   public async handleSpeakerUpdate(
     observed: SpeakerData[],
-    source: string = "ui-observer"
+    source: string
   ): Promise<void> {
     try {
       // Which source drives every committed speaker update: network CSRC,

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -156,11 +156,22 @@ export class SpeakerManager {
       return
     }
 
-    await this.handleSpeakerUpdate(observed)
+    await this.handleSpeakerUpdate(observed, "ui-observer")
   }
 
-  public async handleSpeakerUpdate(observed: SpeakerData[]): Promise<void> {
+  public async handleSpeakerUpdate(
+    observed: SpeakerData[],
+    source: string = "ui-observer"
+  ): Promise<void> {
     try {
+      // Which source drives every committed speaker update: network CSRC,
+      // network dcrpc (NetEq), roster, or the UI-observer bridge. This is the
+      // only node-side signal of source — the browser-side interceptor logs do
+      // not reach the bot log. Count only; names/ids are PII and this ships to S3.
+      const speakingNow = observed.filter((s) => s.isSpeaking).length
+      console.log(
+        `[SPEAKER-SRC] source=${source} speaking=${speakingNow}/${observed.length}`
+      )
       // A recording bot stays in the roster but can never hold the floor — see
       // silenceBotSpeaker for what happens to a meeting when it does. A bot that
       // streams audio in does speak, and keeps its turns.
@@ -200,7 +211,8 @@ export class SpeakerManager {
    */
   public async handleNetworkSpeakerUpdate(
     networkUsers: NetworkUser[],
-    timestamp: number
+    timestamp: number,
+    source: string = "network"
   ): Promise<void> {
     // Once the fallback has retired the network path, the UI observer is the
     // primary source. Stopping the page-side interceptor is best-effort, so a
@@ -278,7 +290,7 @@ export class SpeakerManager {
       }
 
       // Process as regular speaker update
-      await this.handleSpeakerUpdate(speakers)
+      await this.handleSpeakerUpdate(speakers, source)
     } catch (error) {
       console.error("[SpeakerManager] ❌ Error handling network speaker update:", error)
       throw error

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -421,9 +421,13 @@ export class InCallState extends BaseState {
             this.lastNetworkSpeakingKey = speakingKey
           }
 
+          const speakerSource = payload.dcrpc
+            ? "network:dcrpc"
+            : `network:${payload.source ?? "audio"}`
           await SpeakerManager.getInstance().handleNetworkSpeakerUpdate(
             networkUsers,
-            payload.timestamp
+            payload.timestamp,
+            speakerSource
           )
         } catch (error) {
           console.error("Error handling network speaker update:", formatError(error))

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -403,6 +403,13 @@ export class InCallState extends BaseState {
           // Existing speaker update handling
           const networkUsers = payload.users as NetworkUser[]
 
+          // dcrpc is the live speaker signal on NetEq sessions. Note when it
+          // decodes an active speaker so the stale-diarization monitor holds the
+          // network path instead of retiring it to the UI observer.
+          if (payload.dcrpc && networkUsers.some((u) => u.isSpeaking)) {
+            GLOBAL.markDcrpcSpeaker()
+          }
+
           // Confirms diarization is coming from the network path. Never log names or
           // ids here — this goes to the bot log and on to S3. Participants are
           // referred to by a stable per-meeting index instead.

--- a/src/state-machine/states/recording-state.ts
+++ b/src/state-machine/states/recording-state.ts
@@ -480,6 +480,23 @@ export class RecordingState extends BaseState {
           `[DiarizationHealth] [${meetingPlatform}] ⚠️ Stale event ${this.consecutiveStaleCount}/${threshold}${neverProduced ? " (no segment ever produced — fast fallback)" : ""}`
         )
 
+        // dcrpc (the NetEq network speaker signal) recently decoded an active
+        // speaker: the network path is alive even if the diarization file looks
+        // stale for a moment (e.g. a brief pause between speakers). Hold it
+        // rather than retire to the laggier UI observer. This is the guard that
+        // keeps NetEq sessions on the network path once dcrpc is producing.
+        const DCRPC_SPEAKER_HOLD_MS = 15000
+        if (
+          this.consecutiveStaleCount >= threshold &&
+          GLOBAL.msSinceLastDcrpcSpeaker() < DCRPC_SPEAKER_HOLD_MS &&
+          !GLOBAL.hasDiarizationFallbackTriggered()
+        ) {
+          console.log(
+            `[DiarizationHealth] [${meetingPlatform}] ⏳ Holding network path — dcrpc decoded a speaker ${Math.round(GLOBAL.msSinceLastDcrpcSpeaker() / 1000)}s ago (NetEq)`
+          )
+          return
+        }
+
         // Check if we should trigger fallback (Meet, Teams or Zoom, network
         // diarization active).
         //


### PR DESCRIPTION
## What

Adds network active-speaker detection for Google Meet **NetEq sessions** by decoding the `dcrpc` datachannel, and bundles three infrastructure fixes recovered from the media-stack investigation.

## The discovery

On roughly half of prod Meet sessions Google now mixes audio server-side and decodes it in-page with a NetEq AudioWorklet, so there are **no per-participant WebRTC audio tracks** and `getContributingSources()` (the CSRC/audioLevel speaker path) returns nothing. The classic speaker path is blind and the DOM "speaking ring" observer is the only fallback (laggy, and the source of leading-"Unknown" runs).

Meet opens several datachannels; the live active-speaker signal rides **`dcrpc`**:

- Each frame is a protobuf with one top-level field. **Field 1** is a keepalive (ignored). **Field 2** is a GZIP-compressed (`1f 8b`) per-participant state snapshot.
- Inflated, each participant record carries a **device-id string** (field 4) and a nested **"active"** message (field 9) whose field-2 varint presence means **speaking**.
- Names come from the roster we already decode on the `collections` channel (deviceId → name). Joining `dcrpc(deviceId, speaking)` with the roster yields named active speakers from the network on sessions where nothing else can.

Decoded speakers flow through the existing `onNetworkSpeakerUpdate` (`"audio"`) path into `SpeakerManager` exactly like CSRC. Updates dedupe on the set of speaking device ids; a speaker whose roster entry has not decoded yet is still emitted (name `"Unknown"`, real `deviceId`) so the opening seconds are relabelled at finalize instead of lost. **The UI observer becomes a fallback only.**

The decoder (`dcrpc-decoder.ts`) is a self-contained, dependency-free protobuf reader (it takes an `inflate` callback), so the *same* implementation is unit-tested in Node and stringified into the page. The participant walk is deliberately **defensive** — it looks for records at every nesting level and only accepts a field-4 value that is strict UTF-8 — so a wrapper-depth shift between Meet rollouts, or a binary sub-message, can never yield a bogus device id rather than a hard-coded fragile path.

## Three infra fixes bundled

1. **NetEq audio tap** (`audio-capture.ts`) — wrap `AudioWorkletNode` so a `neteq` node's `connect()` hands the destination node's `MediaStreamTrack` to the shared track layer, reviving the frame pipeline (activity detection, health checks) on NetEq. Tapped tracks arrive with no receiver, so `linkReceiverToTrack` now no-ops on a null receiver.
2. **Local datachannel capture** — Meet builds `meet_messages` (and `dcrpc`) itself on many sessions, and those channels never fire the `datachannel` event, so roster/chat/speaker data was never wired up. The message handler is extracted into a WeakSet-deduped `attachDcHandler()` called from both the passive event and a `createDataChannel` wrapper.
3. **CSRC freshness clock** — the frame-independent 500ms CSRC sampler now gates on *our* arrival stamp (`performance.now` via `receiverManager.sourceStamp`) instead of the CSRC entry's `timestamp` (a different clock that dropped every live source). The `getContributingSources` interceptor mirrors every call, including empty results, so a speaker going quiet clears the mirror.

The node side notes a live dcrpc speaker (`GLOBAL.markDcrpcSpeaker`), and the stale-diarization monitor in `RecordingState` holds the network path while dcrpc has produced a speaker recently rather than retiring it to the UI observer.

## Field-number note

The plan's concrete path was `2 { 2 { 4(repeated) { 4:deviceId, 9 { 2:speaking } } } }` from the inflated bytes, while the probe's own field dump had the participant list one wrapper shallower (`inflated → 2 → 4`). Rather than pick one, the walk descends through field-2 wrappers and accepts participants at whichever level they appear (verified by a test that adds an extra wrapper level), so both layouts — and future shifts — decode.

## Testing

- New `dcrpc-decoder.test.ts`: builds a real gzip'd protobuf fixture with `pako.gzip` + `protobufjs` and asserts `{deviceId, speaking}`; covers keepalive → `null`, empty snapshot, non-gzip field-2, and the extra-wrapper defensive walk.
- `tsc --noEmit -p tsconfig.release.json`: clean.
- `npm run build:bundle`: succeeds.
- `jest`: green except two failures that are pre-existing on `v2-improvements` and unrelated to this change — `src/utils/meeting-state-detector.test.ts` and `src/meeting/meet.test.ts` (a ts-jest `axios-retry` type error in `src/api/methods.ts`, confirmed identical on the clean base).

No probe scaffolding from `feat/meet-csrc-audiolevel-probe` is carried over.
