### PR TITLE
fix(meet): name dcrpc numeric speakers via harvested collections map (#305)

### DIFF
--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -399,12 +399,27 @@ export function browserInterceptionLogic(schema: any[]) {
       if ((window as any).__networkInterceptorStopped) return
       if (typeof (window as any).onNetworkSpeakerUpdate !== "function") return
 
-      const speakingSet = new Set(speakingIds)
+      // Normalize each speaking id to its roster device-path up front. dcrpc
+      // reports the active speaker by a numeric id (its device-path is absent);
+      // that numeric is a deviceOutput streamId the collections channel maps to a
+      // real device-path (harvested into ssrcToDeviceMap, read by
+      // getUserByStreamId). Resolving here — instead of after the roster map —
+      // lets a roster user be marked speaking directly and avoids emitting the
+      // same participant twice with conflicting speaking states.
+      const speakingDeviceIds = new Set<string>()
+      const resolvedById = new Map<string, any>()
+      for (const id of speakingIds) {
+        const user = getUserByStreamId(userManager, id)
+        const dev = user?.deviceId ?? id
+        speakingDeviceIds.add(dev)
+        if (user) resolvedById.set(dev, user)
+      }
+
       const filteredUsers = filterActiveUsers(getAllUsers(userManager))
       const seen = new Set<string>()
       const users = filteredUsers.map((user: any) => {
         seen.add(user.deviceId)
-        const isSpeaking = speakingSet.has(user.deviceId)
+        const isSpeaking = speakingDeviceIds.has(user.deviceId)
         return {
           deviceId: user.deviceId,
           name: decodeUserName(user),
@@ -418,42 +433,25 @@ export function browserInterceptionLogic(schema: any[]) {
           profilePicture: user.profilePicture
         }
       })
-      for (const deviceId of speakingIds) {
-        if (seen.has(deviceId)) continue
-        // dcrpc reports the active speaker by a numeric id (its device-path is
-        // absent), so it is not in the roster and lands as "Unknown". That numeric
-        // is a deviceOutput streamId, which the collections channel maps to a
-        // real device-path (harvested into ssrcToDeviceMap). Resolve through it —
-        // getUserByStreamId reads that mapping — before falling back to Unknown.
-        const resolved = getUserByStreamId(userManager, deviceId)
-        if (resolved) {
-          seen.add(deviceId)
-          users.push({
-            deviceId: resolved.deviceId ?? deviceId,
-            name: decodeUserName(resolved),
-            isCurrentUser:
-              resolved.isCurrentUserString === "true" || resolved.isCurrentUserString === "1",
-            isSpeaking: true,
-            status: resolved.status ?? 1,
-            isHost: resolved.isHost === 1,
-            audioLevel: 1,
-            fullName: decodeFullName(resolved),
-            displayName: resolved.displayName,
-            profilePicture: resolved.profilePicture
-          })
-          continue
-        }
+      // Speakers not already emitted from the roster above: a resolved user that
+      // filterActiveUsers dropped (emit it under its real name), or a numeric id
+      // with no deviceOutput mapping at all (genuinely Unknown).
+      for (const dev of speakingDeviceIds) {
+        if (seen.has(dev)) continue
+        seen.add(dev)
+        const user = resolvedById.get(dev)
         users.push({
-          deviceId,
-          name: "Unknown",
-          isCurrentUser: false,
+          deviceId: user?.deviceId ?? dev,
+          name: user ? decodeUserName(user) : "Unknown",
+          isCurrentUser:
+            user?.isCurrentUserString === "true" || user?.isCurrentUserString === "1",
           isSpeaking: true,
-          status: 1,
-          isHost: false,
+          status: user?.status ?? 1,
+          isHost: user?.isHost === 1,
           audioLevel: 1,
-          fullName: undefined,
-          displayName: undefined,
-          profilePicture: undefined
+          fullName: user ? decodeFullName(user) : undefined,
+          displayName: user?.displayName,
+          profilePicture: user?.profilePicture
         })
       }
 

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -420,6 +420,29 @@ export function browserInterceptionLogic(schema: any[]) {
       })
       for (const deviceId of speakingIds) {
         if (seen.has(deviceId)) continue
+        // dcrpc reports the active speaker by a numeric id (its device-path is
+        // absent), so it is not in the roster and lands as "Unknown". That numeric
+        // is a deviceOutput streamId, which the collections channel maps to a
+        // real device-path (harvested into ssrcToDeviceMap). Resolve through it —
+        // getUserByStreamId reads that mapping — before falling back to Unknown.
+        const resolved = getUserByStreamId(userManager, deviceId)
+        if (resolved) {
+          seen.add(deviceId)
+          users.push({
+            deviceId: resolved.deviceId ?? deviceId,
+            name: decodeUserName(resolved),
+            isCurrentUser:
+              resolved.isCurrentUserString === "true" || resolved.isCurrentUserString === "1",
+            isSpeaking: true,
+            status: resolved.status ?? 1,
+            isHost: resolved.isHost === 1,
+            audioLevel: 1,
+            fullName: decodeFullName(resolved),
+            displayName: resolved.displayName,
+            profilePicture: resolved.profilePicture
+          })
+          continue
+        }
         users.push({
           deviceId,
           name: "Unknown",
@@ -1135,6 +1158,90 @@ export function browserInterceptionLogic(schema: any[]) {
       reportHealthCheck()
     }, 10000)
 
+    // Harvest every streamId(field 4, numeric string) -> deviceId(field 6,
+    // device path) pair from a raw collections frame, independent of the schema
+    // decoder. The schema's deviceOutputInfoList path misses some deviceOutput
+    // records, so the dcrpc active-speaker numeric (which IS a deviceOutput
+    // streamId) never reaches ssrcToDeviceMap and the speaker lands as "Unknown".
+    // Walking the raw bytes catches all of them.
+    function harvestDeviceMappings(buf: Uint8Array, um: any, depth: number): void {
+      if (depth > 12) return
+      const parseLevel = (b: Uint8Array): { [f: number]: { wt: number; bytes?: Uint8Array }[] } => {
+        const fields: { [f: number]: { wt: number; bytes?: Uint8Array }[] } = {}
+        let pos = 0
+        while (pos < b.length) {
+          let tag = 0
+          let sh = 0
+          let x: number
+          do {
+            if (pos >= b.length) return fields
+            x = b[pos++]
+            tag += (x & 0x7f) * 2 ** sh
+            sh += 7
+            if (sh > 70) return fields
+          } while (x & 0x80)
+          const field = Math.floor(tag / 8)
+          const wt = tag % 8
+          if (wt === 0) {
+            do {
+              if (pos >= b.length) return fields
+            } while (b[pos++] & 0x80)
+            ;(fields[field] ||= []).push({ wt })
+          } else if (wt === 2) {
+            let len = 0
+            let s2 = 0
+            let y: number
+            do {
+              if (pos >= b.length) return fields
+              y = b[pos++]
+              len += (y & 0x7f) * 2 ** s2
+              s2 += 7
+              if (s2 > 70) return fields
+            } while (y & 0x80)
+            if (pos + len > b.length) return fields
+            ;(fields[field] ||= []).push({ wt, bytes: b.subarray(pos, pos + len) })
+            pos += len
+          } else if (wt === 1) {
+            pos += 8
+          } else if (wt === 5) {
+            pos += 4
+          } else {
+            return fields
+          }
+        }
+        return fields
+      }
+      const fields = parseLevel(buf)
+      const asStr = (e?: { bytes?: Uint8Array }): string | null => {
+        if (!e?.bytes) return null
+        try {
+          return new TextDecoder("utf-8", { fatal: true }).decode(e.bytes)
+        } catch {
+          return null
+        }
+      }
+      const f4 = fields[4]?.[0]
+      const f6 = fields[6]?.[0]
+      if (f4?.wt === 2 && f6?.wt === 2) {
+        const sid = asStr(f4)
+        const dev = asStr(f6)
+        if (sid && dev && /^\d+$/.test(sid) && dev.indexOf("spaces/") === 0) {
+          if (um.ssrcToDeviceMap.get(sid) !== dev) {
+            um.ssrcToDeviceMap.set(sid, dev)
+            const n = Number.parseInt(sid, 10)
+            if (!Number.isNaN(n)) um.ssrcToDeviceMap.set(n, dev)
+          }
+        }
+      }
+      for (const key of Object.keys(fields)) {
+        for (const e of fields[Number(key)]) {
+          if (e.wt === 2 && e.bytes && e.bytes.length > 1) {
+            harvestDeviceMappings(e.bytes, um, depth + 1)
+          }
+        }
+      }
+    }
+
     // Decode the active-speaker state carried on the dcrpc datachannel (NetEq
     // sessions). Returns the sorted set of speaking device ids for dedupe, or
     // null when the frame is a keepalive / not a state frame.
@@ -1226,6 +1333,13 @@ export function browserInterceptionLogic(schema: any[]) {
               throw new Error("pako.inflate is not available")
             }
             const inflated = (window as any).pako.inflate(rawData)
+            // Harvest streamId->deviceId pairs the schema decoder misses, so the
+            // dcrpc active-speaker numeric resolves to a name.
+            try {
+              harvestDeviceMappings(inflated, userManager, 0)
+            } catch {
+              // never break the collections decode
+            }
             const eventData = messageDecoders["CollectionEvent"](inflated)
             const body = eventData.body
             if (body) {


### PR DESCRIPTION
Fixes #305 — the force-native regression where ~30% of network-detected Meet speakers deliver as `Unknown`.

## Root cause (traced live in preprod)
Post force-native, **dcrpc** is the primary Meet active-speaker signal, but it reports the speaker by a **numeric id** (its device-path is absent), so it's not in the roster (keyed by `spaces/…/devices/N`) → `Unknown`.

That numeric **is a deviceOutput `streamId`**, and the collections deviceOutput record carries the **device-path (field 6)** → roster → name (proved live: `274049501 → spaces/…/devices/341 → <name>`). Two gaps blocked it:
1. The **schema-based deviceOutput decode misses some records**, so `streamId → device-path` never reached `ssrcToDeviceMap`.
2. `broadcastDcrpcSpeakers` emitted the numeric directly as `Unknown`.

## Fix (single file, +114 lines)
1. **`harvestDeviceMappings`** — walk the raw collections frame and harvest **every** `streamId(field4 numeric) → deviceId(field6 device-path)` pair into `ssrcToDeviceMap`, independent of the schema path.
2. **`broadcastDcrpcSpeakers`** resolves the numeric via `getUserByStreamId` (the harvested map) before falling back to `Unknown`.

## Validated in preprod (force-native Meet, live speakers)
- `collResolved` > 0, **`collFail = 0`** on every bot — all dcrpc numeric speakers resolve.
- `diarization.jsonl`: **0 Unknown segments**, all named.
- tsc clean; 16/16 unit tests.

## Notes
- Supersedes #306 (its CSRC framing was wrong — the numeric is a dcrpc/deviceOutput id, not a CSRC SSRC).
- Residual: any dcrpc numeric with **no** deviceOutput entry has no device-path and stays Unknown — will measure on prod after deploy.