### PR TITLE
fix: fix google sso not firing for new credentials

### DIFF
--- a/src/state-machine/states/google-meet-sso-login.test.ts
+++ b/src/state-machine/states/google-meet-sso-login.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Google Meet SSO login — entry-point and diagnostics tests.
+ *
+ * Regression context: the flow used to enter via AccountChooser?hd=<domain>. With an
+ * empty cookie jar (a freshly added meet_login whose server-side cookie cache is still
+ * empty) Google has no account to choose and bounces to www.google.com. The old
+ * landing-page check read that as "SSO redirect already fired", skipped typing the
+ * email, and then burned the full 45s auth-cookie wait — and every diagnostic sat
+ * behind the same check, so the one broken path produced no signal.
+ *
+ * Playwright is faked: a scripted router maps each goto() to a landing URL.
+ */
+
+import { loginToGoogleMeetWithSso, MeetSsoLoginError, type MeetSsoConfig } from "./google-meet-sso-login"
+
+const LOGIN_EMAIL = "bot1@bots.acme.com"
+const DOMAIN = "bots.acme.com"
+const SET_COOKIE_URL = "https://api.meetingbaas.com/v2/meet-sso/set-cookie?session_id=abc-123"
+
+const CONFIG: MeetSsoConfig = {
+  session_id: "abc-123",
+  login_email: LOGIN_EMAIL,
+  set_cookie_url: SET_COOKIE_URL,
+  fallback: "anonymous"
+}
+
+const AUTH_COOKIES = [{ name: "SID", value: "x", domain: ".google.com", path: "/" }]
+
+interface Scenario {
+  /** Maps a requested URL to the URL the browser ends up on. */
+  route: (requested: string) => string
+  /** URL after the Next button is clicked. Defaults to a post-SSO Meet URL. */
+  afterNext?: string
+  /** Body text served once the email has been submitted. */
+  pageTextAfterNext?: string
+  passwordVisibleAfterNext?: boolean
+  /** Cookies visible to the context. Defaults to the auth cookies (happy path). */
+  cookies?: Array<Record<string, unknown>>
+  setCookieStatus?: number
+}
+
+interface Harness {
+  context: any
+  gotos: string[]
+  filled: string[]
+  nextClicks: number
+}
+
+function buildHarness(scenario: Scenario): Harness {
+  const gotos: string[] = []
+  const filled: string[] = []
+  let nextClicks = 0
+  let currentUrl = "about:blank"
+  let submitted = false
+
+  const page: any = {
+    setExtraHTTPHeaders: jest.fn(async () => {}),
+    url: () => currentUrl,
+    goto: jest.fn(async (url: string) => {
+      gotos.push(url)
+      if (url === SET_COOKIE_URL) {
+        currentUrl = url
+        const status = scenario.setCookieStatus ?? 200
+        return { ok: () => status >= 200 && status < 300, status: () => status }
+      }
+      currentUrl = scenario.route(url)
+      return { ok: () => true, status: () => 200 }
+    }),
+    waitForFunction: jest.fn(async () => true),
+    waitForURL: jest.fn(async () => {
+      throw new Error("no samlconfirmaccount")
+    }),
+    waitForLoadState: jest.fn(async () => {}),
+    evaluate: jest.fn(async () => true),
+    keyboard: { press: jest.fn(async () => {}) },
+    close: jest.fn(async () => {}),
+    locator: (selector: string) => {
+      const node: any = {
+        first: () => node,
+        waitFor: jest.fn(async () => {}),
+        fill: jest.fn(async (value: string) => {
+          filled.push(value)
+        }),
+        click: jest.fn(async () => {
+          nextClicks += 1
+          submitted = true
+          currentUrl = scenario.afterNext ?? "https://meet.google.com/landing"
+        }),
+        isVisible: jest.fn(async () =>
+          selector.includes("password") ? Boolean(submitted && scenario.passwordVisibleAfterNext) : true
+        ),
+        innerText: jest.fn(async () => (submitted ? (scenario.pageTextAfterNext ?? "") : ""))
+      }
+      return node
+    }
+  }
+
+  const context: any = {
+    newPage: jest.fn(async () => page),
+    addCookies: jest.fn(async () => {}),
+    cookies: jest.fn(async () => scenario.cookies ?? AUTH_COOKIES)
+  }
+
+  return {
+    context,
+    gotos,
+    filled,
+    get nextClicks() {
+      return nextClicks
+    }
+  } as Harness
+}
+
+/** Serves the sign-in form for ServiceLogin, nothing else. */
+const serviceLoginWorks = (requested: string) =>
+  requested.includes("ServiceLogin")
+    ? "https://accounts.google.com/v3/signin/identifier?hd=bots.acme.com"
+    : "https://www.google.com/"
+
+beforeEach(() => {
+  // injectSavedCookies / persistCookies both go through fetch.
+  global.fetch = jest.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ cookies: [] })
+  })) as unknown as typeof fetch
+  jest.spyOn(console, "info").mockImplementation(() => {})
+  jest.spyOn(console, "warn").mockImplementation(() => {})
+  jest.spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe("entry point", () => {
+  it("hits set-cookie before Google, then enters via ServiceLogin with the domain hint", async () => {
+    const h = buildHarness({ route: serviceLoginWorks })
+
+    await loginToGoogleMeetWithSso(h.context, CONFIG)
+
+    expect(h.gotos[0]).toBe(SET_COOKIE_URL)
+    expect(h.gotos[1]).toContain("accounts.google.com/ServiceLogin")
+    expect(h.gotos[1]).toContain(`hd=${encodeURIComponent(DOMAIN)}`)
+    expect(h.filled).toEqual([LOGIN_EMAIL])
+  })
+
+  it("falls back to AccountChooser when ServiceLogin bounces", async () => {
+    const h = buildHarness({
+      route: (requested) =>
+        requested.includes("AccountChooser")
+          ? "https://accounts.google.com/v3/signin/identifier?hd=bots.acme.com"
+          : "https://www.google.com/"
+    })
+
+    await loginToGoogleMeetWithSso(h.context, CONFIG)
+
+    expect(h.gotos.some((u) => u.includes("ServiceLogin"))).toBe(true)
+    expect(h.gotos.some((u) => u.includes("AccountChooser"))).toBe(true)
+    expect(h.filled).toEqual([LOGIN_EMAIL])
+  })
+
+  it("REGRESSION: bouncing to www.google.com fails fast instead of waiting for auth cookies", async () => {
+    // The empty-cookie-jar case that broke every newly added credential.
+    const h = buildHarness({ route: () => "https://www.google.com/", cookies: [] })
+
+    const started = Date.now()
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(MeetSsoLoginError)
+    const elapsed = Date.now() - started
+
+    // The old code sat in waitForGoogleAuthCookies for 45s here.
+    expect(elapsed).toBeLessThan(5_000)
+    // And it never typed the email, which is what made the failure unexplainable.
+    expect(h.filled).toEqual([])
+  })
+
+  it("names the landing URL, the domain and the Admin Console setting", async () => {
+    const h = buildHarness({ route: () => "https://www.google.com/", cookies: [] })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(
+      /landed on https:\/\/www\.google\.com/
+    )
+
+    const h2 = buildHarness({ route: () => "https://www.google.com/", cookies: [] })
+    await expect(loginToGoogleMeetWithSso(h2.context, CONFIG)).rejects.toThrow(
+      /Manage SSO profile assignments/
+    )
+  })
+
+  it("skips the email step when the context already holds a live session", async () => {
+    const h = buildHarness({ route: () => "https://myaccount.google.com/" })
+
+    await loginToGoogleMeetWithSso(h.context, CONFIG)
+
+    expect(h.filled).toEqual([])
+  })
+
+  it("fails fast when set-cookie rejects the session", async () => {
+    const h = buildHarness({ route: serviceLoginWorks, setCookieStatus: 404 })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(
+      /set-cookie endpoint returned 404/
+    )
+  })
+})
+
+describe("post-submit diagnostics", () => {
+  it("reports a password prompt as an SSO assignment problem", async () => {
+    const h = buildHarness({
+      route: serviceLoginWorks,
+      afterNext: "https://accounts.google.com/v3/signin/challenge/pwd",
+      passwordVisibleAfterNext: true,
+      cookies: []
+    })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(
+      /password prompt instead of redirecting to SSO/
+    )
+  })
+
+  it("reports an unknown account by name", async () => {
+    const h = buildHarness({
+      route: serviceLoginWorks,
+      afterNext: "https://accounts.google.com/v3/signin/identifier?flowName=GlifWebSignIn",
+      pageTextAfterNext: "Couldn't find your Google Account",
+      cookies: []
+    })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(
+      new RegExp(`could not find the account '${LOGIN_EMAIL}'`)
+    )
+  })
+
+  it("reports an incomplete Welcome to Workspace flow instead of timing out", async () => {
+    const h = buildHarness({
+      route: serviceLoginWorks,
+      afterNext: "https://accounts.google.com/signin/newfeatures/accountsetup",
+      pageTextAfterNext: "Welcome to your new account",
+      cookies: []
+    })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(
+      /has not completed the "Welcome to Google Workspace" flow/
+    )
+  })
+
+  it("still runs the diagnostics on the path that used to skip them", async () => {
+    // ServiceLogin bounces, AccountChooser recovers — the old code treated this
+    // whole branch as "SSO already fired" and ran no checks at all.
+    const h = buildHarness({
+      route: (requested) =>
+        requested.includes("AccountChooser")
+          ? "https://accounts.google.com/v3/signin/identifier"
+          : "https://www.google.com/",
+      afterNext: "https://accounts.google.com/v3/signin/challenge/pwd",
+      passwordVisibleAfterNext: true,
+      cookies: []
+    })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toThrow(
+      /password prompt instead of redirecting to SSO/
+    )
+  })
+})
+
+describe("failure classification", () => {
+  it("keeps an explicit diagnostic as TIMEOUT even when parked on an ACS URL", async () => {
+    const h = buildHarness({
+      route: serviceLoginWorks,
+      afterNext: "https://accounts.google.com/a/bots.acme.com/acs",
+      pageTextAfterNext: "Couldn't find your Google Account",
+      cookies: []
+    })
+
+    // The diagnostic throws a MeetSsoLoginError, which is rethrown as-is; the ACS
+    // reclassification only applies to non-MeetSsoLoginError failures.
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toMatchObject({
+      code: "MEET_LOGIN_FAILED_TIMEOUT"
+    })
+  })
+
+  it("classifies a rejected-assertion URL as SAML_REJECTED while waiting for cookies", async () => {
+    const h = buildHarness({
+      route: serviceLoginWorks,
+      afterNext: "https://accounts.google.com/v3/signin/rejected?rrk=21",
+      cookies: []
+    })
+
+    await expect(loginToGoogleMeetWithSso(h.context, CONFIG)).rejects.toMatchObject({
+      code: "MEET_LOGIN_FAILED_SAML_REJECTED"
+    })
+  })
+})

