### PR TITLE
feat(meet): attach browser fingerprint to bot-detection telemetry (Phase 0)

### DIFF
--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -1,3 +1,4 @@
+import type { FingerprintSummary } from "../browser/fingerprint-probe"
 import { envVars } from "../config/env-vars"
 import type { MeetBotDetectionSignal } from "../meeting/meet/network-interception"
 import { getProxyTelemetry } from "../proxy/toggle-proxy"
@@ -196,7 +197,11 @@ export class Api {
     }
   }
 
-  public reportMeetBotDetection(signal: MeetBotDetectionSignal, pageAttempt: number): void {
+  public reportMeetBotDetection(
+    signal: MeetBotDetectionSignal,
+    pageAttempt: number,
+    fingerprint?: FingerprintSummary | null
+  ): void {
     if (GLOBAL.isServerless()) {
       console.log("[MeetBotDetection] Serverless mode, skipping telemetry")
       return
@@ -214,6 +219,9 @@ export class Api {
       bot_image_loop_mode: params.bot_image_config?.loop_mode ?? null,
       streaming_input_enabled: Boolean(params.streaming_input),
       network_interception_setup_failed: GLOBAL.hasNetworkInterceptionSetupFailed(),
+      // The fingerprint the detector saw when it decided (null if the probe
+      // failed). Phase-0 instrumentation: correlate each tell vs detected_as_bot.
+      fingerprint: fingerprint ?? null,
       proxy
     }
 

--- a/src/browser/fingerprint-probe.ts
+++ b/src/browser/fingerprint-probe.ts
@@ -301,16 +301,33 @@ function summarizeFingerprint(fp: RawFingerprint): FingerprintSummary {
   }
 }
 
+// The probe runs a page.evaluate, which has no per-call timeout and can hang if
+// the renderer is wedged — precisely the state a flagged/blocked bot's page may
+// be in. Since this gates the detection-signal report, bound it: on deadline we
+// report fingerprint: null rather than losing the signal for that bot.
+const PROBE_TIMEOUT_MS = 3000
+
 /**
  * Prod telemetry entry: capture the fingerprint the detector saw and return a
  * compact summary for the detection signal's run_context. Never throws, writes
  * no files, and is NOT gated on BROWSER_DEBUG_CAPTURE — this is how we correlate
  * fingerprint tells against Meet's flag decision. Returns null if the page is
- * gone or the evaluate fails; callers must treat null as "unknown".
+ * gone, the evaluate fails, or the probe exceeds PROBE_TIMEOUT_MS; callers must
+ * treat null as "unknown".
  */
 export async function probeFingerprint(page: Page): Promise<FingerprintSummary | null> {
-  const fp = await evaluateFingerprint(page)
-  return fp ? summarizeFingerprint(fp) : null
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), PROBE_TIMEOUT_MS)
+    // Don't let a pending probe keep the process alive on shutdown.
+    timer.unref?.()
+  })
+  try {
+    const fp = await Promise.race([evaluateFingerprint(page), deadline])
+    return fp ? summarizeFingerprint(fp) : null
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
 }
 
 /**

--- a/src/browser/fingerprint-probe.ts
+++ b/src/browser/fingerprint-probe.ts
@@ -19,10 +19,14 @@ import { PathManager } from "../utils/PathManager"
  *   - WebGL UNMASKED_VENDOR / UNMASKED_RENDERER — the SwiftShader / GPU tell
  *   - font enumeration (Windows-core vs Linux-only candidates) — the font-list tell
  *   - screen / dpr / viewport geometry — the spoofed-resolution coherence tell
+ *   - CDP Runtime.enable leak self-test — the fingerprint-independent automation tell
  *
- * Output is a JSON blob + a screenshot in the html-snapshots dir, already
- * uploaded to s3://<logs-bucket>/<uuid>/. Gated on BROWSER_DEBUG_CAPTURE, off by
- * default, pure read-only diagnostic — it changes nothing the page can observe.
+ * Two entry points share one page.evaluate:
+ *   - probeFingerprint(): returns a compact summary for telemetry. Runs in prod
+ *     (no debug gate, no file writes), so every Meet detection signal can carry
+ *     the fingerprint the detector saw and we can correlate tells vs flag rate.
+ *   - captureFingerprint(): the debug dump (full JSON + screenshot to the
+ *     html-snapshots dir), gated on BROWSER_DEBUG_CAPTURE. Read-only diagnostic.
  */
 
 // Windows core fonts a real Windows Chrome exposes. Absent in our container.
