### PR TITLE
feat(teams): positively detect the lobby ("Someone will let you in")

### DIFF
--- a/src/meeting/teams-state-config.ts
+++ b/src/meeting/teams-state-config.ts
@@ -24,9 +24,23 @@ export const TEAMS_STATE_CONFIG: StateDetectionConfig = {
       errorMessage: "Teams requires participants to be authenticated before joining"
     }
   ],
-  // Teams doesn't have a distinct waiting room pattern detection
-  // It's handled through the denial patterns above
-  waitingRoomPattern: undefined,
+  // Lobby ("Someone will let you in when the meeting starts"): the bot has
+  // clicked Join now and Teams is holding it for host admission. Detecting this
+  // positively — rather than inferring "still waiting" from the absence of the
+  // in-meeting indicators — lets us tell a genuine lobby wait apart from a
+  // broken/stuck pre-join page, and lets the join loop emit an accurate
+  // in_waiting_room signal. `text=` does case-insensitive substring matching,
+  // so the wording variants share one needle.
+  waitingRoomPattern: {
+    selectors: [
+      'text=let you in when the meeting starts',
+      'text=Someone will let you in',
+      'text=Waiting for someone to let you in',
+      'text=When the meeting starts, we’ll let people know you’re waiting'
+    ],
+    threshold: 1,
+    checkVisibility: true
+  },
   inMeetingPattern: {
     selectors: [
       // React button is a good indicator

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -783,6 +783,7 @@ export class TeamsProvider implements MeetingProviderInterface {
     // Wait to be in the meeting
     console.log("Waiting to confirm meeting join...")
     let inMeeting = false
+    let reachedLobby = false
 
     while (!inMeeting) {
       // Check if we have been refused (or sign-in is required). isBotNotAccepted
@@ -799,6 +800,17 @@ export class TeamsProvider implements MeetingProviderInterface {
           GLOBAL.setError(MeetingEndReason.ApiRequest)
         }
         throw new Error("API request to stop Teams recording")
+      }
+
+      // Positively detect the lobby ("Someone will let you in…"). Seeing it
+      // confirms the join click landed and the bot is correctly parked waiting
+      // for host admission, rather than stuck on a broken pre-join page — the
+      // two look identical from the absence of the in-meeting indicators alone.
+      // Logged once so a timeout can be attributed correctly (host never
+      // admitted vs never reached the lobby).
+      if (!reachedLobby && (await isInTeamsWaitingRoom(page))) {
+        reachedLobby = true
+        console.log("🕓 [teams] In lobby — waiting for host to admit (join click landed)")
       }
 
       // Check if we are in the meeting (multiple indicators)
@@ -1139,6 +1151,15 @@ async function isRemovedFromTheMeeting(page: Page): Promise<boolean> {
     console.error("Error while checking meeting status:", formatError(error))
     return false
   }
+}
+
+// True while Teams shows the lobby ("Someone will let you in when the meeting
+// starts") — the bot has committed to joining and is waiting for host
+// admission. Distinct from the pre-join screen (where the "Join now" button is
+// still present) and from being in the meeting.
+async function isInTeamsWaitingRoom(page: Page): Promise<boolean> {
+  const result = await teamsStateDetector.isWaitingRoom(page)
+  return result.matched
 }
 
 async function isBotNotAccepted(page: Page): Promise<boolean> {

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -1,4 +1,5 @@
 import { type Browser, type BrowserContext, type Page, chromium } from "@playwright/test"
+import { TEAMS_STATE_CONFIG } from "../meeting/teams-state-config"
 import { MeetingEndReason } from "../state-machine/types"
 import { type StateDetectionConfig, createStateDetector } from "./meeting-state-detector"
 
@@ -313,28 +314,9 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
 // Regression for the diio investigation (2026-08-11): 266 Teams bots sat in the
 // lobby for the full 600s. Teams had no waitingRoomPattern, so the bot could not
 // tell a genuine lobby wait apart from a broken pre-join page. Real-DOM check
-// that the lobby text is detected and the pre-join / denial screens are not.
-const TEAMS_LOBBY_CONFIG: StateDetectionConfig = {
-  providerName: "Microsoft Teams (test)",
-  denialPatterns: [
-    {
-      texts: ["Sorry, but you were denied access to the meeting."],
-      reason: MeetingEndReason.BotNotAccepted,
-      errorMessage: "Teams has denied entry",
-    },
-  ],
-  waitingRoomPattern: {
-    selectors: [
-      "text=let you in when the meeting starts",
-      "text=Someone will let you in",
-      "text=Waiting for someone to let you in",
-    ],
-    threshold: 1,
-    checkVisibility: true,
-  },
-  inMeetingPattern: { selectors: ['button:has-text("React")'], threshold: 1, checkVisibility: false },
-}
-
+// that every production lobby copy variant is detected and the pre-join / denial
+// screens are not. Uses the real TEAMS_STATE_CONFIG so the test tracks
+// production selector drift.
 describe("Teams lobby (isWaitingRoom)", () => {
   let browser: Browser
   let context: BrowserContext
@@ -352,12 +334,22 @@ describe("Teams lobby (isWaitingRoom)", () => {
   afterEach(async () => {
     await context?.close()
   })
-  const detector = createStateDetector(TEAMS_LOBBY_CONFIG)
+  const detector = createStateDetector(TEAMS_STATE_CONFIG)
 
-  it("detects the Teams lobby (matches the real captured DOM copy)", async () => {
-    await page.setContent(`
-      <div><h1>Hi, diio. Someone will let you in when the meeting starts.</h1>
-      <div>Microsoft Teams meeting</div></div>`)
+  // Every `text=` needle from TEAMS_STATE_CONFIG.waitingRoomPattern, rendered as
+  // visible page copy — so adding/removing a production variant updates the
+  // matrix automatically and a dropped selector fails here.
+  const lobbySelectors = TEAMS_STATE_CONFIG.waitingRoomPattern?.selectors ?? []
+  const lobbyPhrases = lobbySelectors
+    .filter((s) => s.startsWith("text="))
+    .map((s) => s.slice("text=".length))
+
+  it("has lobby selectors to test", () => {
+    expect(lobbyPhrases.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it.each(lobbyPhrases)("detects the Teams lobby copy: %s", async (phrase) => {
+    await page.setContent(`<div><h1>Hi, diio. ${phrase}</h1><div>Microsoft Teams meeting</div></div>`)
     expect((await detector.isWaitingRoom(page)).matched).toBe(true)
   })
 

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -308,3 +308,68 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
     })
   })
 })
+
+// ── Teams lobby detection (isWaitingRoom) ────────────────────────────────────
+// Regression for the diio investigation (2026-08-11): 266 Teams bots sat in the
+// lobby for the full 600s. Teams had no waitingRoomPattern, so the bot could not
+// tell a genuine lobby wait apart from a broken pre-join page. Real-DOM check
+// that the lobby text is detected and the pre-join / denial screens are not.
+const TEAMS_LOBBY_CONFIG: StateDetectionConfig = {
+  providerName: "Microsoft Teams (test)",
+  denialPatterns: [
+    {
+      texts: ["Sorry, but you were denied access to the meeting."],
+      reason: MeetingEndReason.BotNotAccepted,
+      errorMessage: "Teams has denied entry",
+    },
+  ],
+  waitingRoomPattern: {
+    selectors: [
+      "text=let you in when the meeting starts",
+      "text=Someone will let you in",
+      "text=Waiting for someone to let you in",
+    ],
+    threshold: 1,
+    checkVisibility: true,
+  },
+  inMeetingPattern: { selectors: ['button:has-text("React")'], threshold: 1, checkVisibility: false },
+}
+
+describe("Teams lobby (isWaitingRoom)", () => {
+  let browser: Browser
+  let context: BrowserContext
+  let page: Page
+  beforeAll(async () => {
+    browser = await chromium.launch()
+  })
+  afterAll(async () => {
+    await browser?.close()
+  })
+  beforeEach(async () => {
+    context = await browser.newContext()
+    page = await context.newPage()
+  })
+  afterEach(async () => {
+    await context?.close()
+  })
+  const detector = createStateDetector(TEAMS_LOBBY_CONFIG)
+
+  it("detects the Teams lobby (matches the real captured DOM copy)", async () => {
+    await page.setContent(`
+      <div><h1>Hi, diio. Someone will let you in when the meeting starts.</h1>
+      <div>Microsoft Teams meeting</div></div>`)
+    expect((await detector.isWaitingRoom(page)).matched).toBe(true)
+  })
+
+  it("does NOT flag the pre-join screen (Join now present, no lobby copy) as the lobby", async () => {
+    await page.setContent(`
+      <div><h1>Choose your video and audio options</h1>
+      <button>Join now</button></div>`)
+    expect((await detector.isWaitingRoom(page)).matched).toBe(false)
+  })
+
+  it("does NOT flag the denial screen as the lobby", async () => {
+    await page.setContent(`<div><h1>Sorry, but you were denied access to the meeting.</h1></div>`)
+    expect((await detector.isWaitingRoom(page)).matched).toBe(false)
+  })
+})


### PR DESCRIPTION
## What & why

Investigating a customer's Teams traffic (2026-08-11): of 435 Teams bots that failed to record, **266 (61%) ended in `TIMEOUT_WAITING_TO_START` while their final DOM snapshot showed the Teams lobby** — "Hi, <name>. Someone will let you in when the meeting starts." (screenshot-verified). Another 131 were real denials (correctly `BOT_NOT_ACCEPTED`).

Teams had `waitingRoomPattern: undefined`. The join-confirm loop inferred "still waiting" purely from the **absence** of the in-meeting indicators, so:
- a bot genuinely parked in the lobby (host slow to admit), and
- a bot stuck on a broken/incomplete pre-join page

were **indistinguishable** — both silently burned the full 600s timeout, and the only way to tell which happened was pulling the S3 snapshot after the fact.

Note on the scary logs: the `TargetClosedError2` / "RetryableError: Page load timeout" lines these bots emit are **teardown noise** — the join loop keeps polling the page for a few ms after the waiting-room timeout closes the browser. Not a crash, not the cause. Confirmed by timestamp ordering.

## Change

- `teams-state-config.ts`: add `waitingRoomPattern` matching the lobby copy variants (`text=` substring, `checkVisibility: true`).
- `teams.ts`: `isInTeamsWaitingRoom()` + a one-time log in the join loop (`🕓 In lobby — waiting for host to admit`). A lobby wait is now attributable from the live log and separable from a never-reached-lobby failure. **Timeout behavior unchanged.**

## Tests

Real-Chromium-DOM regression tests (same harness as the Zoom self-kill tests): lobby copy matches `isWaitingRoom`; pre-join (`Join now`) and denial screens do not. Full detector suite 20/20, `tsc` clean.

## Follow-ups (not in this PR)

- With positive lobby detection available, a future change could **fast-fail a never-reached-lobby pre-join** instead of burning 600s, and split the error code (lobby-timeout vs stuck-pre-join).
- Teams email-verification walls (`We need to verify your info`) remain a separate 35-bot class already mapped to `LoginRequired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)