### PR TITLE
fix(meet): bridge dcrpc numeric device id → device-path so CSRC speakers get named (#305)

### DIFF
--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -1144,13 +1144,37 @@ export function browserInterceptionLogic(schema: any[]) {
       if (typeof decode !== "function" || !pako || typeof pako.inflate !== "function") {
         return
       }
-      let participants: Array<{ deviceId: string; speaking: boolean }> | null
+      let participants: Array<{
+        deviceId: string
+        speaking: boolean
+        numericIds?: string[]
+      }> | null
       try {
         participants = decode(rawData, pako.inflate)
       } catch {
         return
       }
       if (participants === null) return // keepalive / non-state frame
+
+      // Bridge the numeric device id(s) dcrpc carries for each participant to
+      // their device-path, into the same ssrcToDeviceMap the CSRC path reads.
+      // The force-native CSRC path resolves speakers by a raw numeric SSRC that
+      // the roster (keyed by device-path) never maps, so those speakers land as
+      // "Unknown"; this lets getUserByStreamId resolve them to the real name.
+      for (const p of participants) {
+        if (!p.deviceId || !p.numericIds || p.numericIds.length === 0) continue
+        for (const numeric of p.numericIds) {
+          if (userManager.ssrcToDeviceMap.get(numeric) === p.deviceId) continue
+          userManager.ssrcToDeviceMap.set(numeric, p.deviceId)
+          const asNumber = Number.parseInt(numeric, 10)
+          if (!Number.isNaN(asNumber)) {
+            userManager.ssrcToDeviceMap.set(asNumber, p.deviceId)
+          }
+          console.error(
+            `[NetworkInterceptor] 🔗 dcrpc bridged numeric ${numeric} → device (roster-known: ${userManager.allUsersMap.has(p.deviceId)})`
+          )
+        }
+      }
 
       const speakingIds: string[] = []
       for (const p of participants) {

--- a/src/meeting/meet/network-interception/dcrpc-decoder.test.ts
+++ b/src/meeting/meet/network-interception/dcrpc-decoder.test.ts
@@ -16,10 +16,16 @@ function activeMessage(): Uint8Array {
   return w.finish()
 }
 
-/** One participant record: field 4 = device id, field 9 = active (optional). */
-function participant(deviceId: string, speaking: boolean): Uint8Array {
+/**
+ * One participant record: field 4 = device id, field 9 = active (optional),
+ * field 8 = numeric device id (optional varint).
+ */
+function participant(deviceId: string, speaking: boolean, numericId?: number): Uint8Array {
   const w = protobuf.Writer.create()
   w.uint32(tag(4, 2)).string(deviceId)
+  if (numericId !== undefined) {
+    w.uint32(tag(8, 0)).uint32(numericId)
+  }
   if (speaking) {
     w.uint32(tag(9, 2)).bytes(activeMessage())
   }
@@ -66,8 +72,8 @@ describe("decodeDcrpcFrame", () => {
     const result = decodeDcrpcFrame(frame, pako.inflate)
 
     expect(result).toEqual([
-      { deviceId: "device-aaa", speaking: true },
-      { deviceId: "device-bbb", speaking: false }
+      { deviceId: "device-aaa", speaking: true, numericIds: [] },
+      { deviceId: "device-bbb", speaking: false, numericIds: [] }
     ])
   })
 
@@ -94,7 +100,7 @@ describe("decodeDcrpcFrame", () => {
     const result = decodeDcrpcFrame(frame, inflate as unknown as (b: Uint8Array) => Uint8Array)
 
     expect(inflate).not.toHaveBeenCalled()
-    expect(result).toEqual([{ deviceId: "device-ccc", speaking: true }])
+    expect(result).toEqual([{ deviceId: "device-ccc", speaking: true, numericIds: [] }])
   })
 
   it("finds participants even with an extra wrapper level (defensive walk)", () => {
@@ -107,7 +113,18 @@ describe("decodeDcrpcFrame", () => {
     const frame = wrapField(2, gzipped)
 
     expect(decodeDcrpcFrame(frame, pako.inflate)).toEqual([
-      { deviceId: "device-ddd", speaking: true }
+      { deviceId: "device-ddd", speaking: true, numericIds: [] }
+    ])
+  })
+
+  it("extracts the numeric device id from participant field 8", () => {
+    const frame = buildStateFrame([
+      participant("device-eee", true, 2375728588),
+      participant("device-fff", false)
+    ])
+    expect(decodeDcrpcFrame(frame, pako.inflate)).toEqual([
+      { deviceId: "device-eee", speaking: true, numericIds: ["2375728588"] },
+      { deviceId: "device-fff", speaking: false, numericIds: [] }
     ])
   })
 })

--- a/src/meeting/meet/network-interception/dcrpc-decoder.ts
+++ b/src/meeting/meet/network-interception/dcrpc-decoder.ts
@@ -32,6 +32,11 @@
 export type DcrpcParticipant = {
   deviceId: string
   speaking: boolean
+  // Numeric device id(s) carried alongside the device-path (participant field 8,
+  // and the ints inside it if it is a length-delimited pair). The CSRC path
+  // resolves speakers by a raw numeric SSRC that the roster (keyed by the
+  // device-path) never maps, so these let us bridge numeric -> device-path.
+  numericIds: string[]
 }
 
 /**
@@ -142,7 +147,25 @@ export function decodeDcrpcFrame(
       const active = parseFields(f9[0].bytes)
       if (active[2] && active[2].length > 0) speaking = true
     }
-    return { deviceId, speaking }
+
+    // Field 8 carries the participant's numeric device id (a bare varint, or a
+    // length-delimited pair of varints). Collect every numeric it yields — one
+    // of them is expected to match the raw SSRC the CSRC path resolves against.
+    const numericIds: string[] = []
+    for (const entry of fields[8] || []) {
+      if (entry.wt === 0 && entry.val !== undefined) {
+        numericIds.push(String(entry.val))
+      } else if (entry.wt === 2 && entry.bytes) {
+        const inner = parseFields(entry.bytes)
+        for (const key of Object.keys(inner)) {
+          for (const sub of inner[Number(key)]) {
+            if (sub.wt === 0 && sub.val !== undefined) numericIds.push(String(sub.val))
+          }
+        }
+      }
+    }
+
+    return { deviceId, speaking, numericIds }
   }
 
   // Descend through field-2 wrappers, stopping at the first level whose field-4


### PR DESCRIPTION
Fixes the force-native regression tracked in #305: ~30% of network-detected Meet speakers deliver as `Unknown` because the dominant CSRC path resolves speakers by a raw numeric SSRC that the roster (keyed by `spaces/…/devices/N`) never maps.

## Approach
dcrpc frames carry, per participant, **both** ids: the device-path (field 4, roster-mappable) and the **numeric device id (field 8, previously ignored)**. This:
- decodes field 8 (`dcrpc-decoder.ts`), and
- registers `numeric → device-path` into the same `ssrcToDeviceMap` the CSRC path already reads (`browser-bundle.ts` `handleDcrpcFrame`),

so the existing `getUserByStreamId` resolves the numeric SSRC to the real roster name.

## Safety
Purely additive. If a field-8 numeric does **not** match the CSRC SSRC, nothing resolves and behavior is unchanged (still Unknown) — no regression path.

## The hypothesis to validate in preprod
The open question is whether dcrpc's **field-8 numeric equals the CSRC SSRC** the roster misses. I couldn't confirm the field-8 shape from a static frame. A diagnostic log makes it observable:
```
[NetworkInterceptor] 🔗 dcrpc bridged numeric <N> → device (roster-known: true/false)
```
**Test in preprod:**
1. Launch Meet bots (force-native), watch for the 🔗 bridge lines.
2. If the bridged numerics match the CSRC SSRCs → the `Unknown` rate on network-detected Meet speakers should drop sharply; `diarization.jsonl` should carry names for previously-numeric ids.
3. If it does **not** drop → field 8 isn't the SSRC; fall back to issue #305 option 2 (find the real CSRC↔device source) or promote dcrpc to primary identity.

## Tests
`dcrpc-decoder.test.ts`: +1 case (field-8 numeric extraction); existing 5 updated for the new `numericIds` field. tsc clean, 6/6 pass.

Separate from #297 (repairs *lost* names); here the name is *never mapped*.