### PR TITLE
feat: raise max_recording_duration cap from 6h to 12h

### DIFF
--- a/src/utils/meeting-params-schema.ts
+++ b/src/utils/meeting-params-schema.ts
@@ -83,7 +83,7 @@ export const BotMessageSchema = object({
   max_recording_duration: number()
     .int()
     .positive()
-    .max(6 * 60 * 60)
+    .max(12 * 60 * 60)
     .nullable()
     .default(null),
   ignored_participant_names: array(string()).default([]),


### PR DESCRIPTION
Raises the per-bot max_recording_duration cap from 6 to 12 hours