@@ -64,16 +68,56 @@ const LINUX_FONTS = [
   "Ubuntu"
 ]
 
-/**
- * Capture the runtime fingerprint once. `label` distinguishes call sites in the
- * filename (e.g. "zoom_prejoin"). Never throws — diagnostics must not break join.
- */
-export async function captureFingerprint(page: Page, label: string): Promise<void> {
-  if (!envVars.BROWSER_DEBUG_CAPTURE) return
-  if (page.isClosed()) return
+/** Raw fingerprint object returned by the in-page evaluate. */
+type RawFingerprint = {
+  navigator: {
+    userAgent: unknown
+    platform: unknown
+    webdriver: unknown
+    [k: string]: unknown
+  }
+  cdp: { runtimeEnableLeak: boolean | null }
+  webgl: { renderer?: unknown; unmaskedRenderer?: unknown } | null
+  webgl2: { renderer?: unknown; unmaskedRenderer?: unknown } | null
+  fonts: {
+    windowsProbed: number
+    windowsPresent: string[]
+    linuxProbed: number
+    linuxPresent: string[]
+    documentFontsSize: number | null
+  }
+  geometry: {
+    dpr: number
+    screen: string
+    inner: string
+    [k: string]: unknown
+  }
+}
 
+/**
+ * Compact, high-signal slice of the fingerprint, sized for telemetry: it rides
+ * in every Meet detection signal's run_context so each attribute can be
+ * correlated against detected_as_bot. Keep it small — one row per bot join.
+ */
+export type FingerprintSummary = {
+  verdict: "CDP-RUNTIME-LEAK" | "MIXED-OS-TELL" | "ok"
+  cdp_runtime_leak: boolean | null
+  claims_windows: boolean
+  platform: string | null
+  webdriver: boolean | null
+  win_fonts_present: number
+  lin_fonts_present: number
+  webgl_renderer: string | null
+  dpr: number | null
+  screen: string | null
+  inner: string | null
+}
+
+/** Run the in-page fingerprint evaluate. Never throws; null on any failure. */
+async function evaluateFingerprint(page: Page): Promise<RawFingerprint | null> {
+  if (page.isClosed()) return null
   try {
-    const fp = await page.evaluate(
+    return (await page.evaluate(
       ({ winFonts, linFonts }) => {
         const nav = navigator as Navigator & {
           userAgentData?: {
@@ -204,7 +248,8 @@ export async function captureFingerprint(page: Page, label: string): Promise<voi
             windowsPresent: detectFonts(winFonts).present,
             linuxProbed: linFonts.length,
             linuxPresent: detectFonts(linFonts).present,
-            documentFontsSize: (document as unknown as { fonts?: { size?: number } }).fonts?.size ?? null
+            documentFontsSize:
+              (document as unknown as { fonts?: { size?: number } }).fonts?.size ?? null
           },
           geometry: {
             dpr: window.devicePixelRatio,
@@ -217,37 +262,85 @@ export async function captureFingerprint(page: Page, label: string): Promise<voi
         }
       },
       { winFonts: WINDOWS_FONTS, linFonts: LINUX_FONTS }
-    )
+    )) as unknown as RawFingerprint
+  } catch {
+    return null
+  }
+}
 
-    // Coherence verdict: Windows UA/platform but Linux fonts present and no
-    // Windows fonts = the mixed-OS tell. Logged inline so it shows in the bot
-    // log without downloading the JSON.
-    const claimsWindows =
-      /windows/i.test(String(fp.navigator.userAgent)) ||
-      String(fp.navigator.platform).startsWith("Win")
-    const winFontCount = fp.fonts.windowsPresent.length
-    const linFontCount = fp.fonts.linuxPresent.length
-    // CDP leak is the most severe tell, so it wins the verdict; then the font mix.
-    const verdict =
-      fp.cdp.runtimeEnableLeak === true
-        ? "CDP-RUNTIME-LEAK"
-        : claimsWindows && winFontCount === 0 && linFontCount > 0
-          ? "MIXED-OS-TELL"
-          : "ok"
+/** Reduce the raw fingerprint to the coherence verdict + telemetry summary. */
+function summarizeFingerprint(fp: RawFingerprint): FingerprintSummary {
+  // Coherence verdict: Windows UA/platform but Linux fonts present and no
+  // Windows fonts = the mixed-OS tell. CDP leak is the most severe tell, so it
+  // wins the verdict; then the font mix.
+  const claimsWindows =
+    /windows/i.test(String(fp.navigator.userAgent)) ||
+    String(fp.navigator.platform).startsWith("Win")
+  const winFontCount = fp.fonts.windowsPresent.length
+  const linFontCount = fp.fonts.linuxPresent.length
+  const verdict =
+    fp.cdp.runtimeEnableLeak === true
+      ? "CDP-RUNTIME-LEAK"
+      : claimsWindows && winFontCount === 0 && linFontCount > 0
+        ? "MIXED-OS-TELL"
+        : "ok"
+
+  const renderer = fp.webgl?.unmaskedRenderer ?? fp.webgl?.renderer ?? null
+  return {
+    verdict,
+    cdp_runtime_leak: fp.cdp.runtimeEnableLeak,
+    claims_windows: claimsWindows,
+    platform: fp.navigator.platform == null ? null : String(fp.navigator.platform),
+    webdriver: typeof fp.navigator.webdriver === "boolean" ? fp.navigator.webdriver : null,
+    win_fonts_present: winFontCount,
+    lin_fonts_present: linFontCount,
+    webgl_renderer: renderer == null ? null : String(renderer),
+    dpr: typeof fp.geometry.dpr === "number" ? fp.geometry.dpr : null,
+    screen: fp.geometry.screen == null ? null : String(fp.geometry.screen),
+    inner: fp.geometry.inner == null ? null : String(fp.geometry.inner)
+  }
+}
+
+/**
+ * Prod telemetry entry: capture the fingerprint the detector saw and return a
+ * compact summary for the detection signal's run_context. Never throws, writes
+ * no files, and is NOT gated on BROWSER_DEBUG_CAPTURE — this is how we correlate
+ * fingerprint tells against Meet's flag decision. Returns null if the page is
+ * gone or the evaluate fails; callers must treat null as "unknown".
+ */
+export async function probeFingerprint(page: Page): Promise<FingerprintSummary | null> {
+  const fp = await evaluateFingerprint(page)
+  return fp ? summarizeFingerprint(fp) : null
+}
+
+/**
+ * Debug dump: full fingerprint JSON + screenshot to the html-snapshots dir.
+ * `label` distinguishes call sites in the filename (e.g. "zoom_prejoin").
+ * Gated on BROWSER_DEBUG_CAPTURE, off by default. Never throws.
+ */
+export async function captureFingerprint(page: Page, label: string): Promise<void> {
+  if (!envVars.BROWSER_DEBUG_CAPTURE) return
+  if (page.isClosed()) return
+
+  try {
+    const fp = await evaluateFingerprint(page)
+    if (!fp) return
+    const summary = summarizeFingerprint(fp)
 
     console.log(
-      `[FingerprintProbe:${label}] verdict=${verdict} ` +
-        `cdpRuntimeLeak=${fp.cdp.runtimeEnableLeak} ` +
-        `platform=${fp.navigator.platform} webdriver=${fp.navigator.webdriver} ` +
-        `winFonts=${winFontCount}/${fp.fonts.windowsProbed} linFonts=${linFontCount}/${fp.fonts.linuxProbed} ` +
-        `glRenderer=${fp.webgl?.unmaskedRenderer ?? fp.webgl?.renderer ?? "?"} ` +
-        `dpr=${fp.geometry.dpr} screen=${fp.geometry.screen} inner=${fp.geometry.inner}`
+      `[FingerprintProbe:${label}] verdict=${summary.verdict} ` +
+        `cdpRuntimeLeak=${summary.cdp_runtime_leak} ` +
+        `platform=${summary.platform} webdriver=${summary.webdriver} ` +
+        `winFonts=${summary.win_fonts_present}/${fp.fonts.windowsProbed} ` +
+        `linFonts=${summary.lin_fonts_present}/${fp.fonts.linuxProbed} ` +
+        `glRenderer=${summary.webgl_renderer ?? "?"} ` +
+        `dpr=${summary.dpr} screen=${summary.screen} inner=${summary.inner}`
     )
 
     const dir = PathManager.getInstance().getHtmlSnapshotsPath()
     await fs.mkdir(dir, { recursive: true }).catch(() => {})
     const jsonPath = path.join(dir, `${Date.now()}_fingerprint_${label}.json`)
-    await fs.writeFile(jsonPath, JSON.stringify({ label, verdict, ...fp }, null, 2))
+    await fs.writeFile(jsonPath, JSON.stringify({ label, verdict: summary.verdict, ...fp }, null, 2))
     console.log(`[FingerprintProbe:${label}] dump written: ${path.basename(jsonPath)}`)
 
     try {

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -15,6 +15,7 @@ import {
   type SelectorPattern
 } from "../utils/meeting-state-detector"
 import { sleep } from "../utils/sleep"
+import { probeFingerprint } from "../browser/fingerprint-probe"
 import { enableMeetAudioCapture } from "./meet/audio-capture"
 import { closeMeeting } from "./meet/closeMeeting"
 import { MEET_STATE_CONFIG } from "./meet-state-config"
@@ -141,7 +142,7 @@ export class MeetProvider implements MeetingProviderInterface {
         // Wire the Meet bot-detection observer (page.on('response') on the
         // CreateMeetingDevice RPC). Must be installed before page.goto so the
         // response listener is in place when the join handshake fires.
-        await setupBotDetectionRoute(page, (signal) => {
+        await setupBotDetectionRoute(page, async (signal) => {
           if (!signal.decoded) {
             console.warn("[Meet] ⚠️ Meet bot-detection response could not be decoded")
           } else if (signal.detectedAsBot) {
@@ -153,7 +154,12 @@ export class MeetProvider implements MeetingProviderInterface {
               `[Meet] ✅ Meet did NOT flag this bot — detectedAsBot=${signal.detectedAsBot} (raw field 36 = ${signal.rawField})`
             )
           }
-          Api.instance?.reportMeetBotDetection(signal, attempts)
+          // Capture the fingerprint the detector saw at the moment it decided,
+          // so the api-server can correlate each tell (CDP leak, mixed-OS font
+          // mix, …) against detected_as_bot. Best-effort — never blocks or
+          // fails the signal report.
+          const fingerprint = await probeFingerprint(page).catch(() => null)
+          Api.instance?.reportMeetBotDetection(signal, attempts, fingerprint)
         })
       } catch (error) {
         console.warn(


### PR DESCRIPTION
## Why

Prod Meet flag rate stepped from ~22% to ~50% **pool-wide overnight on 2026-08-26** — every exit country burned uniformly (US 34%, CA 38%, BR 43%, AU 35%, HK 38%, RO 30%, CO 62%). That defeats the burned-ASN avoidance structurally: nothing crosses the 35% threshold, so nothing lists, and there is no clean network to rotate toward. **91.5% of flags (368/402 in 48h) came from networks sitting below the burn threshold** — invisible to avoidance.

A uniform overnight jump that ignores the exit IP is a **detector-side change reading the browser, not the network**. To fix that we need to know *which* fingerprint tell Google started reading — and we currently store flag outcomes with no fingerprint to correlate them against. This is Phase 0: measure before touching stealth code.

## What

The bot already had `fingerprint-probe.ts` (navigator/UA-CH, WebGL, Windows-vs-Linux font mix, and a **CDP `Runtime.enable` leak self-test** — the fingerprint-independent automation tell), but it was Zoom-only and wrote debug files, never telemetry.

- Extract `probeFingerprint(page)` → compact `FingerprintSummary` (verdict, `cdp_runtime_leak`, `claims_windows`, win/lin font counts, webgl renderer, dpr/screen/inner). **Prod-safe**: no `BROWSER_DEBUG_CAPTURE` gate, no file writes, never throws. The debug `captureFingerprint()` now shares the same evaluate.
- Probe at the **CreateMeetingDevice detection signal** — exactly when the detector decided, page still live — and attach the summary to `run_context.fingerprint`.

## No api-server change

`run_context` is an open `jsonb` record (`record(string(), zodUnknown())`), stored wholesale — so the summary persists as-is. Correlation runs immediately:

```sql
SELECT run_context->'fingerprint'->>'verdict' v,
       run_context->'fingerprint'->>'cdp_runtime_leak' cdp,
       count(*), count(*) FILTER (WHERE detected_as_bot) flagged
FROM meet_bot_detection_signals
WHERE received_at > now() - interval '24 hours' AND run_context ? 'fingerprint'
GROUP BY 1,2 ORDER BY flagged DESC;
```

## Cost / safety

One `page.evaluate` per detection signal (~once per join), best-effort with `.catch(() => null)` — a probe failure reports `fingerprint: null`, never blocks or fails the signal. Read-only; changes nothing the page can observe.

## Next (not this PR)

Once ~a day of data lands: rank tells by flagged-rate correlation → fix the top one (likely CDP leak or the mixed-OS font tell) → A/B in prod via the same run_context tagging.

tsc clean (Node 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)