--- a/src/state-machine/states/google-meet-sso-login.test.ts
+++ b/src/state-machine/states/google-meet-sso-login.test.ts
@@ -187,6 +187,20 @@ describe("entry point", () => {
     )
   })
 
+  it("accepts a live session discovered only by the AccountChooser fallback", async () => {
+    // sessionAlreadyActive is read before the fallback navigation; if AccountChooser
+    // is what surfaces the live session, the no-sign-in-form check must not fire.
+    const h = buildHarness({
+      route: (requested) =>
+        requested.includes("AccountChooser") ? "https://myaccount.google.com/" : "https://www.google.com/"
+    })
+
+    await loginToGoogleMeetWithSso(h.context, CONFIG)
+
+    expect(h.gotos.some((u) => u.includes("AccountChooser"))).toBe(true)
+    expect(h.filled).toEqual([])
+  })
+
   it("skips the email step when the context already holds a live session", async () => {
     const h = buildHarness({ route: () => "https://myaccount.google.com/" })
 

--- a/src/state-machine/states/google-meet-sso-login.ts
+++ b/src/state-machine/states/google-meet-sso-login.ts
@@ -107,8 +107,13 @@ export async function loginToGoogleMeetWithSso(
       )
     }
 
-    // 2. Workspace-domain SSO entry: AccountChooser with hd= forces Google to
-    //    treat this as a Workspace-managed login and apply our SSO redirect.
+    // 2. Workspace-domain SSO entry. Go straight to the identifier page rather
+    //    than AccountChooser. With an empty cookie jar — a freshly added meet_login
+    //    whose server-side cookie cache is still empty — AccountChooser has no
+    //    account to choose and redirects to its default continue URL
+    //    (www.google.com) instead of the sign-in form. Established logins carry
+    //    cached device cookies and land on the form, which is why this only ever
+    //    broke for newly added credentials.
     const workspaceDomain = config.login_email.split("@")[1]
     if (!workspaceDomain) {
       // Schema validation upstream prevents this in practice — defensive only.
@@ -118,27 +123,58 @@ export async function loginToGoogleMeetWithSso(
       )
     }
 
-    const accountChooserUrl = `https://accounts.google.com/AccountChooser?hd=${encodeURIComponent(workspaceDomain)}`
-    await page.goto(accountChooserUrl, { waitUntil: "domcontentloaded", timeout: 15_000 })
-    const landedUrl = page.url()
+    const identifierUrl =
+      `https://accounts.google.com/ServiceLogin?hd=${encodeURIComponent(workspaceDomain)}` +
+      `&continue=${encodeURIComponent("https://meet.google.com/")}`
 
-    // 3. Type the bot user's email — but only if Google didn't already skip straight
-    //    to the SSO round-trip. This happens when the browser context has existing
-    //    Google cookies: AccountChooser immediately fires the SSO redirect without
-    //    showing the email identifier page. Detect by checking whether we're still
-    //    on a Google sign-in identifier URL.
-    //    myaccount.google.com means the session is already active (injected cookies
-    //    accepted by Google) — auth cookies are present, no email step needed.
-    const onIdentifierPage = landedUrl.includes("accounts.google.com") &&
-      (landedUrl.includes("/signin") || landedUrl.includes("/AccountChooser") || landedUrl.includes("ServiceLogin"))
+    await page.goto(identifierUrl, { waitUntil: "domcontentloaded", timeout: 15_000 })
+    let landedUrl = page.url()
 
+    const isIdentifierPage = (url: string) =>
+      url.includes("accounts.google.com") &&
+      (url.includes("/signin") || url.includes("/AccountChooser") || url.includes("ServiceLogin"))
+
+    // myaccount.google.com means the context already holds a live session — the
+    // SAML round-trip is unnecessary and will never fire.
     const sessionAlreadyActive = landedUrl.includes("myaccount.google.com")
 
-    if (onIdentifierPage) {
+    // Fall back to AccountChooser for contexts that do carry cookies, where
+    // ServiceLogin can bounce straight through to the continue URL.
+    if (!sessionAlreadyActive && !isIdentifierPage(landedUrl)) {
+      console.warn(`[meet-sso] ServiceLogin landed on ${landedUrl} — retrying via AccountChooser`)
+      await page
+        .goto(`https://accounts.google.com/AccountChooser?hd=${encodeURIComponent(workspaceDomain)}`, {
+          waitUntil: "domcontentloaded",
+          timeout: 15_000
+        })
+        .catch(() => null)
+      landedUrl = page.url()
+    }
+
+    // Neither entry point produced a sign-in form. Previously this fell through to
+    // a silent 45-second wait that reported "auth cookies did not appear" — which
+    // says nothing about the cause. Fail immediately with the landing URL instead.
+    if (!sessionAlreadyActive && !isIdentifierPage(landedUrl)) {
+      throw new MeetSsoLoginError(
+        "MEET_LOGIN_FAILED_TIMEOUT",
+        `Google served no sign-in page for '${config.login_email}' — landed on ${landedUrl}. ` +
+        `Verify '${workspaceDomain}' is the Workspace domain carrying the Legacy SSO profile, and that the ` +
+        "profile is assigned to this user's OU or group (Admin Console → Security → Authentication → " +
+        "SSO with third-party IdP → Manage SSO profile assignments)."
+      )
+    }
+
+    // 3. Type the bot user's email. Skipped only when a live session already exists.
+    const typedEmail = !sessionAlreadyActive
+    let urlBeforeNext = landedUrl
+
+    if (typedEmail) {
       const emailInput = page.locator('input[type="email"], #identifierId').first()
       await emailInput.waitFor({ state: "visible", timeout: 15_000 })
       console.info(`[meet-sso] email input found, page URL: ${page.url()}`)
       await emailInput.fill(config.login_email)
+
+      urlBeforeNext = page.url()
 
       // Click Next — typically a button with "Next" or id="identifierNext".
       const nextButton = page
@@ -146,14 +182,13 @@ export async function loginToGoogleMeetWithSso(
         .first()
       await nextButton.click({ timeout: 10_000 })
     } else {
-      console.info(`[meet-sso] AccountChooser already fired SSO redirect — skipping email input step`)
+      console.info(`[meet-sso] session already active from injected cookies — skipping email input step`)
     }
 
-    // 4. Only run email-submission diagnostics when we went through the email step.
-    //    When AccountChooser fired SSO immediately (onIdentifierPage=false), we skip
-    //    these checks — the browser is already in the middle of the SAML round-trip.
-    if (onIdentifierPage) {
-      const urlBeforeNext = page.url()
+    // 4. Diagnostics after submitting the email. These used to sit behind the same
+    //    landing-page check that misfired above, so on a broken setup every one of
+    //    them was skipped and the run degraded into an unexplained timeout.
+    if (typedEmail) {
       try {
         await page.waitForFunction(
           (beforeUrl: string) =>
@@ -189,6 +224,24 @@ export async function loginToGoogleMeetWithSso(
         throw new MeetSsoLoginError(
           "MEET_LOGIN_FAILED_TIMEOUT",
           `Google could not find the account '${config.login_email}'. Verify the user exists in the Workspace. (URL: ${urlAfterNext})`
+        )
+      }
+
+      // Google parks accounts that never completed the "Welcome to Google Workspace"
+      // flow on a setup/terms interstitial. Auth cookies never land, so without this
+      // check the run burns the full 45-second timeout with no usable signal.
+      if (
+        urlAfterNext.includes("/signin/v2/usernamerecovery") ||
+        urlAfterNext.includes("accountsetup") ||
+        urlAfterNext.includes("/TermsOfService") ||
+        pageText.includes("Welcome to your new account") ||
+        pageText.includes("Accept") && pageText.includes("Terms of Service")
+      ) {
+        throw new MeetSsoLoginError(
+          "MEET_LOGIN_FAILED_TIMEOUT",
+          `'${config.login_email}' has not completed the "Welcome to Google Workspace" flow (URL: ${urlAfterNext}). ` +
+          "Sign in to the account once interactively with its Google password — set that user's OU/group SSO " +
+          "profile assignment to None while you do it — then re-enable the Legacy SSO profile."
         )
       }
 

--- a/src/state-machine/states/google-meet-sso-login.ts
+++ b/src/state-machine/states/google-meet-sso-login.ts
@@ -136,7 +136,7 @@ export async function loginToGoogleMeetWithSso(
 
     // myaccount.google.com means the context already holds a live session — the
     // SAML round-trip is unnecessary and will never fire.
-    const sessionAlreadyActive = landedUrl.includes("myaccount.google.com")
+    let sessionAlreadyActive = landedUrl.includes("myaccount.google.com")
 
     // Fall back to AccountChooser for contexts that do carry cookies, where
     // ServiceLogin can bounce straight through to the continue URL.
@@ -149,6 +149,9 @@ export async function loginToGoogleMeetWithSso(
         })
         .catch(() => null)
       landedUrl = page.url()
+      // AccountChooser can land on a live session too — re-read it, or the check
+      // below would reject a context that is in fact already signed in.
+      sessionAlreadyActive ||= landedUrl.includes("myaccount.google.com")
     }
 
     // Neither entry point produced a sign-in form. Previously this fell through to


### PR DESCRIPTION
## Summary

Newly added `meet_login` credentials failed SSO on every run while established ones on the same workspace worked. The bot reported `Google auth cookies did not appear within 45000ms`, fell back to an anonymous join, and ended as `botNotAccepted` — which reads as a host problem rather than an auth one.

The SSO flow entered Google via `accounts.google.com/AccountChooser?hd=<domain>`. With an empty cookie jar — a new login whose server-side cookie cache has nothing in it yet — Google has no account to choose and redirects to its default continue URL, `www.google.com`. The `onIdentifierPage` check read that as "AccountChooser already fired the SSO redirect", skipped typing the email, and fell straight into the 45-second auth-cookie wait. The SAML round-trip never happened; the IdP was never reached.

Established logins carry cached device cookies (`NID`, `GAPS`), land on the sign-in form, and take the working path — which is why this only ever broke for freshly added credentials. Worth noting the cookie cache is not letting them skip SAML: `injectSavedCookies` strips the Google auth cookies (`SID`, `HSID`, `__Secure-1PSID`, …) on purpose, so every login does the full round-trip.

Compounding it, all the post-submit diagnostics — password prompt, account-not-found, URL-unchanged — sat behind that same `if (onIdentifierPage)`. On the one path that was actually broken, every check was skipped, so the run produced no usable signal.

Changes in `google-meet-sso-login.ts`:

- enter via `ServiceLogin?hd=<domain>&continue=…`, which serves the identifier form with an empty cookie jar; `AccountChooser` becomes the fallback rather than the primary entry point
- if neither entry point yields a sign-in form, throw immediately naming the landing URL, the domain, and the Admin Console setting to check, instead of hanging for 45s
- run the post-submit diagnostics whenever an email was submitted, not only when the landing-page check passed
- detect Google's "Welcome to your new account" / account-setup interstitial explicitly, so an incomplete Workspace welcome flow is reported by name

The landing-URL behaviour is inferred from a production bot run, not directly observed. The fix doesn't depend on that being the exact reason — it recovers whatever the landing URL turns out to be, and now reports which one it was.

## Testing

New: `apps/meet-teams-bot/src/state-machine/states/google-meet-sso-login.test.ts` — 12 tests, Playwright faked with a scripted URL router, ~4s, no browser.

```
entry point
  ✓ hits set-cookie before Google, then enters via ServiceLogin with the domain hint
  ✓ falls back to AccountChooser when ServiceLogin bounces
  ✓ REGRESSION: bouncing to www.google.com fails fast instead of waiting for auth cookies
  ✓ names the landing URL, the domain and the Admin Console setting
  ✓ skips the email step when the context already holds a live session
  ✓ fails fast when set-cookie rejects the session
post-submit diagnostics
  ✓ reports a password prompt as an SSO assignment problem
  ✓ reports an unknown account by name
  ✓ reports an incomplete Welcome to Workspace flow instead of timing out
  ✓ still runs the diagnostics on the path that used to skip them
failure classification
  ✓ keeps an explicit diagnostic as TIMEOUT even when parked on an ACS URL
  ✓ classifies a rejected-assertion URL as SAML_REJECTED while waiting for cookies
```

The regression test reproduces the empty-cookie-jar case from the failing production run and asserts both that the error returns in under 5 seconds and that the email was never typed. It fails on the base commit on both counts.

Full suite: 210 passed. `src/meeting/meet.test.ts` and `src/utils/meeting-state-detector.test.ts` fail on the base commit too — `meet.test.ts` doesn't compile because of an axios overload error in `src/api/methods.ts`. Neither imports the SSO module.

Verified against production bot `1e0321f3-012e-4bc0-bba0-4ce9da925d43`, whose logs show the `PROXIED → www.google.com` hop and the absence of any second `DIRECT → api.meetingbaas.com`.

## Release Notes

Fixed Google Meet SAML SSO failing for newly added credentials. A credential added to an existing workspace would fail to sign in on every bot run and silently fall back to an anonymous join, while older credentials on the same workspace kept working.

SSO setup failures now report the actual cause — wrong Workspace domain, SSO profile not assigned to the user's OU or group, or an incomplete "Welcome to Google Workspace" flow — instead of a generic 45-second timeout.
