### PR TITLE
fix(diarization): repair Unknown speakers by stable user id (churning-SSRC speakers)

### DIFF
--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -96,6 +96,53 @@ describe("DiarizationTracker backfill", () => {
     expect(segments[1].speaker).toBe("Unknown")
   })
 
+  it("repairs a churning-device speaker by stable user id when the device never resolves", async () => {
+    const tracker = freshTracker()
+
+    // One participant, stable user id 5, but a fresh bare-numeric deviceId every
+    // turn (CSRC/SSRC active-speaker switching). All written as "Unknown" before
+    // a name resolved. The roster never maps these volatile devices, so the
+    // device-keyed pass can't fix them — but the user id did resolve to a name.
+    const churn = (deviceId: string, atSeconds: number): SpeakerData => ({
+      name: "Unknown",
+      id: 5,
+      timestamp: MEETING_START + atSeconds * 1000,
+      isSpeaking: true,
+      deviceId
+    })
+    tracker.updateSpeaker(churn("111", 1), MEETING_START)
+    tracker.updateSpeaker(churn("222", 3), MEETING_START)
+    tracker.updateSpeaker(churn("333", 5), MEETING_START)
+
+    await tracker.end(
+      MEETING_START + 7000,
+      MEETING_START,
+      () => undefined, // device resolver: roster never named these SSRC devices
+      (userId) => (userId === 5 ? "Real Speaker" : undefined)
+    )
+
+    const segments = readSegments()
+    expect(segments).toHaveLength(3)
+    expect(segments.every((s) => s.speaker === "Real Speaker")).toBe(true)
+    expect(segments.every((s) => s.user_id === 5)).toBe(true)
+  })
+
+  it("does not repair by user id when the id is 0 (UI/ambiguous) or the device already resolved", async () => {
+    const tracker = freshTracker()
+
+    // id 0 = UI-based/ambiguous — must never be relabelled by the id pass.
+    tracker.updateSpeaker(speech("ui-dev", "Unknown", 1), MEETING_START)
+
+    await tracker.end(
+      MEETING_START + 3000,
+      MEETING_START,
+      () => undefined,
+      () => "WRONG" // would fire if id 0 were eligible
+    )
+
+    expect(readSegments()[0].speaker).toBe("Unknown")
+  })
+
   it("does not disturb segments that already had a real name", async () => {
     const tracker = freshTracker()
 

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -31,6 +31,10 @@ export interface DiarizationHealthStatus {
 
 /** Resolves a network device to its final name/id, once the roster is complete. */
 export type SpeakerResolver = (deviceId: string) => { name: string; userId: number } | undefined
+// Resolve a stable sequential user id to its final name, for segments whose
+// deviceId never resolved (churning SSRC) but whose user id did resolve while
+// the participant spoke.
+export type UserIdResolver = (userId: number) => string | undefined
 
 export class DiarizationTracker {
   private static instance: DiarizationTracker | null = null
@@ -146,6 +150,31 @@ export class DiarizationTracker {
   }
 
   /**
+   * Second repair pass, keyed on the STABLE user id rather than the device.
+   * A speaker seen only through the CSRC/SSRC path gets a fresh bare-numeric
+   * deviceId on every active-speaker switch, so the roster never maps those
+   * devices and repairUnknownSpeakers leaves the segment "Unknown" — even though
+   * the same participant kept one stable user id that DID resolve to a real name
+   * while they spoke. Match on that id (still a per-participant key, so it can't
+   * hand one person's speech to another) to recover them.
+   */
+  private repairUnknownByUserId(resolve: UserIdResolver): number {
+    let repaired = 0
+    for (const entry of this.allSegments) {
+      if (entry.segment.speaker !== UNKNOWN_SPEAKER || !entry.segment.user_id) {
+        continue
+      }
+      const name = resolve(entry.segment.user_id)
+      if (!name || name === UNKNOWN_SPEAKER) {
+        continue
+      }
+      entry.segment.speaker = name
+      repaired++
+    }
+    return repaired
+  }
+
+  /**
    * True once at least one speaker segment was ever opened this meeting.
    * Distinguishes "network diarization NEVER produced data" (source is dead —
    * fall back fast) from "was producing, currently quiet" (normal silence —
@@ -164,7 +193,8 @@ export class DiarizationTracker {
   public async end(
     lastTimestamp: number,
     meetingStartTime: number,
-    resolveSpeaker?: SpeakerResolver
+    resolveSpeaker?: SpeakerResolver,
+    resolveUserId?: UserIdResolver
   ): Promise<void> {
     if (this.isEnded) {
       return
@@ -190,6 +220,15 @@ export class DiarizationTracker {
     if (repaired > 0) {
       console.log(
         `[DiarizationTracker] Backfilled ${repaired} segment(s) that were written before the roster resolved`
+      )
+    }
+
+    // Second pass: rescue segments the device-keyed repair could not, using the
+    // stable user id (churning-SSRC speakers whose device never mapped).
+    const repairedById = resolveUserId ? this.repairUnknownByUserId(resolveUserId) : 0
+    if (repairedById > 0) {
+      console.log(
+        `[DiarizationTracker] Backfilled ${repairedById} segment(s) by stable user id (device never resolved)`
       )
     }
 

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -26,6 +26,12 @@ export class SpeakerManager {
   // a later payload can omit a name that an earlier one carried; without this,
   // a participant flips back to "Unknown" mid-meeting.
   private deviceNames = new Map<string, string>()
+  // Stable sequential user id -> resolved name. Populated live whenever a
+  // speaker resolves to a real name. The device-keyed backfill misses speakers
+  // whose deviceId churns (CSRC/SSRC active-speaker switching: each swap is a
+  // new bare-numeric deviceId the roster never maps), but their user id stays
+  // stable — so this lets finalize repair them by user id instead of device.
+  private userIdNames = new Map<number, string>()
   // Profile picture per device, so a backfilled segment gets the same stable id
   // the live path would have produced for that participant.
   private deviceProfilePictures = new Map<string, string | undefined>()
@@ -100,7 +106,8 @@ export class SpeakerManager {
         await instance.diarizationTracker.end(
           lastTimestamp,
           meetingStartTime,
-          (deviceId) => instance.resolveDeviceForBackfill(deviceId)
+          (deviceId) => instance.resolveDeviceForBackfill(deviceId),
+          (userId) => instance.userIdNames.get(userId)
         )
       }
     }
@@ -177,6 +184,15 @@ export class SpeakerManager {
       // streams audio in does speak, and keeps its turns.
       const params = GLOBAL.get()
       const speakers = silenceBotSpeaker(observed, params.bot_name, Boolean(params.streaming_input))
+
+      // Remember every user id we ever resolved to a real name, so finalize can
+      // repair Unknown segments by user id when the device-keyed repair can't
+      // (churning SSRC deviceId). Never store the placeholder.
+      for (const speaker of speakers) {
+        if (speaker.id != null && speaker.name && speaker.name !== UNKNOWN_SPEAKER) {
+          this.userIdNames.set(speaker.id, speaker.name)
+        }
+      }
 
       // Update singleton with participants and speakers
       this.updateSingletonParticipants(speakers)


### PR DESCRIPTION
## Problem
A participant seen only via the **CSRC/SSRC audio path** gets a fresh bare-numeric `deviceId` on every active-speaker switch (Meet's virtual-SSRC slot rotation). The roster only maps stable `spaces/.../devices/N` ids, so `DiarizationTracker.repairUnknownSpeakers()` — which backfills **by deviceId** — can never resolve those volatile devices and leaves the segments `"Unknown"` in the finalized `diarization.jsonl`. The transcript speaker-mapper then faithfully carries the Unknown through, so **the participant who talks the most can be delivered entirely as `Unknown`**.

This is distinct from the old *leading*-Unknown (join gap); it's a long **mid-call** Unknown, after the intro.

## Evidence (prod)
Multiple prod bots show one speaker holding a **stable `user_id`** but **2–11 churning `deviceId`s**; in the worst case **~48 min of a 57 min meeting** was delivered as `Unknown`. In every case the Unknown segments already carried a stable `user_id` — the id resolved, only the device didn't.

## Fix
- `SpeakerManager` records `userId → name` whenever a speaker resolves to a real name (the live path knows the name even when the device is volatile).
- New second finalize pass `repairUnknownByUserId` relabels any still-`Unknown` segment by its **stable user id**.
- Keyed on `user_id` (a per-participant key), so it stays collision-safe — it can never hand one person's speech to another, which is exactly why the device-keyed pass exists. `user_id === 0` (UI/ambiguous) is never eligible.

## Tests
`diarization-tracker.test.ts`: +2 cases — a churning-device speaker with a stable id is repaired by id; id 0 / already-resolved devices are never touched by the id pass. `tsc` clean, 15/15 pass.

## Notes
- Forward fix only. The already-affected transcripts can't be retro-named (those speakers' real names lived only in the live roster, never persisted).