### PR TITLE
fix(teams): resolve the active speaker from one evidence timeline instead of switching between dsh and captions

### DIFF
--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -203,6 +203,35 @@ describe("DiarizationTracker recording-clock clamp", () => {
     expect(segments.every((s) => s.start_time >= 0)).toBe(true)
   })
 
+  it("survives an append-stream failure instead of taking the bot down", async () => {
+    const tracker = freshTracker()
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+
+    try {
+      // With no listener Node throws 'error' as an uncaught exception and the bot
+      // dies mid-meeting. ENOSPC on the pod's ephemeral disk is the real trigger.
+      const stream = (tracker as unknown as { fileStream: NodeJS.EventEmitter | null }).fileStream
+      expect(stream).not.toBeNull()
+      const diskFull = Object.assign(new Error("no space left on device"), { code: "ENOSPC" })
+      expect(() => stream?.emit("error", diskFull)).not.toThrow()
+
+      // Segments still accumulate in memory; end() rewrites the file from them.
+      tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 1), MEETING_START)
+      tracker.updateSpeaker(speech("dev-b", "Jonny", 4), MEETING_START)
+
+      await tracker.end(MEETING_START + 8000, MEETING_START, () => undefined)
+
+      expect(readSegments().map((s) => s.speaker)).toEqual(["Amr El Shimy", "Jonny"])
+      // Reported once, not per speaker change.
+      const failureLogs = errorSpy.mock.calls.filter((call) =>
+        String(call[0]).includes("Append stream failed")
+      )
+      expect(failureLogs).toHaveLength(1)
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
   it("drops a segment the clamp collapses to zero length", async () => {
     const tracker = freshTracker()
 

--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, type WriteStream } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { DiarizationTracker } from "./diarization-tracker"
@@ -210,10 +210,13 @@ describe("DiarizationTracker recording-clock clamp", () => {
     try {
       // With no listener Node throws 'error' as an uncaught exception and the bot
       // dies mid-meeting. ENOSPC on the pod's ephemeral disk is the real trigger.
-      const stream = (tracker as unknown as { fileStream: NodeJS.EventEmitter | null }).fileStream
+      // destroy() rather than emit() so the stream really tears down.
+      const stream = (tracker as unknown as { fileStream: WriteStream | null }).fileStream
       expect(stream).not.toBeNull()
       const diskFull = Object.assign(new Error("no space left on device"), { code: "ENOSPC" })
-      expect(() => stream?.emit("error", diskFull)).not.toThrow()
+      const closed = new Promise<void>((resolve) => stream?.once("close", () => resolve()))
+      stream?.destroy(diskFull)
+      await closed
 
       // Segments still accumulate in memory; end() rewrites the file from them.
       tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 1), MEETING_START)
@@ -225,6 +228,32 @@ describe("DiarizationTracker recording-clock clamp", () => {
       // Reported once, not per speaker change.
       const failureLogs = errorSpy.mock.calls.filter((call) =>
         String(call[0]).includes("Append stream failed")
+      )
+      expect(failureLogs).toHaveLength(1)
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it("reports a stream that fails during end() once, not from both listeners", async () => {
+    const tracker = freshTracker()
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+
+    try {
+      tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 1), MEETING_START)
+
+      // Failure at close time: the constructor listener and closeStream's own
+      // listener both see it, and would otherwise log the same fault twice.
+      const stream = (tracker as unknown as { fileStream: WriteStream }).fileStream
+      jest.spyOn(stream, "end").mockImplementation(function (this: WriteStream) {
+        this.destroy(Object.assign(new Error("disk lost"), { code: "EIO" }))
+        return this
+      } as WriteStream["end"])
+
+      await tracker.end(MEETING_START + 5000, MEETING_START, () => undefined)
+
+      const failureLogs = errorSpy.mock.calls.filter((call) =>
+        /Append stream failed|Error closing stream/.test(String(call[0]))
       )
       expect(failureLogs).toHaveLength(1)
     } finally {

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -55,11 +55,22 @@ export class DiarizationTracker {
   private filePath: string
   private isEnded = false
   private hasTrackedAnySegment = false // True once ANY speaker segment was ever opened
+  private streamFailed = false // True once the append stream errored and was dropped
 
   private constructor(tempDir: string) {
     this.filePath = join(tempDir, "diarization.jsonl")
     // Open file stream for append-only writing (efficient for continuous logs)
     this.fileStream = createWriteStream(this.filePath, { flags: "a" })
+    // Unhandled 'error' (ENOSPC) would kill the bot mid-meeting. Degrade to
+    // memory — end() rewrites the file from allSegments.
+    this.fileStream.on("error", (error) => {
+      if (this.streamFailed) return
+      this.streamFailed = true
+      this.fileStream = null
+      console.error(
+        `[DiarizationTracker] Append stream failed (${error}) — continuing in memory; segments are rewritten from the buffer on end()`
+      )
+    })
   }
 
   public static getInstance(): DiarizationTracker {
@@ -371,7 +382,10 @@ export class DiarizationTracker {
    */
   private writeToFile(segment: DiarizationSegment): void {
     if (!this.fileStream) {
-      console.error("DiarizationTracker: File stream not initialized")
+      // Already reported once by the error handler.
+      if (!this.streamFailed) {
+        console.error("DiarizationTracker: File stream not initialized")
+      }
       return
     }
 

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -288,7 +288,10 @@ export class DiarizationTracker {
       stream.end()
       stream.once("finish", () => resolve())
       stream.once("error", (error) => {
-        console.error(`DiarizationTracker: Error closing stream: ${error}`)
+        // The constructor listener runs first and already reported this one.
+        if (!this.streamFailed) {
+          console.error(`DiarizationTracker: Error closing stream: ${error}`)
+        }
         resolve()
       })
     })

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -754,7 +754,10 @@ export function teamsBrowserInterceptionLogic(resolveSpeakingSet: SpeakerSetReso
           clearInterval(captionExpiryTimer)
           return
         }
-        if (csrcAvailable || hasFreshDominantSpeaker()) return
+        // Not gated on dsh freshness: once a caption interval has been selected,
+        // only this update ends it, and resolveSpeakingSet hands the floor back to
+        // a live dsh rather than emitting silence.
+        if (csrcAvailable) return
         // Speech having stopped can only be seen on the wall clock: the audio
         // clock says nothing once captions go quiet. So the TRIGGER is "no
         // caption result for CAPTION_SILENCE_MS", while the resulting update is

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -8,7 +8,11 @@
 
 /** biome-ignore-all lint/suspicious/noExplicitAny: browser-side bundle over untyped Teams/WebRTC internals. */
 
-export function teamsBrowserInterceptionLogic() {
+// Type-only: erased, so the stringified bundle stays self-contained.
+import type { SpeakerSetResolver, SpeakerTimelineRung } from "./speaker-timeline"
+
+/** @param resolveSpeakingSet - Passed in, not imported: this is stringified into the page. */
+export function teamsBrowserInterceptionLogic(resolveSpeakingSet: SpeakerSetResolver) {
   try {
     if ((window as any).__teamsNetworkInterceptorInitialized === true) {
       console.warn("[Teams NetworkInterceptor] ⚠️ Already initialized, skipping duplicate")
@@ -152,6 +156,10 @@ export function teamsBrowserInterceptionLogic() {
     const speakingStateMachines = new Map<string, any>()
     // last logged speaking set, to log only on change
     let lastSpeakingLogKey = ""
+    // Floors the caption stamp on hybrid sessions.
+    let lastBroadcastStamp = 0
+    // Log the rung only on change.
+    let lastRung: SpeakerTimelineRung | "" = ""
     // Lean, non-PII pipeline counters. The browser console is filtered in prod, so
     // Node reads these via page.evaluate to see which stage stops producing.
     ;(window as any).__teamsNetDiag = (window as any).__teamsNetDiag || {
@@ -172,7 +180,9 @@ export function teamsBrowserInterceptionLogic() {
       captionResults: 0,
       captionMatched: 0,
       captionUnmatched: 0,
-      captionsEnabled: false
+      captionsEnabled: false,
+      // Caption interval overruling a live dsh — 0 on single-signal sessions.
+      rungCaptionOverDsh: 0
     }
     const diag = (window as any).__teamsNetDiag
 
@@ -517,8 +527,8 @@ export function teamsBrowserInterceptionLogic() {
           // window so attribution degrades rather than disappearing.
           captionSpeakingUntil.set(resolved, Date.now() + windowMs)
         }
-        // Only drive the speaker signal from captions when nothing better exists.
-        if (!csrcAvailable && !hasFreshDominantSpeaker()) {
+        // Every result, not only when dsh is dead — resolveSpeakingSet arbitrates.
+        if (!csrcAvailable) {
           broadcastSpeakerUpdate("caption")
         }
       } catch {
@@ -582,11 +592,26 @@ export function teamsBrowserInterceptionLogic() {
       return bestKey
     }
 
+    // Roster deviceIds sharing any of these caption identity keys.
+    function deviceIdsForIdentityKeys(activeKeys: Set<string>): Set<string> {
+      const out = new Set<string>()
+      if (activeKeys.size === 0) return out
+      for (const p of participantsByDeviceId.values()) {
+        if (activeKeys.has(identityKey(p.deviceId))) out.add(p.deviceId)
+      }
+      return out
+    }
+
+    // deviceIds whose caption interval CONTAINS tMs — no hold or window mixed in.
+    function captionDeviceIdsAtAudioTime(tMs: number): Set<string> {
+      const key = captionIdentityAt(tMs)
+      return deviceIdsForIdentityKeys(key ? new Set([key]) : new Set<string>())
+    }
+
     // Roster deviceIds speaking at tMs. Caption results that carried no usable
     // audio timing fall back to the wall-clock window, so a client that omits
     // timestampAudioSent still attributes rather than going silent.
     function getCaptionSpeakingDeviceIds(tMs: number, audioClock: boolean): Set<string> {
-      const out = new Set<string>()
       const activeKeys = new Set<string>()
       if (audioClock) {
         const byAudio = captionIdentityAt(tMs)
@@ -605,11 +630,7 @@ export function teamsBrowserInterceptionLogic() {
         if (until > now) activeKeys.add(key)
         else captionSpeakingUntil.delete(key)
       }
-      if (activeKeys.size === 0) return out
-      for (const p of participantsByDeviceId.values()) {
-        if (activeKeys.has(identityKey(p.deviceId))) out.add(p.deviceId)
-      }
-      return out
+      return deviceIdsForIdentityKeys(activeKeys)
     }
 
     // Does any roster participant share this caption identity key? Used to count
@@ -864,7 +885,22 @@ export function teamsBrowserInterceptionLogic() {
       const now = Date.now()
       if (source !== "caption") return now
       const audioStamp = captionExpiry ? lastCaptionAudioEndMs : lastCaptionAudioStartMs
-      return audioStamp > 0 ? Math.min(audioStamp, now) : now
+      if (audioStamp <= 0) return now
+      const stamp = Math.min(audioStamp, now)
+      // Hybrid only: a backdated caption would close the dsh segment before it
+      // opened and the tracker drops that as zero-length.
+      if (stamp < lastBroadcastStamp && hasFreshDominantSpeaker()) {
+        return Math.min(lastBroadcastStamp, now)
+      }
+      return stamp
+    }
+
+    // Rung labels only — no PII, this log ships to S3.
+    function logRungChange(rung: SpeakerTimelineRung): void {
+      if (rung === "caption-interval") diag.rungCaptionOverDsh++
+      if (rung === lastRung) return
+      lastRung = rung
+      debug("🎚️ speaker evidence rung →", rung)
     }
 
     // captionExpiry marks the update that ENDS a caption utterance. Two things
@@ -884,37 +920,25 @@ export function teamsBrowserInterceptionLogic() {
       // clock", not "who has a live window right now".
       const stamp = computeBroadcastStamp(source, captionExpiry)
 
-      // Priority: CSRC (silence == nobody) → dsh dominant speaker → captions.
-      // Captions are the fallback for server-mixed sessions that emit neither.
-      let speaking: Set<string>
-      if (csrcAvailable) {
-        speaking = getCsrcSpeakingIds()
-      } else {
-        const dominant = getDominantSpeakerParticipantId()
-        // A live caption window outranks a dsh event that has gone stale — on the
-        // mixed-audio sessions the single early dsh would otherwise pin its speaker
-        // for the whole call. A fresh dsh still wins; healthy sessions ramp dsh
-        // continuously and never reach the caption branch.
-        const captionSpeaking = !hasFreshDominantSpeaker()
-          ? getCaptionSpeakingDeviceIds(stamp, source === "caption")
-          : new Set<string>()
-        if (captionSpeaking.size > 0) {
-          speaking = captionSpeaking
-        } else if (
-          dominant &&
-          !captionExpiry &&
-          (!captionsEnabled || hasFreshDominantSpeaker())
-        ) {
-          // Gated on captionsEnabled, not on freshness alone: if Teams emits dsh
-          // only on speaker CHANGES, a freshness test would silence someone still
-          // mid-monologue on a healthy call. Captions only ever run on sessions
-          // whose dsh is already dead, so there a stale dominant must never come
-          // back — including on a roster update after the expiry emitted silence.
-          speaking = new Set([dominant])
-        } else {
-          speaking = new Set()
-        }
-      }
+      // One timeline: sources are evidence, ranked — none suppresses another.
+      const dominantFresh = hasFreshDominantSpeaker()
+      const decision = resolveSpeakingSet({
+        csrcAvailable,
+        csrcSpeaking: csrcAvailable ? Array.from(getCsrcSpeakingIds()) : [],
+        // Only scanned where the rung can fire.
+        captionAtInstant:
+          !csrcAvailable && dominantFresh ? Array.from(captionDeviceIdsAtAudioTime(stamp)) : [],
+        captionWindowed:
+          !csrcAvailable && !dominantFresh
+            ? Array.from(getCaptionSpeakingDeviceIds(stamp, source === "caption"))
+            : [],
+        dominant: getDominantSpeakerParticipantId(),
+        dominantFresh,
+        captionsEnabled,
+        captionExpiry
+      })
+      logRungChange(decision.rung)
+      const speaking = new Set(decision.deviceIds)
 
       const rawUsers = Array.from(participantsByDeviceId.values()).map((p) => ({
         deviceId: p.deviceId,
@@ -973,6 +997,8 @@ export function teamsBrowserInterceptionLogic() {
         // sits 1-3s late, which is the whole point of reading timestampAudioSent.
         // Never stamp ahead of now: a clock skew would put speech in the future.
         q.push({ users, timestamp: stamp, source })
+        // Only once the update is really on its way to Node.
+        lastBroadcastStamp = Math.max(lastBroadcastStamp, stamp)
         diag.broadcasts++
       } catch {
         // ignore

--- a/src/meeting/teams/network-interception/index.ts
+++ b/src/meeting/teams/network-interception/index.ts
@@ -4,6 +4,7 @@
 import path from "node:path"
 import type { Page } from "@playwright/test"
 import { teamsBrowserInterceptionLogic } from "./browser-bundle"
+import { resolveSpeakingSet } from "./speaker-timeline"
 
 export type { NetworkPayload, NetworkUser } from "./types"
 import type { NetworkPayload } from "./types"
@@ -42,7 +43,8 @@ export async function setupTeamsNetworkInterceptionScripts(page: Page): Promise<
                 if (!window.pako) {
                     console.error("[Teams NetworkInterceptor] pako dependency not loaded");
                 }
-                (${teamsBrowserInterceptionLogic.toString()})();
+                // As source: the stringified bundle cannot import it.
+                (${teamsBrowserInterceptionLogic.toString()})(${resolveSpeakingSet.toString()});
             } catch (e) {
                 console.error("[Teams NetworkInterceptor] Initialization error:", e);
             }

--- a/src/meeting/teams/network-interception/speaker-timeline.test.ts
+++ b/src/meeting/teams/network-interception/speaker-timeline.test.ts
@@ -1,0 +1,125 @@
+import { resolveSpeakingSet, type SpeakerTimelineEvidence } from "./speaker-timeline"
+
+function evidence(overrides: Partial<SpeakerTimelineEvidence> = {}): SpeakerTimelineEvidence {
+  return {
+    csrcAvailable: false,
+    csrcSpeaking: [],
+    captionAtInstant: [],
+    captionWindowed: [],
+    dominant: null,
+    dominantFresh: false,
+    captionsEnabled: false,
+    captionExpiry: false,
+    ...overrides
+  }
+}
+
+describe("resolveSpeakingSet — the hybrid dsh + caption session", () => {
+  // The bug: dsh stays fresh while still naming the previous speaker.
+  it("lets a caption interval containing the instant overrule a dsh that has not expired", () => {
+    const decision = resolveSpeakingSet(
+      evidence({
+        captionAtInstant: ["dev-b"],
+        dominant: "dev-a",
+        dominantFresh: true,
+        captionsEnabled: true
+      })
+    )
+
+    expect(decision).toEqual({ deviceIds: ["dev-b"], rung: "caption-interval" })
+  })
+
+  it("keeps the fresh dsh speaker when no caption covers the instant", () => {
+    // Between utterances dsh is the only continuous signal.
+    const decision = resolveSpeakingSet(
+      evidence({ dominant: "dev-a", dominantFresh: true, captionsEnabled: true })
+    )
+
+    expect(decision).toEqual({ deviceIds: ["dev-a"], rung: "dsh-fresh" })
+  })
+
+  it("emits silence on the caption expiry update rather than re-selecting either source", () => {
+    // Falling through to either source would swallow the silence.
+    const decision = resolveSpeakingSet(
+      evidence({
+        captionAtInstant: ["dev-b"],
+        dominant: "dev-a",
+        dominantFresh: true,
+        captionsEnabled: true,
+        captionExpiry: true
+      })
+    )
+
+    expect(decision).toEqual({ deviceIds: [], rung: "silence" })
+  })
+})
+
+describe("resolveSpeakingSet — unchanged behaviour on single-signal sessions", () => {
+  it("prefers CSRC over everything, including reading its silence as nobody", () => {
+    const decision = resolveSpeakingSet(
+      evidence({
+        csrcAvailable: true,
+        csrcSpeaking: [],
+        captionAtInstant: ["dev-b"],
+        dominant: "dev-a",
+        dominantFresh: true
+      })
+    )
+
+    expect(decision).toEqual({ deviceIds: [], rung: "csrc" })
+  })
+
+  it("uses the caption window when dsh is dead — the server-mixed-audio session", () => {
+    const decision = resolveSpeakingSet(
+      evidence({
+        captionWindowed: ["dev-b"],
+        dominant: "dev-a",
+        dominantFresh: false,
+        captionsEnabled: true
+      })
+    )
+
+    expect(decision).toEqual({ deviceIds: ["dev-b"], rung: "caption-window" })
+  })
+
+  it("never revives a stale dominant once captions are the working signal", () => {
+    // These sessions emit dsh once or not at all; it would pin one speaker.
+    const decision = resolveSpeakingSet(
+      evidence({ dominant: "dev-a", dominantFresh: false, captionsEnabled: true })
+    )
+
+    expect(decision).toEqual({ deviceIds: [], rung: "silence" })
+  })
+
+  it("holds a stale dominant on a session where captions never came up", () => {
+    // A stale dominant here is a monologue, and it is all the bot has.
+    const decision = resolveSpeakingSet(
+      evidence({ dominant: "dev-a", dominantFresh: false, captionsEnabled: false })
+    )
+
+    expect(decision).toEqual({ deviceIds: ["dev-a"], rung: "dsh-stale" })
+  })
+
+  it("reports silence when no source has anything to say", () => {
+    expect(resolveSpeakingSet(evidence())).toEqual({ deviceIds: [], rung: "silence" })
+  })
+})
+
+describe("resolveSpeakingSet — injectable into the page", () => {
+  // A closure would arrive undefined in the page — silent mis-attribution.
+  it("is self-contained enough to survive toString() + eval", () => {
+    // biome-ignore lint/security/noGlobalEval: this is the production injection path
+    const rehydrated = eval(`(${resolveSpeakingSet.toString()})`) as typeof resolveSpeakingSet
+
+    expect(
+      rehydrated(
+        evidence({
+          captionAtInstant: ["dev-b"],
+          dominant: "dev-a",
+          dominantFresh: true,
+          captionsEnabled: true
+        })
+      )
+    ).toEqual({ deviceIds: ["dev-b"], rung: "caption-interval" })
+  })
+})

--- a/src/meeting/teams/network-interception/speaker-timeline.test.ts
+++ b/src/meeting/teams/network-interception/speaker-timeline.test.ts
@@ -38,8 +38,9 @@ describe("resolveSpeakingSet — the hybrid dsh + caption session", () => {
     expect(decision).toEqual({ deviceIds: ["dev-a"], rung: "dsh-fresh" })
   })
 
-  it("emits silence on the caption expiry update rather than re-selecting either source", () => {
-    // Falling through to either source would swallow the silence.
+  it("hands the floor back to a live dsh when the caption utterance expires", () => {
+    // Only the expiry update ends a selected caption interval; emitting silence
+    // here would cut off a speaker dsh still reports as active.
     const decision = resolveSpeakingSet(
       evidence({
         captionAtInstant: ["dev-b"],
@@ -48,6 +49,14 @@ describe("resolveSpeakingSet — the hybrid dsh + caption session", () => {
         captionsEnabled: true,
         captionExpiry: true
       })
+    )
+
+    expect(decision).toEqual({ deviceIds: ["dev-a"], rung: "dsh-fresh" })
+  })
+
+  it("emits silence on expiry when dsh is not live either", () => {
+    const decision = resolveSpeakingSet(
+      evidence({ dominant: "dev-a", captionsEnabled: true, captionExpiry: true })
     )
 
     expect(decision).toEqual({ deviceIds: [], rung: "silence" })

--- a/src/meeting/teams/network-interception/speaker-timeline.ts
+++ b/src/meeting/teams/network-interception/speaker-timeline.ts
@@ -49,7 +49,9 @@ export function resolveSpeakingSet(evidence: SpeakerTimelineEvidence): SpeakerTi
     return { deviceIds: evidence.captionAtInstant, rung: "caption-interval" }
   }
 
-  if (evidence.dominant && !evidence.captionExpiry && evidence.dominantFresh) {
+  // Reached on expiry too: a live dsh is the right answer when an utterance ends,
+  // and emitting silence there would cut the speaker off mid-turn.
+  if (evidence.dominant && evidence.dominantFresh) {
     return { deviceIds: [evidence.dominant], rung: "dsh-fresh" }
   }
 

--- a/src/meeting/teams/network-interception/speaker-timeline.ts
+++ b/src/meeting/teams/network-interception/speaker-timeline.ts
@@ -1,0 +1,70 @@
+// Who was speaking at instant T. Ranks evidence instead of switching sources:
+// dsh only re-reports on a speaker CHANGE, so it stays "fresh" for DSH_FRESH_MS
+// while still naming the previous speaker.
+//
+// Separate from browser-bundle.ts, which is stringified and cannot import — this
+// is injected the same way, and is therefore testable.
+
+/** Which rung decided the answer. Logged, never PII. */
+export type SpeakerTimelineRung =
+  | "csrc"
+  | "caption-interval"
+  | "dsh-fresh"
+  | "caption-window"
+  | "dsh-stale"
+  | "silence"
+
+export interface SpeakerTimelineEvidence {
+  csrcAvailable: boolean
+  /** Only meaningful when csrcAvailable. */
+  csrcSpeaking: string[]
+  /** deviceIds whose caption interval CONTAINS the instant, on the audio clock. */
+  captionAtInstant: string[]
+  /** deviceIds from the caption hold + wall-clock windows. Superset of the above. */
+  captionWindowed: string[]
+  dominant: string | null
+  /** Whether the dsh event behind `dominant` is inside DSH_FRESH_MS. */
+  dominantFresh: boolean
+  /** True once caption results are arriving, not merely requested. */
+  captionsEnabled: boolean
+  /** This update ENDS an utterance: it must be able to emit silence. */
+  captionExpiry: boolean
+}
+
+export interface SpeakerTimelineDecision {
+  deviceIds: string[]
+  rung: SpeakerTimelineRung
+}
+
+/** Pure and closure-free — it is stringified into the page. */
+export function resolveSpeakingSet(evidence: SpeakerTimelineEvidence): SpeakerTimelineDecision {
+  if (evidence.csrcAvailable) {
+    return { deviceIds: evidence.csrcSpeaking, rung: "csrc" }
+  }
+
+  // A caption covering this instant beats a dsh that merely has not expired.
+  // Gated on dominantFresh so caption-only sessions keep their old behaviour:
+  // there rungs 3/5 cannot fire and captionWindowed already covers this set.
+  if (evidence.dominantFresh && !evidence.captionExpiry && evidence.captionAtInstant.length > 0) {
+    return { deviceIds: evidence.captionAtInstant, rung: "caption-interval" }
+  }
+
+  if (evidence.dominant && !evidence.captionExpiry && evidence.dominantFresh) {
+    return { deviceIds: [evidence.dominant], rung: "dsh-fresh" }
+  }
+
+  if (evidence.captionWindowed.length > 0) {
+    return { deviceIds: evidence.captionWindowed, rung: "caption-window" }
+  }
+
+  // Gated on captionsEnabled, not freshness: a healthy call may emit dsh only on
+  // changes, so dropping a stale dominant would silence a monologue.
+  if (evidence.dominant && !evidence.captionExpiry && !evidence.captionsEnabled) {
+    return { deviceIds: [evidence.dominant], rung: "dsh-stale" }
+  }
+
+  return { deviceIds: [], rung: "silence" }
+}
+
+/** Signature of the resolver as the browser bundle receives it. */
+export type SpeakerSetResolver = typeof resolveSpeakingSet


### PR DESCRIPTION
## Summary

Teams active-speaker attribution arbitrated its sources as a priority switch: whichever source ranked highest at that moment supplied the whole answer and the others were not consulted. dsh only re-reports on a speaker _change_, so it stays inside `DSH_FRESH_MS` (20s) while still naming the previous speaker — and on sessions where dsh and captions both run, the caption that lands mid-window already knows the turn changed, carries the speaker's identity, and was discarded for being the lower-ranked source. Turn changes were attributed to the wrong person.

This replaces the switch with a single ranked resolver, `resolveSpeakingSet` in `src/meeting/teams/network-interception/speaker-timeline.ts`, that ranks _evidence_ rather than sources: `csrc` → `caption-interval` → `dsh-fresh` → `caption-window` → `dsh-stale` → `silence`. A caption interval that contains the broadcast instant on the audio clock is a direct observation and now outranks a dsh event that has merely not expired. Caption results also broadcast unconditionally — the old `!hasFreshDominantSpeaker()` gate meant a hybrid session never produced a caption-driven update at all.

The new rung is gated on `dominantFresh` on purpose, so caption-only (server-mixed-audio) and dsh-only sessions resolve exactly as before; the only behavioural change is the hybrid case. Caption stamps stay backdated to the utterance's audio start, but are floored at the last stamp sent to Node while dsh is live: a caption stamped before the segment it closes is dropped by the tracker as zero-length, which would lose the turn instead of fixing it.

The resolver lives in its own module and is passed into `teamsBrowserInterceptionLogic` as a parameter, because the bundle is stringified into `addInitScript` and cannot import at runtime. That also makes the arbitration unit-testable, which the bundle itself is not.

Second commit, unrelated but in the same area: `DiarizationTracker` opened its append stream with no `error` listener, so an fs failure (ENOSPC on the pod's ephemeral disk) emitted an unhandled `'error'` event and took the bot process down mid-meeting — costing the recording, not just the diarization. It now drops the stream, logs once, and keeps accumulating in memory; `end()` already rewrites the file from that buffer.

## Testing

- `npx jest` — 245 pass. New `speaker-timeline.test.ts` covers all six rungs, including the hybrid case the change exists for, the caption-expiry silence path, and the single-signal sessions asserted unchanged. One test rehydrates the resolver through `toString()` + `eval` to catch a closure that would arrive `undefined` in the page.
- `diarization-tracker.test.ts` gains a case that emits ENOSPC on the stream and asserts both segments still reach the file and the failure is logged once.
- `tsc --noEmit` clean; biome findings unchanged from the base commit.
- `src/utils/meeting-state-detector.test.ts` was not run — it launches real Chromium, which is unavailable in the environment these were run in. It is untouched by this change.

## Release Notes

Operational. Teams transcripts on sessions that emit both dsh and live captions should attribute turn changes to the correct speaker instead of holding the previous one until the next dsh event. No config, no flag, no API change; caption-only and dsh-only sessions are unaffected by design.

To verify in prod, watch `rungCaptionOverDsh` in the Teams network diag counters: it counts how often a caption interval overruled a live dsh, so it should stay 0 on single-signal sessions and go non-zero exactly on the hybrid ones this targets.

The diarization tracker fix removes a crash path — a disk error during a meeting now degrades attribution instead of ending the recording.
