### PR TITLE
fix(zoom): narrow removal detection

### DIFF
--- a/src/chat-manager.ts
+++ b/src/chat-manager.ts
@@ -5,7 +5,6 @@ import type { Page } from "@playwright/test"
 import axios from "./api/axios-instance"
 import { envVars } from "./config/env-vars"
 import type { ChatObserver } from "./meeting/chatObserver"
-import { markZoomEntryMessageSent } from "./meeting/zoom/entry-message-timing"
 import { GLOBAL } from "./singleton"
 import type { ChatMessageData, MeetingProvider } from "./types"
 import { formatError } from "./utils/Logger"
@@ -286,11 +285,6 @@ export class ChatManager {
       await page.keyboard.press("Enter")
 
       this.persistBotSentMessage(message)
-      // Record when the bot's own chat bubble was posted. The end-of-meeting
-      // denial scanner must not trust a "removed"/"ended" text match right after
-      // this — Zoom echoes our own message into the chat list (2026-08 Noota
-      // incident). zoom.ts consults this during its grace window.
-      markZoomEntryMessageSent()
       return { success: true }
     } catch (error) {
       console.error("[ChatManager] Zoom send failed:", formatError(error))

--- a/src/chat-manager.ts
+++ b/src/chat-manager.ts
@@ -180,13 +180,8 @@ export class ChatManager {
       const { sendChatMessage } = await import("./meeting/meet/network-interception")
       const success = await sendChatMessage(page, message)
       if (success) {
-this.persistBotSentMessage(message)
-      // Record when the bot's own chat bubble was posted. The end-of-meeting
-      // denial scanner must not trust a "removed"/"ended" text match right after
-      // this — Zoom echoes our own message into the chat list (2026-08 Noota
-      // incident). zoom.ts consults this during its grace window.
-      markZoomEntryMessageSent()
-      return { success: true }
+        this.persistBotSentMessage(message)
+        return { success: true }
       }
       return { success: false, error: "Failed to send chat message via network", status: 500 }
     } catch (error) {
@@ -291,6 +286,11 @@ this.persistBotSentMessage(message)
       await page.keyboard.press("Enter")
 
       this.persistBotSentMessage(message)
+      // Record when the bot's own chat bubble was posted. The end-of-meeting
+      // denial scanner must not trust a "removed"/"ended" text match right after
+      // this — Zoom echoes our own message into the chat list (2026-08 Noota
+      // incident). zoom.ts consults this during its grace window.
+      markZoomEntryMessageSent()
       return { success: true }
     } catch (error) {
       console.error("[ChatManager] Zoom send failed:", formatError(error))

--- a/src/chat-manager.ts
+++ b/src/chat-manager.ts
@@ -5,6 +5,7 @@ import type { Page } from "@playwright/test"
 import axios from "./api/axios-instance"
 import { envVars } from "./config/env-vars"
 import type { ChatObserver } from "./meeting/chatObserver"
+import { markZoomEntryMessageSent } from "./meeting/zoom/entry-message-timing"
 import { GLOBAL } from "./singleton"
 import type { ChatMessageData, MeetingProvider } from "./types"
 import { formatError } from "./utils/Logger"
@@ -179,8 +180,13 @@ export class ChatManager {
       const { sendChatMessage } = await import("./meeting/meet/network-interception")
       const success = await sendChatMessage(page, message)
       if (success) {
-        this.persistBotSentMessage(message)
-        return { success: true }
+this.persistBotSentMessage(message)
+      // Record when the bot's own chat bubble was posted. The end-of-meeting
+      // denial scanner must not trust a "removed"/"ended" text match right after
+      // this — Zoom echoes our own message into the chat list (2026-08 Noota
+      // incident). zoom.ts consults this during its grace window.
+      markZoomEntryMessageSent()
+      return { success: true }
       }
       return { success: false, error: "Failed to send chat message via network", status: 500 }
     } catch (error) {

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -59,6 +59,14 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
       // [class*="modal"] was rejected in review because it also matches
       // settings/feedback modals, which must never be treated as end-of-meeting
       // UI.
+      //
+      // Accepted residual risk (deliberate, false-negative-averse): `.zm-modal`
+      // is Zoom's generic modal class, so a hypothetical non-removal dialog
+      // rendering one of these phrases would still match. Tightening further
+      // (e.g. requiring a `modal-body-title` descendant) risks MISSING genuine
+      // removals when Zoom's markup shifts — a bot lingering in a dead meeting
+      // is worse than a rare early exit. Keep this broad enough to always catch
+      // the real removal modal.
       scopeSelectors: [
         ".zm-modal",
         '[class*="meeting-ended"]',

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -1,5 +1,6 @@
 import { MeetingEndReason } from "../state-machine/types"
 import type { StateDetectionConfig } from "../utils/meeting-state-detector"
+import { CHAT_IGNORE_SELECTORS } from "./zoom/chat-selectors"
 
 /**
  * Zoom Web Client (browser) state-detection config (live-DOM-verified).
@@ -49,7 +50,20 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
       ],
       reason: MeetingEndReason.BotRemoved,
       logPrefix: "XXXXXXXXXXXXXXXXXX Zoom removed the bot / meeting ended",
-      errorMessage: "Bot removed or Zoom meeting ended"
+      errorMessage: "Bot removed or Zoom meeting ended",
+      // POSITIVE scoping: these phrases must ONLY count inside genuine Zoom
+      // end-of-meeting UI (modal / full-page end screen). They are never scanned
+      // on the general page, so chat content — including the bot's own entry
+      // message — can never trip BotRemoved again, even in a chat container the
+      // ignore-list does not (yet) know about.
+      scopeSelectors: [
+        ".zm-modal",
+        '[class*="modal"]',
+        '[class*="meeting-ended"]',
+        '[class*="ended-meeting"]',
+        '[class*="end-screen"]',
+        '[class*="leave-page"]'
+      ]
     }
   ],
   // Never treat chat content as a meeting-end signal. The bot's own entry chat
@@ -58,23 +72,9 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
   // message was sent — the bot killed itself 1-2s after joining. Any participant
   // typing "removed from the meeting"/"meeting has ended" into chat (message or
   // the compose box) would do the same. Genuine removal/meeting-ended UI is a
-  // Zoom modal / full-page overlay (.zm-modal, leave page), never inside the
-  // chat panel (#chat > .chat-container, items .new-chat-item__*/
-  // .new-chat-message__*, compose .chat-rtf-box__*).
-  denialIgnoreWithinSelectors: [
-    "#chat",
-    ".chat-container",
-    '[aria-label="Chat Message List"]',
-    ".chat-virtuoso-wrapper",
-    "#chat-list-content",
-    ".chat-list-content",
-    ".chat-container__chat-list",
-    ".chat-rtf-box__editor-outer",
-    '[id^="chat-message-"]',
-    '[class*="new-chat"]',
-    '[class*="chat-message"]',
-    '[class*="chatMessage"]'
-  ],
+  // Zoom modal / full-page overlay, never inside a chat subtree. The list is
+  // shared with ZoomChatObserver (single source of truth) so it can't drift.
+  denialIgnoreWithinSelectors: [...CHAT_IGNORE_SELECTORS],
   waitingRoomPattern: {
     // The waiting room has no unique class — only text. Substring match survives
     // minor copy changes.

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -55,10 +55,12 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
       // end-of-meeting UI (modal / full-page end screen). They are never scanned
       // on the general page, so chat content — including the bot's own entry
       // message — can never trip BotRemoved again, even in a chat container the
-      // ignore-list does not (yet) know about.
+      // ignore-list does not (yet) know about. Deliberately narrow: the generic
+      // [class*="modal"] was rejected in review because it also matches
+      // settings/feedback modals, which must never be treated as end-of-meeting
+      // UI.
       scopeSelectors: [
         ".zm-modal",
-        '[class*="modal"]',
         '[class*="meeting-ended"]',
         '[class*="ended-meeting"]',
         '[class*="end-screen"]',

--- a/src/meeting/zoom-state-config.ts
+++ b/src/meeting/zoom-state-config.ts
@@ -43,7 +43,6 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
         "This meeting has been ended by host",
         "host ended the meeting",
         "ended by the host",
-        "removed from the meeting",
         "You have been removed",
         "meeting has ended",
         "Meeting has ended"
@@ -65,8 +64,16 @@ export const ZOOM_STATE_CONFIG: StateDetectionConfig = {
   denialIgnoreWithinSelectors: [
     "#chat",
     ".chat-container",
+    '[aria-label="Chat Message List"]',
+    ".chat-virtuoso-wrapper",
+    "#chat-list-content",
+    ".chat-list-content",
+    ".chat-container__chat-list",
     ".chat-rtf-box__editor-outer",
-    '[class*="new-chat"]'
+    '[id^="chat-message-"]',
+    '[class*="new-chat"]',
+    '[class*="chat-message"]',
+    '[class*="chatMessage"]'
   ],
   waitingRoomPattern: {
     // The waiting room has no unique class — only text. Substring match survives

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -64,7 +64,7 @@ const LEAVE_GRACE_MS = 20_000
 // chat list. Depending on the DOM it may land in a container the denial
 // scanner's ignore-list does not know yet, and the message text can contain
 // denial-ish wording ("…can be removed from the meeting…") — which killed bots
-// ~200-700ms after joining (2026-08 Noota incident). During this window a
+// ~200-700ms after joining (2026-08 production incident). During this window a
 // denial match is only trusted if the in-meeting controls (Leave button) are
 // GONE — i.e. a genuine removal would hide them — otherwise the echo of our own
 // message must never end the meeting.

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -15,6 +15,7 @@ import { humanClick, humanType } from "../utils/humanize"
 import { formatError } from "../utils/Logger"
 import { createStateDetector } from "../utils/meeting-state-detector"
 import { sleep } from "../utils/sleep"
+import { getZoomEntryMessageSentAt } from "./zoom/entry-message-timing"
 import { ZOOM_STATE_CONFIG } from "./zoom-state-config"
 
 // Zoom Web Client selectors (verified against the live DOM). Two client variants
@@ -58,6 +59,16 @@ const HOST_NOT_STARTED_MAX_WAIT_MS = 10 * 60 * 1000
 // any transient repaint.
 const LEAVE_MISS_THRESHOLD = 3
 const LEAVE_GRACE_MS = 20_000
+
+// After the bot posts its entry chat message, Zoom echoes it into the rendered
+// chat list. Depending on the DOM it may land in a container the denial
+// scanner's ignore-list does not know yet, and the message text can contain
+// denial-ish wording ("…can be removed from the meeting…") — which killed bots
+// ~200-700ms after joining (2026-08 Noota incident). During this window a
+// denial match is only trusted if the in-meeting controls (Leave button) are
+// GONE — i.e. a genuine removal would hide them — otherwise the echo of our own
+// message must never end the meeting.
+const ENTRY_MESSAGE_GRACE_MS = 10_000
 
 const zoomStateDetector = createStateDetector(ZOOM_STATE_CONFIG)
 
@@ -822,11 +833,33 @@ export class ZoomProvider implements MeetingProviderInterface {
       return true
     }
 
-    // Removal / meeting-ended modal text.
+    // Removal / meeting-ended modal text. Within the post-entry-message grace
+    // window this is only trusted if the in-meeting controls are gone (a real
+    // removal hides the Leave button) — otherwise the bot's own echoed chat
+    // message could kill the meeting.
     const denied = await zoomStateDetector.isDenied(page)
     if (denied.matched) {
-      console.log(`[Zoom] End detected: "${denied.matchedText}"`)
-      return true
+      const entrySentAt = getZoomEntryMessageSentAt()
+      const withinEntryGrace =
+        entrySentAt !== null && Date.now() - entrySentAt < ENTRY_MESSAGE_GRACE_MS
+      if (withinEntryGrace) {
+        const leaveStillVisible = await page
+          .locator(LEAVE_BUTTON)
+          .first()
+          .isVisible({ timeout: 300 })
+          .catch(() => false)
+        if (leaveStillVisible) {
+          console.warn(
+            `[Zoom] Suppressed denial match "${denied.matchedText}" within entry-message grace window (${Date.now() - entrySentAt}ms, Leave still visible)`
+          )
+        } else {
+          console.log(`[Zoom] End detected: "${denied.matchedText}"`)
+          return true
+        }
+      } else {
+        console.log(`[Zoom] End detected: "${denied.matchedText}"`)
+        return true
+      }
     }
 
     // Leave button gone → probably removed. But recording-state ends the meeting

--- a/src/meeting/zoom/chat-selectors.ts
+++ b/src/meeting/zoom/chat-selectors.ts
@@ -1,0 +1,46 @@
+/**
+ * Single source of truth for the Zoom Web chat DOM selectors.
+ *
+ * Both the chat reader (ZoomChatObserver) and the end-of-meeting denial scanner
+ * (zoom-state-config) need to know where chat content lives. Keeping them in one
+ * place means the denial scanner's ignore-list can never drift from what the
+ * observer actually reads — the exact gap that let the bot's own entry message
+ * ("…can be removed from the meeting…") escape the ignore-list and kill the bot
+ * ~200ms after joining (2026-08 Noota incident, bots c97b775f / ee8053f9).
+ *
+ * The observer must pass these into page.evaluate as ARGS (Playwright
+ * serializes them into the page context); the denial scanner imports them
+ * directly on the Node side.
+ */
+
+export const CHAT_CONTAINER_SELECTORS = [
+  '[aria-label="Chat Message List"]',
+  ".chat-virtuoso-wrapper",
+  "#chat-list-content",
+  ".chat-list-content",
+  ".chat-container__chat-list",
+  '[class*="chat-list"]',
+  '[class*="chat-message-list"]'
+] as const
+
+export const CHAT_MESSAGE_SELECTORS = [
+  '[id^="chat-message-"]',
+  ".new-chat-message__container",
+  '[class*="chat-message-item"]',
+  '[class*="chatMessage"]',
+  "div[data-index]"
+] as const
+
+/**
+ * Every subtree whose text must NEVER be treated as a meeting-end/denial signal.
+ * Union of the chat containers/message items the observer reads, plus the
+ * top-level chat panel roots and the compose editor.
+ */
+export const CHAT_IGNORE_SELECTORS: readonly string[] = [
+  ...CHAT_CONTAINER_SELECTORS,
+  ...CHAT_MESSAGE_SELECTORS,
+  "#chat",
+  ".chat-container",
+  ".chat-rtf-box__editor-outer",
+  '[class*="new-chat"]'
+]

--- a/src/meeting/zoom/chat-selectors.ts
+++ b/src/meeting/zoom/chat-selectors.ts
@@ -32,13 +32,26 @@ export const CHAT_MESSAGE_SELECTORS = [
 ] as const
 
 /**
+ * Chat-scoped forms of the generic virtualized-row selector, used only by the
+ * denial ignore-list. The bare `div[data-index]` also matches participants
+ * lists and other virtualized panels anywhere in the Zoom DOM — using it in
+ * the ignore-list would create denial blind spots outside chat.
+ */
+const CHAT_SCOPED_MESSAGE_SELECTORS = [
+  ".chat-virtuoso-wrapper div[data-index]",
+  ".chat-container__chat-list div[data-index]",
+  ".chat-list-content div[data-index]"
+] as const
+
+/**
  * Every subtree whose text must NEVER be treated as a meeting-end/denial signal.
  * Union of the chat containers/message items the observer reads, plus the
  * top-level chat panel roots and the compose editor.
  */
 export const CHAT_IGNORE_SELECTORS: readonly string[] = [
   ...CHAT_CONTAINER_SELECTORS,
-  ...CHAT_MESSAGE_SELECTORS,
+  ...CHAT_MESSAGE_SELECTORS.filter((s) => s !== "div[data-index]"),
+  ...CHAT_SCOPED_MESSAGE_SELECTORS,
   "#chat",
   ".chat-container",
   ".chat-rtf-box__editor-outer",

--- a/src/meeting/zoom/chat-selectors.ts
+++ b/src/meeting/zoom/chat-selectors.ts
@@ -6,7 +6,7 @@
  * place means the denial scanner's ignore-list can never drift from what the
  * observer actually reads — the exact gap that let the bot's own entry message
  * ("…can be removed from the meeting…") escape the ignore-list and kill the bot
- * ~200ms after joining (2026-08 Noota incident, bots c97b775f / ee8053f9).
+ * ~200ms after joining (2026-08 production incident).
  *
  * The observer must pass these into page.evaluate as ARGS (Playwright
  * serializes them into the page context); the denial scanner imports them

--- a/src/meeting/zoom/chatObserver.ts
+++ b/src/meeting/zoom/chatObserver.ts
@@ -2,6 +2,10 @@ import type { Page } from "@playwright/test"
 import { ChatManager } from "../../chat-manager"
 import { GLOBAL } from "../../singleton"
 import type { ChatMessageData } from "../../types"
+import {
+  CHAT_CONTAINER_SELECTORS,
+  CHAT_MESSAGE_SELECTORS
+} from "./chat-selectors"
 
 declare global {
   interface Window {
@@ -91,24 +95,11 @@ export class ZoomChatObserver {
       }
     )
 
-    await this.page.evaluate(() => {
-      const CONTAINER_SELECTORS = [
-        '[aria-label="Chat Message List"]',
-        ".chat-virtuoso-wrapper",
-        "#chat-list-content",
-        ".chat-list-content",
-        ".chat-container__chat-list",
-        '[class*="chat-list"]',
-        '[class*="chat-message-list"]'
-      ]
-      const MESSAGE_SELECTORS = [
-        '[id^="chat-message-"]',
-        ".new-chat-message__container",
-        '[class*="chat-message-item"]',
-        '[class*="chatMessage"]',
-        "div[data-index]"
-      ]
-      const SENDER_SELECTORS = [
+    await this.page.evaluate(
+      ({ containers, messages }) => {
+        const CONTAINER_SELECTORS = containers
+        const MESSAGE_SELECTORS = messages
+        const SENDER_SELECTORS = [
         ".chat-message-text__user-name",
         '[class*="user-name"]',
         '[class*="userName"]',
@@ -247,7 +238,9 @@ export class ZoomChatObserver {
         window.clearInterval(poll)
         observer.disconnect()
       }
-    })
+      },
+      { containers: CHAT_CONTAINER_SELECTORS, messages: CHAT_MESSAGE_SELECTORS }
+    )
 
     this.isObserving = true
     console.log("[ZoomChatObserver] Chat observation started")

--- a/src/meeting/zoom/chatObserver.ts
+++ b/src/meeting/zoom/chatObserver.ts
@@ -132,7 +132,8 @@ export class ZoomChatObserver {
         for (let i = 0; i < 4 && cur; i++, cur = cur.parentElement) {
           const al = cur.getAttribute?.("aria-label") || ""
           const m = al.match(/^(.+?)\s+(?:said|to\s+Everyone|to\s+[A-Z])/i)
-          if (m && m[1].trim()) return m[1].trim()
+          const sender = m?.[1]?.trim()
+          if (sender) return sender
         }
         return ""
       }
@@ -204,7 +205,7 @@ export class ZoomChatObserver {
         for (const sel of MESSAGE_SELECTORS) {
           const nodes = root.querySelectorAll(sel)
           if (nodes.length) {
-            nodes.forEach((n) => emit(n))
+            for (const n of nodes) emit(n)
             return
           }
         }

--- a/src/meeting/zoom/entry-message-timing.ts
+++ b/src/meeting/zoom/entry-message-timing.ts
@@ -3,11 +3,11 @@
  *
  * The end-of-meeting denial scanner can false-positive on the bot's OWN entry
  * message: it echoes into the rendered chat list and, depending on Zoom's DOM,
- * may not sit in a container the ignore-list knows about (2026-08 Noota
- * incident: bots c97b775f / ee8053f9 killed themselves ~200-700ms after
- * sending it). Module-scoped so both the in-call state machine (writes, on the
- * ENTRY message only) and the Zoom end detector (reads) share one clock
- * without threading an instance through.
+ * may not sit in a container the ignore-list knows about (2026-08 production
+ * incident: bots killed themselves ~200-700ms after sending it). Module-scoped
+ * so both the in-call state machine (writes, on the ENTRY message only) and
+ * the Zoom end detector (reads) share one clock without threading an instance
+ * through.
  */
 
 let entryMessageSentAt: number | null = null

--- a/src/meeting/zoom/entry-message-timing.ts
+++ b/src/meeting/zoom/entry-message-timing.ts
@@ -11,14 +11,26 @@
 
 let entryMessageSentAt: number | null = null
 
+/**
+ * Record that the bot just posted its Zoom entry chat message. Called by
+ * ChatManager.sendViaZoom once the message bubble is persisted.
+ */
 export function markZoomEntryMessageSent(): void {
   entryMessageSentAt = Date.now()
 }
 
+/**
+ * Timestamp (ms epoch) of the last entry-message send, or null if none was
+ * sent this session. Read by zoom.ts findEndMeeting to suppress denial matches
+ * during the post-send grace window.
+ */
 export function getZoomEntryMessageSentAt(): number | null {
   return entryMessageSentAt
 }
 
+/**
+ * Clear the entry-message timestamp (e.g. on a fresh bot session).
+ */
 export function resetZoomEntryMessageTiming(): void {
   entryMessageSentAt = null
 }

--- a/src/meeting/zoom/entry-message-timing.ts
+++ b/src/meeting/zoom/entry-message-timing.ts
@@ -1,0 +1,24 @@
+/**
+ * Tracks when the bot posted its Zoom entry chat message.
+ *
+ * The end-of-meeting denial scanner can false-positive on the bot's OWN entry
+ * message: it echoes into the rendered chat list and, depending on Zoom's DOM,
+ * may not sit in a container the ignore-list knows about (2026-08 Noota
+ * incident: bots c97b775f / ee8053f9 killed themselves ~200-700ms after
+ * sending it). Module-scoped so both ChatManager (writes) and the Zoom end
+ * detector (reads) share one clock without threading an instance through.
+ */
+
+let entryMessageSentAt: number | null = null
+
+export function markZoomEntryMessageSent(): void {
+  entryMessageSentAt = Date.now()
+}
+
+export function getZoomEntryMessageSentAt(): number | null {
+  return entryMessageSentAt
+}
+
+export function resetZoomEntryMessageTiming(): void {
+  entryMessageSentAt = null
+}

--- a/src/meeting/zoom/entry-message-timing.ts
+++ b/src/meeting/zoom/entry-message-timing.ts
@@ -5,15 +5,18 @@
  * message: it echoes into the rendered chat list and, depending on Zoom's DOM,
  * may not sit in a container the ignore-list knows about (2026-08 Noota
  * incident: bots c97b775f / ee8053f9 killed themselves ~200-700ms after
- * sending it). Module-scoped so both ChatManager (writes) and the Zoom end
- * detector (reads) share one clock without threading an instance through.
+ * sending it). Module-scoped so both the in-call state machine (writes, on the
+ * ENTRY message only) and the Zoom end detector (reads) share one clock
+ * without threading an instance through.
  */
 
 let entryMessageSentAt: number | null = null
 
 /**
- * Record that the bot just posted its Zoom entry chat message. Called by
- * ChatManager.sendViaZoom once the message bubble is persisted.
+ * Record that the bot just posted its Zoom entry chat message. Called by the
+ * in-call state machine after a successful entry-message send (zoom only) —
+ * deliberately NOT on other mid-meeting chat sends, so the grace window cannot
+ * be re-armed by API-triggered messages.
  */
 export function markZoomEntryMessageSent(): void {
   entryMessageSentAt = Date.now()

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -12,6 +12,7 @@ import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { GLOBAL } from "../../singleton"
 import { SpeakerManager } from "../../speaker-manager"
 import { formatError } from "../../utils/Logger"
+import { markZoomEntryMessageSent } from "../../meeting/zoom/entry-message-timing"
 import { MEETING_CONSTANTS } from "../constants"
 import { MeetingEndReason, MeetingStateType, type StateExecuteResult } from "../types"
 import { BaseState } from "./base-state"
@@ -226,6 +227,13 @@ export class InCallState extends BaseState {
         )
         if (result.success) {
           console.log("[InCallState] Entry message sent successfully")
+          // Only the ENTRY message arms the zoom end-detection grace window.
+          // Mid-meeting bot chat sends (e.g. API-triggered) must NOT re-arm it,
+          // otherwise a genuine removal right after such a message could be
+          // suppressed. See zoom.ts findEndMeeting.
+          if (platform === "zoom") {
+            markZoomEntryMessageSent()
+          }
         } else {
           console.error("[InCallState] Entry message failed:", (result as { error: string }).error)
         }

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -1,5 +1,6 @@
 import { type Browser, type BrowserContext, type Page, chromium } from "@playwright/test"
 import { MeetingEndReason } from "../state-machine/types"
+import { ZOOM_STATE_CONFIG } from "../meeting/zoom-state-config"
 import { type StateDetectionConfig, createStateDetector } from "./meeting-state-detector"
 
 /**
@@ -11,50 +12,14 @@ import { type StateDetectionConfig, createStateDetector } from "./meeting-state-
  * participant typing a denial phrase into chat killed the bot.
  *
  * These tests run against a real Chromium page (real DOM: closest(),
- * getBoundingClientRect, TreeWalker) rather than mocks.
+ * getBoundingClientRect, TreeWalker) rather than mocks. They are bound to the
+ * PRODUCTION ZOOM_STATE_CONFIG (not a fixture copy) so the regression contract
+ * can never drift from what the bot actually runs.
  */
 
 jest.setTimeout(60_000)
 
-// Mirrors the relevant parts of ZOOM_STATE_CONFIG (BotRemoved pattern + chat scoping)
-const ZOOM_LIKE_CONFIG: StateDetectionConfig = {
-  providerName: "Zoom Web (test)",
-  denialPatterns: [
-    {
-      texts: ["automated bots aren't allowed"],
-      reason: MeetingEndReason.ZoomAnonymousJoinNotAllowed,
-      errorMessage: "anti-bot wall"
-    },
-    {
-      texts: [
-        "This meeting has been ended by host",
-        "You have been removed",
-        "meeting has ended"
-      ],
-      reason: MeetingEndReason.BotRemoved,
-      errorMessage: "Bot removed or Zoom meeting ended"
-    }
-  ],
-  denialIgnoreWithinSelectors: [
-    "#chat",
-    ".chat-container",
-    '[aria-label="Chat Message List"]',
-    ".chat-virtuoso-wrapper",
-    "#chat-list-content",
-    ".chat-list-content",
-    ".chat-container__chat-list",
-    ".chat-rtf-box__editor-outer",
-    '[id^="chat-message-"]',
-    '[class*="new-chat"]',
-    '[class*="chat-message"]',
-    '[class*="chatMessage"]'
-  ],
-  inMeetingPattern: {
-    selectors: ['button[aria-label="Leave"]'],
-    threshold: 1,
-    checkVisibility: true
-  }
-}
+const ZOOM_LIKE_CONFIG: StateDetectionConfig = ZOOM_STATE_CONFIG
 
 // Chat panel markup as rendered by the real Zoom web client (from the crash
 // HTML snapshot of bot 02c5dd71-28ce-4902-a96c-6ad10e95d04b)
@@ -129,6 +94,26 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
       expect(result.matched).toBe(false)
     })
 
+    it("does NOT match a removal phrase in a chat container the ignore-list does not know yet (positive scoping)", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="future-virtualized-chat-list">
+          <div data-index="0">You have been removed from the meeting</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
+    it("does NOT match a participant typing 'You have been removed' in an uncovered toast/notification", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="toast-notification">You have been removed from the meeting</div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
     it("does NOT match a participant typing 'meeting has ended' into a chat message (griefing vector)", async () => {
       await page.setContent(`
         ${IN_MEETING_HTML}
@@ -175,8 +160,23 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
       expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
     })
 
+    it("matches the full-page meeting-ended screen (end-of-meeting overlay)", async () => {
+      await page.setContent(`
+        <div class="meeting-ended-screen">
+          <div>This meeting has ended. You can leave or rejoin later.</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(true)
+      expect(result.matchedText).toBe("meeting has ended")
+      expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
+    })
+
     it("matches case-insensitively (Playwright text= semantics preserved)", async () => {
-      await page.setContent("<div>THIS MEETING HAS BEEN ENDED BY HOST</div>")
+      await page.setContent(`
+        <div class="zm-modal">
+          <div>THIS MEETING HAS BEEN ENDED BY HOST</div>
+        </div>`)
 
       const result = await detector.isDenied(page)
       expect(result.matched).toBe(true)
@@ -185,7 +185,7 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
 
     it("respects pattern priority order (first configured pattern wins)", async () => {
       await page.setContent(`
-        <div>meeting has ended</div>
+        <div class="zm-modal">meeting has ended</div>
         <div>Sorry, automated bots aren't allowed in this meeting</div>`)
 
       const result = await detector.isDenied(page)

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -28,7 +28,7 @@ const ZOOM_LIKE_CONFIG: StateDetectionConfig = {
     {
       texts: [
         "This meeting has been ended by host",
-        "removed from the meeting",
+        "You have been removed",
         "meeting has ended"
       ],
       reason: MeetingEndReason.BotRemoved,
@@ -38,8 +38,16 @@ const ZOOM_LIKE_CONFIG: StateDetectionConfig = {
   denialIgnoreWithinSelectors: [
     "#chat",
     ".chat-container",
+    '[aria-label="Chat Message List"]',
+    ".chat-virtuoso-wrapper",
+    "#chat-list-content",
+    ".chat-list-content",
+    ".chat-container__chat-list",
     ".chat-rtf-box__editor-outer",
-    '[class*="new-chat"]'
+    '[id^="chat-message-"]',
+    '[class*="new-chat"]',
+    '[class*="chat-message"]',
+    '[class*="chatMessage"]'
   ],
   inMeetingPattern: {
     selectors: ['button[aria-label="Leave"]'],
@@ -101,6 +109,26 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
       expect(result.matched).toBe(false)
     })
 
+    it("does NOT match the ambiguous removal fragment outside known chat roots", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="future-zoom-message-wrapper">removed from the meeting</div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
+    it("does NOT match remaining denial text in Zoom's virtualized chat portal", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="chat-virtuoso-wrapper">
+          <div data-index="0">lol watch this: meeting has ended</div>
+        </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
     it("does NOT match a participant typing 'meeting has ended' into a chat message (griefing vector)", async () => {
       await page.setContent(`
         ${IN_MEETING_HTML}
@@ -123,15 +151,15 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
   })
 
   describe("genuine denial UI still detected", () => {
-    it("matches the same phrase in a visible Zoom modal outside the chat panel", async () => {
+    it("matches Zoom's real removal copy in a visible modal outside the chat panel", async () => {
       await page.setContent(`
         <div class="zm-modal zm-modal-legacy">
-          <div class="zm-modal-body-title">You have been removed from the meeting</div>
+          <div class="zm-modal-body-title">You have been removed from this meeting by the host.</div>
         </div>`)
 
       const result = await detector.isDenied(page)
       expect(result.matched).toBe(true)
-      expect(result.matchedText).toBe("removed from the meeting")
+      expect(result.matchedText).toBe("You have been removed")
       expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
     })
 
@@ -195,7 +223,7 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
 
       const result = await detector.isDenied(page)
       expect(result.matched).toBe(true)
-      expect(result.matchedText).toBe("removed from the meeting")
+      expect(result.matchedText).toBe("You have been removed")
       expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
     })
 
@@ -225,7 +253,7 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
 
       const result = await detector.isDenied(page)
       expect(result.matched).toBe(true)
-      expect(result.matchedText).toBe("removed from the meeting")
+      expect(result.matchedText).toBe("You have been removed")
       expect(result.pattern?.reason).toBe(MeetingEndReason.BotRemoved)
     })
 

--- a/src/utils/meeting-state-detector.test.ts
+++ b/src/utils/meeting-state-detector.test.ts
@@ -98,8 +98,18 @@ describe("meeting-state-detector isDenied (real Chromium DOM)", () => {
       await page.setContent(`
         ${IN_MEETING_HTML}
         <div class="future-virtualized-chat-list">
-          <div data-index="0">You have been removed from the meeting</div>
+          <div class="future-virtualized-chat-row">You have been removed from the meeting</div>
         </div>`)
+
+      const result = await detector.isDenied(page)
+      expect(result.matched).toBe(false)
+    })
+
+    it("does NOT match removal text inside unrelated modals (settings/feedback)", async () => {
+      await page.setContent(`
+        ${IN_MEETING_HTML}
+        <div class="settings-modal"><div>You have been removed from the meeting</div></div>
+        <div class="feedback-modal"><div>meeting has ended</div></div>`)
 
       const result = await detector.isDenied(page)
       expect(result.matched).toBe(false)

--- a/src/utils/meeting-state-detector.ts
+++ b/src/utils/meeting-state-detector.ts
@@ -13,6 +13,14 @@ export type DenialPattern = {
   reason?: MeetingEndReason
   logPrefix?: string
   errorMessage?: string
+  // POSITIVE scoping. When set, a matched text only counts if it lives inside a
+  // subtree matching one of these selectors (modal / full-page end-of-meeting
+  // UI). This is the robust counterpart to denialIgnoreWithinSelectors: instead
+  // of trying to deny-list every place user content can appear (chat, compose,
+  // virtualized lists…), a scoped pattern can only ever fire on genuine end UI.
+  // Unset/empty = match anywhere on the page (used for unambiguous full-page
+  // walls such as the anti-bot screen).
+  scopeSelectors?: string[]
 }
 
 export type SelectorPattern = {
@@ -126,13 +134,12 @@ async function checkIndicators(
  * Exported for tests; production callers go through isDenied().
  */
 export const findVisibleDenialTextIndex = (args: {
-  texts: string[]
+  patterns: { texts: string[]; scopeSelectors: string[] }[]
   ignoreSelectors: string[]
-}): number => {
+}): { patternIdx: number; textIdx: number; detail: string } => {
   const normalize = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase()
-  const needles = args.texts.map(normalize)
   const root = document.body || document.documentElement
-  if (!root) return -1
+  if (!root) return { patternIdx: -1, textIdx: -1, detail: "" }
 
   // ── one post-order pass: normalized subtree text per element, entering
   //    open shadow roots ──────────────────────────────────────────────────
@@ -206,16 +213,72 @@ export const findVisibleDenialTextIndex = (args: {
     return view.getComputedStyle(el).visibility === "visible"
   }
 
-  // Needles in config order: the first one with a valid rendered match wins
-  for (let i = 0; i < needles.length; i++) {
-    if (!needles[i]) continue
-    const candidates: Element[] = []
-    findInnermost(root, needles[i], candidates)
-    for (const candidate of candidates) {
-      if (!isIgnored(candidate) && isRendered(candidate)) return i
+  // Positive scoping: candidate must sit inside a subtree matching one of the
+  // pattern's scopeSelectors (empty scope list = match anywhere).
+  const isInScope = (el: Element, scopeSelectors: string[]): boolean => {
+    if (scopeSelectors.length === 0) return true
+    let node: Node | null = el
+    while (node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        for (const selector of scopeSelectors) {
+          try {
+            if ((node as Element).matches(selector)) return true
+          } catch (_e) {
+            // Invalid selector must never break end-of-meeting detection
+          }
+        }
+        node = node.parentNode
+      } else if (node instanceof ShadowRoot) {
+        node = node.host
+      } else {
+        node = node.parentNode
+      }
+    }
+    return false
+  }
+
+  // Compact forensic descriptor of the matched element so every false positive
+  // is provable from the logs (tag/class/id/role + ancestor chain).
+  const describe = (el: Element): string => {
+    const tag = el.tagName.toLowerCase()
+    const cls =
+      typeof el.className === "string" ? el.className.split(/\s+/).slice(0, 3).join(".") : ""
+    const id = el.id ? `#${el.id}` : ""
+    const role = el.getAttribute("role") || ""
+    const chain: string[] = []
+    let node: Node | null = el
+    for (let i = 0; i < 5 && node; i++, node = node.parentNode) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const n = node as Element
+        const c =
+          typeof n.className === "string" ? n.className.split(/\s+/).slice(0, 2).join(".") : ""
+        chain.push(`${n.tagName.toLowerCase()}${c ? "." + c : ""}`)
+      }
+    }
+    return `${tag}${cls ? "." + cls : ""}${id}${role ? `[role=${role}]` : ""} < ${chain.join(" < ")}`
+  }
+
+  // Patterns in config order — the first pattern with a valid rendered,
+  // non-ignored, in-scope match wins.
+  for (let p = 0; p < args.patterns.length; p++) {
+    const { texts, scopeSelectors } = args.patterns[p]
+    for (let i = 0; i < texts.length; i++) {
+      const needle = normalize(texts[i])
+      if (!needle) continue
+      const candidates: Element[] = []
+      findInnermost(root, needle, candidates)
+      for (const candidate of candidates) {
+        if (
+          !isIgnored(candidate) &&
+          isRendered(candidate) &&
+          isInScope(candidate, scopeSelectors)
+        ) {
+          return { patternIdx: p, textIdx: i, detail: describe(candidate) }
+        }
+      }
     }
   }
-  return -1
+  return { patternIdx: -1, textIdx: -1, detail: "" }
 }
 
 /**
@@ -235,23 +298,27 @@ export const createStateDetector = (config: StateDetectionConfig): MeetingStateD
         }
 
         // Single in-page pass instead of one locator round-trip per phrase
-        const matchedIndex = await page.evaluate(findVisibleDenialTextIndex, {
-          texts: allTexts,
+        const matched = await page.evaluate(findVisibleDenialTextIndex, {
+          patterns: config.denialPatterns.map((p) => ({
+            texts: p.texts,
+            scopeSelectors: p.scopeSelectors ?? []
+          })),
           ignoreSelectors: config.denialIgnoreWithinSelectors ?? []
         })
 
-        if (matchedIndex >= 0) {
-          let offset = 0
-          for (const pattern of config.denialPatterns) {
-            if (matchedIndex < offset + pattern.texts.length) {
-              return {
-                state: "denied",
-                matched: true,
-                matchedText: pattern.texts[matchedIndex - offset],
-                pattern
-              }
-            }
-            offset += pattern.texts.length
+        if (matched.patternIdx >= 0) {
+          const pattern = config.denialPatterns[matched.patternIdx]
+          const matchedText = pattern.texts[matched.textIdx]
+          // Log the matched element's tag/class/id/role + ancestry so any future
+          // false positive is provable from the logs instead of a fresh incident.
+          console.warn(
+            `[${config.providerName}] Denial match "${matchedText}" at ${matched.detail}`
+          )
+          return {
+            state: "denied",
+            matched: true,
+            matchedText,
+            pattern
           }
         }
         return { state: "denied", matched: false }

--- a/src/utils/meeting-state-detector.ts
+++ b/src/utils/meeting-state-detector.ts
@@ -252,10 +252,10 @@ export const findVisibleDenialTextIndex = (args: {
         const n = node as Element
         const c =
           typeof n.className === "string" ? n.className.split(/\s+/).slice(0, 2).join(".") : ""
-        chain.push(`${n.tagName.toLowerCase()}${c ? "." + c : ""}`)
+        chain.push(`${n.tagName.toLowerCase()}${c ? `.${c}` : ""}`)
       }
     }
-    return `${tag}${cls ? "." + cls : ""}${id}${role ? `[role=${role}]` : ""} < ${chain.join(" < ")}`
+    return `${tag}${cls ? `.${cls}` : ""}${id}${role ? `[role=${role}]` : ""} < ${chain.join(" < ")}`
   }
 
   // Patterns in config order — the first pattern with a valid rendered,


### PR DESCRIPTION
## Summary

- stop treating generic "removed from the meeting" as a Zoom removal signal
- preserve genuine removal detection through specific "You have been removed" copy
- ignore current virtualized and portaled Zoom chat containers
- run detector regressions against actual Zoom production config

## Evidence

Two affected Zoom runs sent entry messages containing the generic phrase, then detected that phrase immediately afterward. Meeting BaaS-owned Zoom HTML snapshots confirm current chat DOM selectors and the real Zoom localization copy: "You have been removed from this meeting by the host."

## Verification

- 19 meeting-state-detector Chromium tests pass
- TypeScript no-emit check passes
- Biome lint passes
- git diff --check passes