### PR TITLE
fix(audio): byte-align inbound injection audio to stop Teams garble

### DIFF
--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -465,6 +465,9 @@ export class Streaming {
     }
 
     this.isPaused = true
+    // Drop any partial inbound sample: paused messages are discarded, so a
+    // leftover byte would misalign the first message after resume.
+    this.inboundRemainder = Buffer.alloc(0)
     console.log("[Streaming] Paused")
   }
 
@@ -600,6 +603,11 @@ export class Streaming {
   }
 
   private createAudioStreamFromWebSocket = (input_ws: WebSocket) => {
+    // Fresh stream (e.g. a dual-channel WebSocket reconnect attaching a new
+    // handler on the same Streaming instance) must not inherit a stale partial
+    // sample from the previous connection.
+    this.inboundRemainder = Buffer.alloc(0)
+
     const stream = new Readable({
       read() {}
     })

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -69,6 +69,15 @@ export class Streaming {
   private ffmpegProcess: ChildProcess | null = null
   private audioRemainder: Buffer = Buffer.alloc(0)
 
+  // Inbound (injection) byte remainder: incoming ws audio messages are raw
+  // Int16 PCM but are NOT guaranteed to carry a whole number of samples — a
+  // 16-bit sample can straddle two messages, and a message can have an odd
+  // byte length. `new Int16Array(buffer)` then throws on odd lengths (dropping
+  // the whole chunk) or, worse, silently byte-shifts every subsequent sample,
+  // which plays back as garbled/"overloaded-mic" audio. Carry the leftover
+  // byte(s) across messages so only complete samples are ever decoded.
+  private inboundRemainder: Buffer = Buffer.alloc(0)
+
   // Debug: Save streamed audio to file
   private debugAudioStream: fs.WriteStream | null = null
   private debugAudioBytesWritten = 0
@@ -492,6 +501,7 @@ export class Streaming {
     // Reset output buffer
     this.outputBuffer = null
     this.outputBufferOffset = 0
+    this.inboundRemainder = Buffer.alloc(0)
 
     // Close external WebSockets
     this.closeExternalWebSockets()
@@ -598,16 +608,32 @@ export class Streaming {
       if (this.isPaused) return
 
       if (message instanceof Buffer) {
-        const uint8Array = new Uint8Array(message)
         try {
-          const s16Array = new Int16Array(uint8Array.buffer)
-          const f32Array = new Float32Array(s16Array.length)
-          for (let i = 0; i < s16Array.length; i++) {
-            f32Array[i] = s16Array[i] / 32768
+          // Prepend any leftover byte from the previous message, then decode
+          // only whole Int16 samples (2-byte aligned). Anything trailing is an
+          // incomplete sample — hold it for the next message instead of
+          // dropping it or misaligning the stream.
+          const buf =
+            this.inboundRemainder.length > 0
+              ? Buffer.concat([this.inboundRemainder, message])
+              : message
+          const alignedLen = buf.length - (buf.length % 2)
+          if (alignedLen === 0) {
+            this.inboundRemainder = Buffer.from(buf)
+            return
+          }
+          this.inboundRemainder =
+            alignedLen < buf.length ? Buffer.from(buf.subarray(alignedLen)) : Buffer.alloc(0)
+
+          const sampleCount = alignedLen / 2
+          const f32Array = new Float32Array(sampleCount)
+          for (let i = 0; i < sampleCount; i++) {
+            // Read Int16 LE explicitly — avoids ArrayBuffer alignment/offset
+            // pitfalls of `new Int16Array(buf.buffer)` on pooled Node buffers.
+            f32Array[i] = buf.readInt16LE(i * 2) / 32768
           }
 
-          const buffer = Buffer.from(f32Array.buffer)
-          stream.push(buffer)
+          stream.push(Buffer.from(f32Array.buffer))
         } catch (error) {
           console.error("[Streaming] Error processing external audio chunk:", formatError(error))
         }


### PR DESCRIPTION
## Summary

Fixes **garbled ("overloaded-mic") bot audio in Microsoft Teams**. The recording pipeline was otherwise healthy — `recording_succeeded`, no api-server errors — the corruption was purely in the audio **injection** path.

## Root cause

`Streaming.createAudioStreamFromWebSocket` (src/streaming.ts) decoded each incoming WebSocket audio message as a whole number of Int16 samples:

```ts
const s16Array = new Int16Array(uint8Array.buffer)
```

Incoming ws messages are **not** guaranteed to carry complete samples:
- a 16-bit sample can **straddle two messages**, and
- a message can have an **odd byte length**.

On an odd length `new Int16Array(buffer)` **throws** → the whole chunk is dropped (audio gaps). Across messages it also **byte-shifts** every subsequent sample. Both play back as garbled / "overloaded-mic" audio.

**Teams-specific** because Teams' audio framing produces odd/straddling ws frames where Google Meet's did not — so the same shared injection code garbles only on Teams.

The capture path (`ffmpegProcess.stdout` handler) already carries an `audioRemainder` for exactly this reason; the injection path had no equivalent.

## Fix

Carry a byte remainder across messages and decode only complete, 2-byte-aligned samples with an explicit `readInt16LE` (also sidesteps `ArrayBuffer` offset pitfalls of pooled Node buffers). No sample is ever dropped or misaligned. Remainder reset on `stop()`.

## Verification

- Reconstruction test: feeding the same PCM split into **odd-length** ws messages (7/5/3/5 bytes, samples straddling frame boundaries) — old code drops everything, new code reconstructs all samples exactly.
- Diagnosed live from the prod recorder pod: injection FFmpeg `non monotonically increasing dts` + `virtual_speaker` 0-byte capture on a Teams bot; rate was already matched (24 kHz both sides), ruling out sample-rate as the cause.

## Scope

One function in `src/streaming.ts` (inbound audio decode) + a reset line in `stop()`. No API/format changes; Meet path behaves identically (its frames were already aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
