### PR TITLE
feat(meet): telemetry — dcrpc numeric-speaker resolution (late vs never)

### DIFF
--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -408,11 +408,25 @@ export function browserInterceptionLogic(schema: any[]) {
       // same participant twice with conflicting speaking states.
       const speakingDeviceIds = new Set<string>()
       const resolvedById = new Map<string, any>()
+      // Measurement only: a dcrpc speaker is reported by a numeric id resolved to
+      // a name via the collections streamId map. Track how many numeric speakers
+      // resolve LATE (their deviceOutput only reached collections after they first
+      // spoke — a timing gap that a finalize re-resolution could close) vs NEVER
+      // (no deviceOutput ever published — genuinely unnameable). Counts only.
+      const numPending: Set<string> = ((window as any).__dcrpcNumPending ||= new Set())
       for (const id of speakingIds) {
         const user = getUserByStreamId(userManager, id)
         const dev = user?.deviceId ?? id
         speakingDeviceIds.add(dev)
-        if (user) resolvedById.set(dev, user)
+        if (user) {
+          resolvedById.set(dev, user)
+          if (numPending.has(id)) {
+            numPending.delete(id)
+            ;(window as any).__dcrpcNumLate = ((window as any).__dcrpcNumLate || 0) + 1
+          }
+        } else if (/^\d+$/.test(id)) {
+          numPending.add(id)
+        }
       }
 
       const filteredUsers = filterActiveUsers(getAllUsers(userManager))
@@ -1100,6 +1114,14 @@ export function browserInterceptionLogic(schema: any[]) {
         lastFrameAgeMs,
         audioProcessingActive,
         subscriptionError,
+        // dcrpc numeric-speaker resolution telemetry (counts only):
+        //   late    = numeric speakers whose deviceOutput reached collections
+        //             only after they first spoke (a finalize re-resolution
+        //             could recover these)
+        //   pending = numeric speakers still unresolved (no deviceOutput yet /
+        //             ever — genuinely unnameable if it stays this way)
+        dcrpcNumericLate: (window as any).__dcrpcNumLate || 0,
+        dcrpcNumericPending: ((window as any).__dcrpcNumPending?.size as number) || 0,
         timestamp: Date.now()
       }
 

--- a/src/meeting/meet/network-interception/types.ts
+++ b/src/meeting/meet/network-interception/types.ts
@@ -44,6 +44,10 @@ export type NetworkPayload = {
     lastFrameAgeMs?: number | null
     audioProcessingActive: boolean
     subscriptionError: string | null
+    /** dcrpc numeric speakers whose deviceOutput resolved after first speech. */
+    dcrpcNumericLate?: number
+    /** dcrpc numeric speakers still unresolved (no deviceOutput yet/ever). */
+    dcrpcNumericPending?: number
     timestamp: number
   }
   failure?: {

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -371,7 +371,9 @@ export class InCallState extends BaseState {
               registeredTrackCount,
               lastFrameAgeMs,
               audioProcessingActive,
-              subscriptionError
+              subscriptionError,
+              dcrpcNumericLate,
+              dcrpcNumericPending
             } = payload.health
 
             if (subscriptionError) {
@@ -416,6 +418,14 @@ export class InCallState extends BaseState {
             console.log(
               `[NetworkInterceptor] Health Status: subscribed=${subscribed}, delivering=${activeTrackCount}, registered=${registeredTrackCount ?? "n/a"}, lastFrameAgeMs=${lastFrameAgeMs ?? "never"}, processing=${audioProcessingActive}`
             )
+
+            // dcrpc numeric-speaker resolution telemetry (counts only): how much
+            // of the residual Unknown is late-resolving timing vs never-resolved.
+            if ((dcrpcNumericLate ?? 0) > 0 || (dcrpcNumericPending ?? 0) > 0) {
+              console.log(
+                `[DCRPC-NUMERIC] resolvedLate=${dcrpcNumericLate ?? 0} pending=${dcrpcNumericPending ?? 0}`
+              )
+            }
 
             return // Don't process as speaker update
           }


### PR DESCRIPTION
Follow-up to #307. That fix dropped the Meet network-detected `Unknown` rate from ~11.6% → ~1.3% in prod. This instruments the **residual** so we can decide whether it's worth chasing.

## What it measures (counts only, no PII)
Per bot, emitted on the health check as `[DCRPC-NUMERIC] resolvedLate=N pending=M`:
- **resolvedLate** — numeric speakers whose deviceOutput reached collections *after* they first spoke. A timing gap; a finalize re-resolution could recover these.
- **pending** — numeric speakers still unresolved at the health check (no deviceOutput yet, or ever). If it stays pending, the participant is genuinely unnameable (no device-path anywhere).

## Why
The one residual prod bot reviewed had a numeric speaker that spoke at 1s **and** 424s and never resolved, while others named fine by 152s — i.e. it looked *genuinely* unnameable, not timing. This telemetry lets us size timing-vs-genuine across the fleet before investing in a finalize re-resolution or a nearest-speaker fallback (which carries misattribution risk).

## Safety
Measurement only — does not change speaker ownership, diarization, streaming, or fallback. Counts only; no device ids or names logged. tsc clean, tests pass.