### PR TITLE
feat(meet): add dcrpc attribution shadow telemetry

### DIFF
--- a/src/speaker-attribution-shadow.test.ts
+++ b/src/speaker-attribution-shadow.test.ts
@@ -1,0 +1,132 @@
+import { SpeakerAttributionShadowTracker } from "./speaker-attribution-shadow"
+
+const SALT = Buffer.alloc(32, 7)
+
+function speaker(deviceId: string, name: string, isSpeaking = true) {
+  return { deviceId, name, isSpeaking }
+}
+
+function trackerWith(events: Array<Record<string, unknown>>) {
+  return new SpeakerAttributionShadowTracker({
+    salt: SALT,
+    logger: (event) => events.push(event)
+  })
+}
+
+describe("SpeakerAttributionShadowTracker", () => {
+  it("measures exact-device resolution without logging names or device ids", () => {
+    const events: Array<Record<string, unknown>> = []
+    const tracker = trackerWith(events)
+
+    tracker.observeNetwork([speaker("raw-device-a", "Unknown")], 1_000, "network:dcrpc")
+    tracker.observeUi([speaker("ui", "Alice")], 1_200)
+    tracker.observeNetwork([speaker("raw-device-a", "Alice", false)], 1_600, "network:roster")
+    tracker.finalize(2_000)
+
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      event: "resolved_exact_device",
+      resolver_source: "network:roster",
+      resolution_delay_ms: 600,
+      dcrpc_callbacks: 1,
+      dcrpc_speaking_callbacks: 1,
+      ui_candidate: {
+        samples: 1,
+        distinct_identities: 1,
+        first_delay_ms: 200,
+        matches_resolved: true
+      }
+    })
+    expect(events[1]).toMatchObject({
+      event: "summary",
+      unresolved_dcrpc_devices: 1,
+      exact_device_resolutions: 1,
+      unresolved_final: 0
+    })
+
+    const output = JSON.stringify(events)
+    expect(output).not.toContain("raw-device-a")
+    expect(output).not.toContain("Alice")
+    expect(events[0].device).toMatch(/^dev_[0-9a-f]{12}$/)
+    expect(events[0].identity).toMatch(/^spk_[0-9a-f]{12}$/)
+  })
+
+  it("validates a unique resolved network candidate against later exact identity", () => {
+    const events: Array<Record<string, unknown>> = []
+    const tracker = trackerWith(events)
+
+    tracker.observeNetwork([speaker("dcrpc-device", "Unknown")], 1_000, "network:dcrpc")
+    tracker.observeNetwork([speaker("csrc-device", "Alice")], 1_250, "network:audio")
+    tracker.observeNetwork([speaker("dcrpc-device", "Alice", false)], 1_900, "network:roster")
+
+    expect(events[0]).toMatchObject({
+      event: "resolved_exact_device",
+      network_candidate: {
+        samples: 1,
+        ambiguous_samples: 0,
+        distinct_identities: 1,
+        first_delay_ms: 250,
+        sources: ["network:audio"],
+        matches_resolved: true
+      }
+    })
+  })
+
+  it("marks candidate evidence ambiguous when multiple devices are pending", () => {
+    const events: Array<Record<string, unknown>> = []
+    const tracker = trackerWith(events)
+
+    tracker.observeNetwork(
+      [speaker("device-a", "Unknown"), speaker("device-b", "Unknown")],
+      1_000,
+      "network:dcrpc"
+    )
+    tracker.observeUi([speaker("ui", "Alice")], 1_200)
+    tracker.finalize(2_000)
+
+    const unresolved = events.filter((event) => event.event === "unresolved_final")
+    expect(unresolved).toHaveLength(2)
+    for (const event of unresolved) {
+      expect(event.ui_candidate).toMatchObject({
+        samples: 0,
+        ambiguous_samples: 1,
+        distinct_identities: 0,
+        identity: null
+      })
+    }
+  })
+
+  it("reports a consistent candidate for a device that never resolves", () => {
+    const events: Array<Record<string, unknown>> = []
+    const tracker = trackerWith(events)
+
+    tracker.observeNetwork([speaker("device-a", "Unknown")], 1_000, "network:dcrpc")
+    tracker.observeUi([speaker("ui", "Alice")], 1_100)
+    tracker.observeUi([speaker("ui", "Alice")], 1_300)
+    tracker.finalize(2_000)
+
+    expect(events[0]).toMatchObject({
+      event: "unresolved_final",
+      pending_age_ms: 1_000,
+      ui_candidate: {
+        samples: 2,
+        ambiguous_samples: 0,
+        distinct_identities: 1,
+        first_delay_ms: 100,
+        last_delay_ms: 300,
+        matches_resolved: null
+      }
+    })
+  })
+
+  it("finalizes once", () => {
+    const events: Array<Record<string, unknown>> = []
+    const tracker = trackerWith(events)
+
+    tracker.finalize(1_000)
+    tracker.finalize(2_000)
+
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe("summary")
+  })
+})

