### PR TITLE
fix(meet): resolve dcrpc speakers via DOM data-ssrc when deviceOutputs misses them

### DIFF
--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -215,26 +215,26 @@ export function browserInterceptionLogic(schema: any[]) {
     // mirroring it into ssrcToDeviceMap closes the gap with the participant's
     // real name. Throttled to at most once per 500ms; tiles/ssrcs populate and
     // change over the call, so this must run repeatedly, not once at join.
-    // Returns true when it added at least one new SSRC -> device-path mapping,
-    // so the caller can force a speaker broadcast even when the dcrpc speaking
-    // set is unchanged (a tile can render only after the frame that first marks
-    // that participant as speaking).
-    function harvestSsrcFromDom(userManager: any): boolean {
+    //
+    // Precedence: the collections deviceOutputs channel is authoritative. The
+    // DOM only *fills* SSRCs deviceOutputs never mapped — it never overwrites an
+    // existing deviceOutputs mapping, since a stale or reused tile could
+    // otherwise reassign an SSRC to the wrong participant.
+    function harvestSsrcFromDom(userManager: any): void {
       const now = Date.now()
       if (
         userManager.__lastDomSsrcHarvest &&
         now - userManager.__lastDomSsrcHarvest < 500
       ) {
-        return false
+        return
       }
       userManager.__lastDomSsrcHarvest = now
       let tiles: any
       try {
         tiles = document.querySelectorAll("[data-ssrc]")
       } catch {
-        return false
+        return
       }
-      let addedNew = false
       tiles.forEach((el: any) => {
         const ssrc = el.getAttribute("data-ssrc")
         if (!ssrc) return
@@ -244,18 +244,12 @@ export function browserInterceptionLogic(schema: any[]) {
         if (!devicePath) return
         if (userManager.ssrcToDeviceMap.get(ssrc) === devicePath) return
 
-        // Was this SSRC already known from the collections deviceOutputs
-        // channel? If not, the DOM is the ONLY source that resolves it — the
-        // exact case this harvest exists for. Log those (one line per newly
-        // resolved ssrc) so prod review can quantify how often the DOM path was
-        // load-bearing vs. redundant with deviceOutputs. Log only the SSRC and
-        // whether it resolved to a rostered user — never the device-path or
-        // participant name, which are PII that page logging would persist.
-        let knownFromDeviceOutputs = false
+        // If deviceOutputs already carries this SSRC, it wins — leave its
+        // mapping untouched and let the DOM only populate SSRCs it never
+        // provided (exactly the residual this harvest targets).
         for (const dOut of userManager.deviceOutputMap.values()) {
           if (dOut?.streamId != null && String(dOut.streamId) === String(ssrc)) {
-            knownFromDeviceOutputs = true
-            break
+            return
           }
         }
 
@@ -264,17 +258,17 @@ export function browserInterceptionLogic(schema: any[]) {
         if (!Number.isNaN(numericSSRC)) {
           userManager.ssrcToDeviceMap.set(numericSSRC, devicePath)
         }
-        addedNew = true
 
-        if (!knownFromDeviceOutputs) {
-          const rostered = userManager.allUsersMap.has(devicePath)
-          console.log(
-            `[SSRC-DOM] resolved ssrc=${ssrc} rostered=${rostered} ` +
-              `(absent from deviceOutputs — DOM harvest was necessary)`
-          )
-        }
+        // One line per newly resolved SSRC so prod review can quantify where the
+        // DOM path was load-bearing. Log only the SSRC and whether it resolved
+        // to a rostered user — never the device-path or participant name, which
+        // are PII that page logging would persist.
+        const rostered = userManager.allUsersMap.has(devicePath)
+        console.log(
+          `[SSRC-DOM] resolved ssrc=${ssrc} rostered=${rostered} ` +
+            `(absent from deviceOutputs — DOM harvest was necessary)`
+        )
       })
-      return addedNew
     }
 
     function getUserByStreamId(userManager: any, streamId: any) {
@@ -1342,16 +1336,27 @@ export function browserInterceptionLogic(schema: any[]) {
         if (p.speaking) speakingIds.push(p.deviceId)
       }
       speakingIds.sort()
-      const key = speakingIds.join("|")
 
-      // Refresh SSRC -> device-path from the DOM before the unchanged-state
-      // early return. A participant tile can render only after the frame that
-      // first marks that participant as speaking; if harvesting resolves a
-      // previously unmapped SSRC we must re-broadcast even when the speaking set
-      // is identical, or that speaker stays "Unknown" until the set next changes.
-      const harvestedNew = harvestSsrcFromDom(userManager)
+      // Refresh SSRC -> device-path from the DOM before computing the dedup key,
+      // so the key reflects the freshest resolution.
+      harvestSsrcFromDom(userManager)
 
-      if (key === lastDcrpcSpeakingKey && !harvestedNew) return
+      // Dedup on the *resolved* state, not the raw speaking ids. A speaker can be
+      // marked speaking before their SSRC maps (DOM harvest) or before their name
+      // enters the roster (updateUsers) — resolving to "Unknown" on the first
+      // broadcast. Those later resolutions touch neither the speaking set nor
+      // lastDcrpcSpeakingKey, so keying on ids alone would dedup the corrected
+      // frame away and strand the speaker as "Unknown". Folding each speaker's
+      // resolved device id into the key makes any resolution change (Unknown ->
+      // named) a new key that re-broadcasts.
+      const key = speakingIds
+        .map((id) => {
+          const user = getUserByStreamId(userManager, id)
+          return `${id}=${user?.deviceId ?? "?"}`
+        })
+        .join("|")
+
+      if (key === lastDcrpcSpeakingKey) return
       lastDcrpcSpeakingKey = key
       broadcastDcrpcSpeakers(userManager, speakingIds)
     }

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -197,6 +197,78 @@ export function browserInterceptionLogic(schema: any[]) {
       return Array.from(userManager.allUsersMap.values())
     }
 
+    // DOM-sourced SSRC -> device-path harvest.
+    //
+    // Google Meet stamps every rendered media tile with
+    // `data-ssrc="<rtp-ssrc>"`, nested inside that participant's
+    // `[data-participant-id="spaces/<space>/devices/<n>"]` container. That SSRC
+    // is exactly the numeric id dcrpc reports as the active speaker. For most
+    // participants the `collections` deviceOutputs channel already carries the
+    // same streamId -> device-path link (see updateDeviceOutputs /
+    // harvestDeviceMappings). But for some joiners that deviceOutput record
+    // never arrives, so the dcrpc numeric can't be resolved and the speaker
+    // lands as "Unknown" even though they are a fully rostered participant
+    // (confirmed in prod: a dcrpc numeric matched a rostered user's tile ssrc in
+    // the DOM but was absent from every deviceOutput).
+    //
+    // The DOM binding is authoritative and present once the tile renders, so
+    // mirroring it into ssrcToDeviceMap closes the gap with the participant's
+    // real name. Throttled to at most once per 500ms; tiles/ssrcs populate and
+    // change over the call, so this must run repeatedly, not once at join.
+    function harvestSsrcFromDom(userManager: any): void {
+      const now = Date.now()
+      if (
+        userManager.__lastDomSsrcHarvest &&
+        now - userManager.__lastDomSsrcHarvest < 500
+      ) {
+        return
+      }
+      userManager.__lastDomSsrcHarvest = now
+      let tiles: any
+      try {
+        tiles = document.querySelectorAll("[data-ssrc]")
+      } catch {
+        return
+      }
+      tiles.forEach((el: any) => {
+        const ssrc = el.getAttribute("data-ssrc")
+        if (!ssrc) return
+        const container = el.closest("[data-participant-id]")
+        if (!container) return
+        const devicePath = container.getAttribute("data-participant-id")
+        if (!devicePath) return
+        if (userManager.ssrcToDeviceMap.get(ssrc) === devicePath) return
+
+        // Was this SSRC already known from the collections deviceOutputs
+        // channel? If not, the DOM is the ONLY source that resolves it — the
+        // exact case this harvest exists for. Log those (throttled to one line
+        // per newly-resolved ssrc) so prod review can quantify how often the DOM
+        // path was load-bearing vs. redundant with deviceOutputs.
+        let knownFromDeviceOutputs = false
+        for (const dOut of userManager.deviceOutputMap.values()) {
+          if (dOut?.streamId != null && String(dOut.streamId) === String(ssrc)) {
+            knownFromDeviceOutputs = true
+            break
+          }
+        }
+
+        userManager.ssrcToDeviceMap.set(ssrc, devicePath)
+        const numericSSRC = Number.parseInt(ssrc, 10)
+        if (!Number.isNaN(numericSSRC)) {
+          userManager.ssrcToDeviceMap.set(numericSSRC, devicePath)
+        }
+
+        if (!knownFromDeviceOutputs) {
+          const resolvedUser = userManager.allUsersMap.get(devicePath)
+          const resolvedName = resolvedUser ? decodeUserName(resolvedUser) : "(unrostered)"
+          console.log(
+            `[SSRC-DOM] resolved ssrc=${ssrc} -> ${devicePath} name=${resolvedName} ` +
+              `(absent from deviceOutputs — DOM harvest was necessary)`
+          )
+        }
+      })
+    }
+
     function getUserByStreamId(userManager: any, streamId: any) {
       let deviceId = userManager.ssrcToDeviceMap.get(streamId)
       if (!deviceId && typeof streamId !== "string") {
@@ -406,6 +478,11 @@ export function browserInterceptionLogic(schema: any[]) {
       // getUserByStreamId). Resolving here — instead of after the roster map —
       // lets a roster user be marked speaking directly and avoids emitting the
       // same participant twice with conflicting speaking states.
+      // Refresh SSRC -> device-path from the DOM first, so a dcrpc numeric that
+      // never appeared in the deviceOutputs channel still resolves to the real
+      // rostered participant instead of "Unknown".
+      harvestSsrcFromDom(userManager)
+
       const speakingDeviceIds = new Set<string>()
       const resolvedById = new Map<string, any>()
       for (const id of speakingIds) {

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -139,7 +139,12 @@ export function browserInterceptionLogic(schema: any[]) {
       return {
         deviceOutputMap: new Map(),
         allUsersMap: new Map(),
-        ssrcToDeviceMap: new Map()
+        ssrcToDeviceMap: new Map(),
+        // SSRCs whose device-path came from an authoritative collections source
+        // (deviceOutputs records or harvestDeviceMappings). The DOM fallback must
+        // never overwrite these — it only fills SSRCs no collections source
+        // provided. Holds both string and numeric variants of each SSRC.
+        authoritativeSsrc: new Set()
       }
     }
 
@@ -177,9 +182,11 @@ export function browserInterceptionLogic(schema: any[]) {
           userManager.deviceOutputMap.set(key, deviceOutput)
           if (output.streamId) {
             userManager.ssrcToDeviceMap.set(output.streamId, output.deviceId)
+            userManager.authoritativeSsrc?.add(String(output.streamId))
             const numericSSRC = Number.parseInt(output.streamId, 10)
             if (!Number.isNaN(numericSSRC)) {
               userManager.ssrcToDeviceMap.set(numericSSRC, output.deviceId)
+              userManager.authoritativeSsrc?.add(numericSSRC)
             }
           }
         })
@@ -244,17 +251,20 @@ export function browserInterceptionLogic(schema: any[]) {
         if (!devicePath) return
         if (userManager.ssrcToDeviceMap.get(ssrc) === devicePath) return
 
-        // If deviceOutputs already carries this SSRC, it wins — leave its
-        // mapping untouched and let the DOM only populate SSRCs it never
-        // provided (exactly the residual this harvest targets).
-        for (const dOut of userManager.deviceOutputMap.values()) {
-          if (dOut?.streamId != null && String(dOut.streamId) === String(ssrc)) {
-            return
-          }
+        // If an authoritative collections source (deviceOutputs records or
+        // harvestDeviceMappings) already resolved this SSRC, it wins — leave its
+        // mapping untouched. The DOM only populates SSRCs no collections source
+        // provided (exactly the residual this harvest targets); a stale or reused
+        // tile must never reassign an authoritative SSRC to the wrong participant.
+        const numericSSRC = Number.parseInt(ssrc, 10)
+        if (
+          userManager.authoritativeSsrc?.has(ssrc) ||
+          (!Number.isNaN(numericSSRC) && userManager.authoritativeSsrc?.has(numericSSRC))
+        ) {
+          return
         }
 
         userManager.ssrcToDeviceMap.set(ssrc, devicePath)
-        const numericSSRC = Number.parseInt(ssrc, 10)
         if (!Number.isNaN(numericSSRC)) {
           userManager.ssrcToDeviceMap.set(numericSSRC, devicePath)
         }
@@ -266,7 +276,7 @@ export function browserInterceptionLogic(schema: any[]) {
         const rostered = userManager.allUsersMap.has(devicePath)
         console.log(
           `[SSRC-DOM] resolved ssrc=${ssrc} rostered=${rostered} ` +
-            `(absent from deviceOutputs — DOM harvest was necessary)`
+            `(no authoritative collections mapping — DOM harvest was necessary)`
         )
       })
     }
@@ -1300,8 +1310,12 @@ export function browserInterceptionLogic(schema: any[]) {
         if (sid && dev && /^\d+$/.test(sid) && dev.indexOf("spaces/") === 0) {
           if (um.ssrcToDeviceMap.get(sid) !== dev) {
             um.ssrcToDeviceMap.set(sid, dev)
+            um.authoritativeSsrc?.add(sid)
             const n = Number.parseInt(sid, 10)
-            if (!Number.isNaN(n)) um.ssrcToDeviceMap.set(n, dev)
+            if (!Number.isNaN(n)) {
+              um.ssrcToDeviceMap.set(n, dev)
+              um.authoritativeSsrc?.add(n)
+            }
           }
         }
       }

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -1308,14 +1308,20 @@ export function browserInterceptionLogic(schema: any[]) {
         const sid = asStr(f4)
         const dev = asStr(f6)
         if (sid && dev && /^\d+$/.test(sid) && dev.indexOf("spaces/") === 0) {
+          // Record provenance unconditionally: even when the mapping already
+          // matches (e.g. the DOM fallback set it first), this SSRC is now
+          // confirmed by an authoritative collections source and must be marked
+          // so a later stale/reused tile cannot overwrite it.
           if (um.ssrcToDeviceMap.get(sid) !== dev) {
             um.ssrcToDeviceMap.set(sid, dev)
-            um.authoritativeSsrc?.add(sid)
-            const n = Number.parseInt(sid, 10)
-            if (!Number.isNaN(n)) {
+          }
+          um.authoritativeSsrc?.add(sid)
+          const n = Number.parseInt(sid, 10)
+          if (!Number.isNaN(n)) {
+            if (um.ssrcToDeviceMap.get(n) !== dev) {
               um.ssrcToDeviceMap.set(n, dev)
-              um.authoritativeSsrc?.add(n)
             }
+            um.authoritativeSsrc?.add(n)
           }
         }
       }

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -215,21 +215,26 @@ export function browserInterceptionLogic(schema: any[]) {
     // mirroring it into ssrcToDeviceMap closes the gap with the participant's
     // real name. Throttled to at most once per 500ms; tiles/ssrcs populate and
     // change over the call, so this must run repeatedly, not once at join.
-    function harvestSsrcFromDom(userManager: any): void {
+    // Returns true when it added at least one new SSRC -> device-path mapping,
+    // so the caller can force a speaker broadcast even when the dcrpc speaking
+    // set is unchanged (a tile can render only after the frame that first marks
+    // that participant as speaking).
+    function harvestSsrcFromDom(userManager: any): boolean {
       const now = Date.now()
       if (
         userManager.__lastDomSsrcHarvest &&
         now - userManager.__lastDomSsrcHarvest < 500
       ) {
-        return
+        return false
       }
       userManager.__lastDomSsrcHarvest = now
       let tiles: any
       try {
         tiles = document.querySelectorAll("[data-ssrc]")
       } catch {
-        return
+        return false
       }
+      let addedNew = false
       tiles.forEach((el: any) => {
         const ssrc = el.getAttribute("data-ssrc")
         if (!ssrc) return
@@ -241,9 +246,11 @@ export function browserInterceptionLogic(schema: any[]) {
 
         // Was this SSRC already known from the collections deviceOutputs
         // channel? If not, the DOM is the ONLY source that resolves it — the
-        // exact case this harvest exists for. Log those (throttled to one line
-        // per newly-resolved ssrc) so prod review can quantify how often the DOM
-        // path was load-bearing vs. redundant with deviceOutputs.
+        // exact case this harvest exists for. Log those (one line per newly
+        // resolved ssrc) so prod review can quantify how often the DOM path was
+        // load-bearing vs. redundant with deviceOutputs. Log only the SSRC and
+        // whether it resolved to a rostered user — never the device-path or
+        // participant name, which are PII that page logging would persist.
         let knownFromDeviceOutputs = false
         for (const dOut of userManager.deviceOutputMap.values()) {
           if (dOut?.streamId != null && String(dOut.streamId) === String(ssrc)) {
@@ -257,16 +264,17 @@ export function browserInterceptionLogic(schema: any[]) {
         if (!Number.isNaN(numericSSRC)) {
           userManager.ssrcToDeviceMap.set(numericSSRC, devicePath)
         }
+        addedNew = true
 
         if (!knownFromDeviceOutputs) {
-          const resolvedUser = userManager.allUsersMap.get(devicePath)
-          const resolvedName = resolvedUser ? decodeUserName(resolvedUser) : "(unrostered)"
+          const rostered = userManager.allUsersMap.has(devicePath)
           console.log(
-            `[SSRC-DOM] resolved ssrc=${ssrc} -> ${devicePath} name=${resolvedName} ` +
+            `[SSRC-DOM] resolved ssrc=${ssrc} rostered=${rostered} ` +
               `(absent from deviceOutputs — DOM harvest was necessary)`
           )
         }
       })
+      return addedNew
     }
 
     function getUserByStreamId(userManager: any, streamId: any) {
@@ -478,11 +486,6 @@ export function browserInterceptionLogic(schema: any[]) {
       // getUserByStreamId). Resolving here — instead of after the roster map —
       // lets a roster user be marked speaking directly and avoids emitting the
       // same participant twice with conflicting speaking states.
-      // Refresh SSRC -> device-path from the DOM first, so a dcrpc numeric that
-      // never appeared in the deviceOutputs channel still resolves to the real
-      // rostered participant instead of "Unknown".
-      harvestSsrcFromDom(userManager)
-
       const speakingDeviceIds = new Set<string>()
       const resolvedById = new Map<string, any>()
       for (const id of speakingIds) {
@@ -1340,7 +1343,15 @@ export function browserInterceptionLogic(schema: any[]) {
       }
       speakingIds.sort()
       const key = speakingIds.join("|")
-      if (key === lastDcrpcSpeakingKey) return
+
+      // Refresh SSRC -> device-path from the DOM before the unchanged-state
+      // early return. A participant tile can render only after the frame that
+      // first marks that participant as speaking; if harvesting resolves a
+      // previously unmapped SSRC we must re-broadcast even when the speaking set
+      // is identical, or that speaker stays "Unknown" until the set next changes.
+      const harvestedNew = harvestSsrcFromDom(userManager)
+
+      if (key === lastDcrpcSpeakingKey && !harvestedNew) return
       lastDcrpcSpeakingKey = key
       broadcastDcrpcSpeakers(userManager, speakingIds)
     }

--- a/src/meeting/meet/network-interception/types.ts
+++ b/src/meeting/meet/network-interception/types.ts
@@ -97,6 +97,13 @@ export type UserManager = {
   deviceOutputMap: Map<string, DeviceOutput>
   allUsersMap: Map<string, RawUser>
   ssrcToDeviceMap: Map<unknown, string>
+  /**
+   * SSRCs whose device-path came from an authoritative collections source
+   * (deviceOutputs records or harvestDeviceMappings). The DOM fallback harvest
+   * never overwrites these — it only fills SSRCs no collections source provided.
+   * Holds both string and numeric variants of each SSRC.
+   */
+  authoritativeSsrc?: Set<unknown>
 }
 
 // --- Utility Types ---


### PR DESCRIPTION
## Problem
A small residual of Meet bots still deliver an **Unknown** speaker after v2.6.1 (#307). Root-caused in prod: the Unknown is **a fully-rostered participant**, not an external guest. dcrpc reports their active-speaker signal by a numeric **RTP SSRC**, but the `collections` **deviceOutputs** channel never emits a record linking that SSRC → the participant's `device-path`. #307's harvest only maps SSRCs that appear in deviceOutputs, so these speakers never resolve → 0 named segments, speech delivered as `Unknown`.

## Evidence
- Each affected bot: a rostered participant with **zero named segments**, and exactly one dcrpc numeric that resolves to nothing.
- The DOM proves the link: Meet stamps each media tile `data-ssrc="<rtp-ssrc>"` inside the participant's `[data-participant-id="spaces/.../devices/N"]`. That SSRC = the dcrpc numeric. Confirmed across multiple bots (the `Unknown` SSRC maps in the DOM to a rostered participant's device-path; binding stable across all join-window snapshots).

## Fix
`harvestSsrcFromDom(userManager)` mirrors the DOM `data-ssrc → data-participant-id` binding into `ssrcToDeviceMap`, so `getUserByStreamId` resolves the dcrpc numeric to the **real rostered name**.
- Runs in `handleDcrpcFrame` **before** the dedup early-return, throttled to 500ms.
- Runs **repeatedly** (not once at join): Meet reuses device slots on rejoin, so it tracks the live binding at speak-time.
- **deviceOutputs precedence:** the DOM only fills SSRCs deviceOutputs never mapped; it never overwrites an existing deviceOutputs mapping (a stale/reused tile can't reassign an SSRC to the wrong participant).
- **Resolution-aware dedup:** the dcrpc dedup key folds each speaker's resolved device id, so a speaker resolved late (DOM harvest, or roster name arriving after the first broadcast) re-broadcasts instead of being deduped away as `Unknown`.

## Observability
Emits `[SSRC-DOM] resolved ssrc=… rostered=…` **only** when the DOM resolves an SSRC that deviceOutputs lacked — i.e. the load-bearing cases. Non-PII (SSRC + rostered flag only; no device-path, no name). Lets us quantify how often this path was necessary vs redundant.

## Risk
Low. Additive: only *adds* SSRC→device-path entries the deviceOutputs path missed; never overrides an existing correct mapping. No new deps. `tsc --noEmit` clean.

## Validation
- [ ] preprod image soak — confirm speakers still resolve, no duplicate/regressed attribution, watch `[SSRC-DOM]`
- [ ] then promote as a follow-up to v2.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)