--- a/src/speaker-attribution-shadow.ts
+++ b/src/speaker-attribution-shadow.ts
@@ -1,0 +1,287 @@
+import { createHmac, randomBytes } from "node:crypto"
+
+type ShadowSpeaker = {
+  deviceId?: string
+  name?: string
+  isSpeaking: boolean
+}
+
+type CandidateEvidence = {
+  samples: number
+  ambiguousSamples: number
+  firstAtMs: number | null
+  lastAtMs: number | null
+  identities: Set<string>
+  sources: Set<string>
+}
+
+type PendingDevice = {
+  token: string
+  firstUnresolvedAtMs: number
+  lastUnresolvedAtMs: number
+  dcrpcCallbacks: number
+  dcrpcSpeakingCallbacks: number
+  network: CandidateEvidence
+  ui: CandidateEvidence
+}
+
+type ShadowEvent = Record<string, unknown>
+
+type ShadowTrackerOptions = {
+  salt?: Uint8Array
+  logger?: (event: ShadowEvent) => void
+}
+
+const KNOWN_SOURCES = new Set([
+  "network:audio",
+  "network:dcrpc",
+  "network:health_check",
+  "network:roster",
+  "network:unknown",
+  "ui-observer"
+])
+
+function candidateEvidence(): CandidateEvidence {
+  return {
+    samples: 0,
+    ambiguousSamples: 0,
+    firstAtMs: null,
+    lastAtMs: null,
+    identities: new Set(),
+    sources: new Set()
+  }
+}
+
+/**
+ * Shadow-only evidence for deciding whether unresolved dcrpc speech can safely
+ * wait for CSRC, roster, or UI identity. It never changes live attribution.
+ *
+ * Raw device ids and names stay in memory. Logs contain only per-process HMAC
+ * tokens, so events can be correlated within one meeting but not across bots.
+ */
+export class SpeakerAttributionShadowTracker {
+  private readonly salt: Uint8Array
+  private readonly logger: (event: ShadowEvent) => void
+  private readonly pending = new Map<string, PendingDevice>()
+  private createdDevices = 0
+  private resolvedDevices = 0
+  private finalized = false
+  private readonly resolverSources = new Map<string, number>()
+
+  public constructor(options: ShadowTrackerOptions = {}) {
+    this.salt = options.salt ?? randomBytes(32)
+    this.logger =
+      options.logger ?? ((event) => console.log(`[SPEAKER-SHADOW] ${JSON.stringify(event)}`))
+  }
+
+  public observeNetwork(speakers: ShadowSpeaker[], timestamp: number, source: string): void {
+    if (this.finalized) return
+
+    const atMs = this.validTimestamp(timestamp)
+    const safeSource = this.safeSource(source)
+
+    // First update exact-device state. A roster/CSRC callback can resolve a
+    // device even when it is not speaking anymore.
+    for (const speaker of speakers) {
+      const deviceId = speaker.deviceId?.trim()
+      if (!deviceId) continue
+
+      const name = this.resolvedName(speaker.name)
+      if (name) {
+        this.resolvePendingDevice(deviceId, name, atMs, safeSource)
+        continue
+      }
+
+      if (safeSource !== "network:dcrpc") continue
+      const existing = this.pending.get(deviceId)
+      if (!speaker.isSpeaking && !existing) continue
+
+      const pending = existing ?? this.createPendingDevice(deviceId, atMs)
+      pending.lastUnresolvedAtMs = atMs
+      pending.dcrpcCallbacks += 1
+      if (speaker.isSpeaking) pending.dcrpcSpeakingCallbacks += 1
+    }
+
+    // A resolved CSRC/roster speaker on a different device is useful candidate
+    // evidence, but safe only with one pending device and one active identity.
+    if (safeSource !== "network:dcrpc") {
+      const activeNames = speakers
+        .filter((speaker) => speaker.isSpeaking)
+        .map((speaker) => this.resolvedName(speaker.name))
+        .filter((name): name is string => Boolean(name))
+      this.recordCandidates("network", activeNames, safeSource, atMs)
+    }
+  }
+
+  /** Record UI evidence even while current arbitration mutes UI attribution. */
+  public observeUi(speakers: ShadowSpeaker[], timestamp: number): void {
+    if (this.finalized) return
+
+    const activeNames = speakers
+      .filter((speaker) => speaker.isSpeaking)
+      .map((speaker) => this.resolvedName(speaker.name))
+      .filter((name): name is string => Boolean(name))
+    this.recordCandidates("ui", activeNames, "ui-observer", this.validTimestamp(timestamp))
+  }
+
+  public finalize(timestamp: number): void {
+    if (this.finalized) return
+    this.finalized = true
+    const atMs = this.validTimestamp(timestamp)
+
+    for (const pending of this.pending.values()) {
+      this.emit({
+        schema_version: 1,
+        event: "unresolved_final",
+        device: pending.token,
+        first_unresolved_at_ms: pending.firstUnresolvedAtMs,
+        last_unresolved_at_ms: pending.lastUnresolvedAtMs,
+        pending_age_ms: Math.max(0, atMs - pending.firstUnresolvedAtMs),
+        dcrpc_callbacks: pending.dcrpcCallbacks,
+        dcrpc_speaking_callbacks: pending.dcrpcSpeakingCallbacks,
+        network_candidate: this.summarizeEvidence(
+          pending.network,
+          pending.firstUnresolvedAtMs
+        ),
+        ui_candidate: this.summarizeEvidence(pending.ui, pending.firstUnresolvedAtMs)
+      })
+    }
+
+    this.emit({
+      schema_version: 1,
+      event: "summary",
+      unresolved_dcrpc_devices: this.createdDevices,
+      exact_device_resolutions: this.resolvedDevices,
+      unresolved_final: this.pending.size,
+      resolver_sources: Object.fromEntries(this.resolverSources)
+    })
+  }
+
+  private createPendingDevice(deviceId: string, atMs: number): PendingDevice {
+    const pending: PendingDevice = {
+      token: this.token("device", deviceId),
+      firstUnresolvedAtMs: atMs,
+      lastUnresolvedAtMs: atMs,
+      dcrpcCallbacks: 0,
+      dcrpcSpeakingCallbacks: 0,
+      network: candidateEvidence(),
+      ui: candidateEvidence()
+    }
+    this.pending.set(deviceId, pending)
+    this.createdDevices += 1
+    return pending
+  }
+
+  private resolvePendingDevice(deviceId: string, name: string, atMs: number, source: string): void {
+    const pending = this.pending.get(deviceId)
+    if (!pending) return
+
+    const identity = this.token("identity", this.normalizeName(name))
+    this.pending.delete(deviceId)
+    this.resolvedDevices += 1
+    this.resolverSources.set(source, (this.resolverSources.get(source) ?? 0) + 1)
+
+    this.emit({
+      schema_version: 1,
+      event: "resolved_exact_device",
+      device: pending.token,
+      identity,
+      resolver_source: source,
+      first_unresolved_at_ms: pending.firstUnresolvedAtMs,
+      resolved_at_ms: atMs,
+      resolution_delay_ms: Math.max(0, atMs - pending.firstUnresolvedAtMs),
+      dcrpc_callbacks: pending.dcrpcCallbacks,
+      dcrpc_speaking_callbacks: pending.dcrpcSpeakingCallbacks,
+      network_candidate: this.summarizeEvidence(
+        pending.network,
+        pending.firstUnresolvedAtMs,
+        identity
+      ),
+      ui_candidate: this.summarizeEvidence(pending.ui, pending.firstUnresolvedAtMs, identity)
+    })
+  }
+
+  private recordCandidates(
+    kind: "network" | "ui",
+    names: string[],
+    source: string,
+    atMs: number
+  ): void {
+    if (this.pending.size === 0 || names.length === 0) return
+
+    const identities = new Set(
+      names.map((name) => this.token("identity", this.normalizeName(name)))
+    )
+    if (this.pending.size === 1 && identities.size === 1) {
+      const pending = this.pending.values().next().value as PendingDevice
+      const evidence = pending[kind]
+      evidence.samples += 1
+      evidence.firstAtMs ??= atMs
+      evidence.lastAtMs = atMs
+      evidence.identities.add(identities.values().next().value as string)
+      evidence.sources.add(source)
+      return
+    }
+
+    for (const pending of this.pending.values()) {
+      pending[kind].ambiguousSamples += 1
+    }
+  }
+
+  private summarizeEvidence(
+    evidence: CandidateEvidence,
+    pendingAtMs: number,
+    resolvedIdentity?: string
+  ) {
+    const singleIdentity =
+      evidence.identities.size === 1 ? evidence.identities.values().next().value : null
+    return {
+      samples: evidence.samples,
+      ambiguous_samples: evidence.ambiguousSamples,
+      distinct_identities: evidence.identities.size,
+      identity: singleIdentity,
+      first_delay_ms:
+        evidence.firstAtMs === null ? null : Math.max(0, evidence.firstAtMs - pendingAtMs),
+      last_delay_ms:
+        evidence.lastAtMs === null ? null : Math.max(0, evidence.lastAtMs - pendingAtMs),
+      sources: [...evidence.sources].sort(),
+      matches_resolved:
+        resolvedIdentity && singleIdentity ? singleIdentity === resolvedIdentity : null
+    }
+  }
+
+  private resolvedName(name: string | undefined): string | null {
+    const normalized = name?.trim()
+    if (!normalized || normalized.toLocaleLowerCase() === "unknown") return null
+    return normalized
+  }
+
+  private normalizeName(name: string): string {
+    return name.normalize("NFKC").trim().replace(/\s+/g, " ").toLocaleLowerCase()
+  }
+
+  private safeSource(source: string): string {
+    return KNOWN_SOURCES.has(source) ? source : "network:unknown"
+  }
+
+  private validTimestamp(timestamp: number): number {
+    return Number.isFinite(timestamp) && timestamp > 0 ? Math.round(timestamp) : Date.now()
+  }
+
+  private token(kind: "device" | "identity", value: string): string {
+    const digest = createHmac("sha256", this.salt)
+      .update(`${kind}\0${value}`)
+      .digest("hex")
+      .slice(0, 12)
+    return `${kind === "device" ? "dev" : "spk"}_${digest}`
+  }
+
+  private emit(event: ShadowEvent): void {
+    try {
+      this.logger(event)
+    } catch {
+      // Diagnostic-only path must never affect recording or finalization.
+      console.error("[SPEAKER-SHADOW] telemetry_error")
+    }
+  }
+}

--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -153,6 +153,39 @@ describe("SpeakerManager UI bridge arbitration", () => {
     expect(registeredParticipants).not.toContain("Late UI Speaker")
   })
 
+  it("keeps shadow UI evidence while unresolved dcrpc mutes attribution", async () => {
+    const manager = SpeakerManager.getInstance()
+    const log = jest.spyOn(console, "log").mockImplementation(() => {})
+
+    await manager.handleNetworkSpeakerUpdate(
+      [networkUser("Unknown", true, "device-1")],
+      1785941000000,
+      "network:dcrpc"
+    )
+    await manager.handleUiBridgeUpdate([uiSpeaker("Alice", true)])
+    await manager.handleNetworkSpeakerUpdate(
+      [networkUser("Alice", false, "device-1")],
+      1785941000600,
+      "network:roster"
+    )
+
+    // UI remains muted for product behavior.
+    expect(registeredSpeakers).toEqual(["Unknown"])
+    // Alice enters participants only when the later roster callback resolves her.
+    expect(registeredParticipants).toContain("Alice")
+
+    const shadowLine = log.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes('"event":"resolved_exact_device"'))
+    if (!shadowLine) throw new Error("resolved shadow event not logged")
+    const event = JSON.parse(shadowLine.slice(shadowLine.indexOf("{")))
+    expect(event.ui_candidate).toMatchObject({
+      samples: 1,
+      distinct_identities: 1,
+      matches_resolved: true
+    })
+  })
+
   it("does not mute the bridge on roster-only network updates (nobody speaking)", async () => {
     const manager = SpeakerManager.getInstance()
     await manager.handleNetworkSpeakerUpdate([networkUser("Silent Sam", false, "device-3")], 1785941000000)

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -6,6 +6,7 @@ import { GLOBAL } from "./singleton"
 import { MeetingStateMachine } from "./state-machine/machine"
 import type { ParticipantState } from "./state-machine/types"
 import { Streaming } from "./streaming"
+import { SpeakerAttributionShadowTracker } from "./speaker-attribution-shadow"
 import { type Participant, type SpeakerData, UNKNOWN_SPEAKER } from "./types"
 import { PathManager } from "./utils/PathManager"
 import { PiiRedactor } from "./utils/PiiRedactor"
@@ -41,6 +42,8 @@ export class SpeakerManager {
   // seconds after they first speak — Meet's UI indicator fires much earlier.
   private networkSpeakerActive = false
   private uiBridgeMuteLogged = false
+  // Diagnostic-only arbitration evidence. Never changes speaker ownership.
+  private readonly attributionShadow = new SpeakerAttributionShadowTracker()
 
   private constructor() {}
 
@@ -95,21 +98,34 @@ export class SpeakerManager {
    */
   public static async finalize(): Promise<void> {
     const instance = SpeakerManager.getInstance()
-    if (instance.diarizationTracker) {
-      const lastTimestamp = Date.now()
-      const meetingStartTime = MeetingStateMachine.instance.getStartTime()
-      if (meetingStartTime) {
-        // Hand over the FINAL roster so any segment written while a participant
-        // was still unnamed gets repaired before the artifact is uploaded. The
-        // live path can only ever fix the segment that is still open; by the end
-        // of the meeting we know every name we are ever going to know.
-        await instance.diarizationTracker.end(
-          lastTimestamp,
-          meetingStartTime,
-          (deviceId) => instance.resolveDeviceForBackfill(deviceId),
-          (userId) => instance.userIdNames.get(userId)
-        )
+    const lastTimestamp = Date.now()
+    try {
+      if (instance.diarizationTracker) {
+        const meetingStartTime = MeetingStateMachine.instance.getStartTime()
+        if (meetingStartTime) {
+          // Hand over the FINAL roster so any segment written while a participant
+          // was still unnamed gets repaired before the artifact is uploaded. The
+          // live path can only ever fix the segment that is still open; by the end
+          // of the meeting we know every name we are ever going to know.
+          await instance.diarizationTracker.end(
+            lastTimestamp,
+            meetingStartTime,
+            (deviceId) => instance.resolveDeviceForBackfill(deviceId),
+            (userId) => instance.userIdNames.get(userId)
+          )
+        }
       }
+    } finally {
+      instance.observeAttributionShadow(() => instance.attributionShadow.finalize(lastTimestamp))
+    }
+  }
+
+  /** Shadow telemetry must never change recording or finalization behavior. */
+  private observeAttributionShadow(observe: () => void): void {
+    try {
+      observe()
+    } catch {
+      console.error("[SPEAKER-SHADOW] telemetry_error")
     }
   }
 
@@ -150,6 +166,16 @@ export class SpeakerManager {
    * automatically and the same observer becomes the primary source.
    */
   public async handleUiBridgeUpdate(observed: SpeakerData[]): Promise<void> {
+    const timestamps = observed
+      .map((speaker) => speaker.timestamp)
+      .filter((timestamp) => Number.isFinite(timestamp) && timestamp > 0)
+    this.observeAttributionShadow(() =>
+      this.attributionShadow.observeUi(
+        observed,
+        timestamps.length > 0 ? Math.max(...timestamps) : Date.now()
+      )
+    )
+
     const networkRetired =
       GLOBAL.hasNetworkInterceptionSetupFailed() || GLOBAL.hasDiarizationFallbackTriggered()
 
@@ -255,7 +281,7 @@ export class SpeakerManager {
   public async handleNetworkSpeakerUpdate(
     networkUsers: NetworkUser[],
     timestamp: number,
-    source: string = "network"
+    source = "network"
   ): Promise<void> {
     // Once the fallback has retired the network path, the UI observer is the
     // primary source. Stopping the page-side interceptor is best-effort, so a
@@ -324,6 +350,10 @@ export class SpeakerManager {
           isSpeaking
         }
       })
+
+      this.observeAttributionShadow(() =>
+        this.attributionShadow.observeNetwork(speakers, timestamp, source)
+      )
 
       // First actual speaker from the network path mutes the UI bridge — from
       // here the track-based signal is live and authoritative.


### PR DESCRIPTION
## Why

Post-rollout Unknown speaker intervals are concentrated in Meet sessions where unresolved dcrpc owns attribution. Existing source logs omit device/name correlation, and UI evidence is invisible after the network path mutes it. Historical artifacts therefore cannot prove whether delayed roster, CSRC, or UI identity is safe to use.

## What

- Track unresolved speaking dcrpc devices without changing attribution.
- Emit exact same-device resolution source and delay.
- Record resolved CSRC/roster candidates only when one device and one identity are active.
- Record UI candidates even while UI attribution is muted.
- Report ambiguity, candidate consistency, and whether candidates match a later exact identity.
- Emit one per-meeting summary plus one result per affected device.
- HMAC device IDs and names with a random process-local key. Raw identities never enter telemetry.

Events use the `[SPEAKER-SHADOW]` prefix and JSON schema version 1:

- `resolved_exact_device`
- `unresolved_final`
- `summary`

No speaker ownership, diarization, streaming, or fallback behavior changes.

## 2-3 day decision

After this reaches production and accumulates 2-3 days:

1. Measure exact-device resolution rate and delay percentiles by resolver source.
2. Measure precision of unique CSRC/roster and UI candidates against later exact-device truth.
3. Measure candidate consistency for devices still unresolved at meeting end.
4. Select a bounded hold from observed delay distribution only if coverage and precision justify it.
5. Keep ambiguous/multi-device cases Unknown; never infer from timing alone.

## Verification

- 27 related Jest tests pass.
- TypeScript no-emit check passes.
- Biome lint passes for changed files.