### PR TITLE
Feat/decodo zoom consumption+meet antibot followups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,20 @@
 node_modules
 node_modules/**/**
-buid
-buid/**/**
+build
+build/**/**
+
+# .env must NOT be baked into the image.
+# Two reasons, both bit us:
+#  1. Secrets. COPY . . freezes AWS keys and proxy credentials into a layer.
+#  2. Silent config drift. run_bot.sh passes --env-file at runtime, but
+#     dotenv.config() inside the container fills in any var the runtime file
+#     omits — from whatever .env happened to exist at BUILD time. A stale value
+#     baked this way once made a local A/B run measure one configuration while
+#     reporting itself as the other, and nothing in the log said so.
+.env
+.env.*
+*.env
+
+# Local test output — large, and never wanted in the image.
+recordings
+proxy-test-logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,36 @@ RUN apt-get update && \
     ffmpeg \
     # System monitoring
     sysstat procps \
-    # Fonts for rendering / fingerprint realism. crosextra = metric-compatible
-    # Windows clones (Carlito=Calibri, Caladea=Cambria) so a Windows-spoofed UA
-    # also exposes those font names on enumeration.
-    fonts-liberation fonts-dejavu-core \
-    fonts-freefont-ttf fonts-noto-color-emoji fonts-ipafont-gothic fonts-wqy-zenhei \
-    fonts-crosextra-carlito fonts-crosextra-caladea fontconfig \
+    # Fonts. Two jobs: render text at all, and answer the Windows font
+    # enumeration a Windows-spoofed UA has to survive. These are the SOURCES —
+    # scripts/make-windows-metric-clones.py below re-emits them under the
+    # Windows family names, because fontconfig aliases alone do NOT satisfy
+    # Chromium (see that script's docstring for the measurements).
+    fonts-liberation fonts-liberation-sans-narrow fonts-dejavu-core \
+    fonts-freefont-ttf fonts-noto-color-emoji fonts-noto-core \
+    fonts-ipafont-gothic fonts-wqy-zenhei \
+    fonts-crosextra-carlito fonts-crosextra-caladea \
+    fonts-open-sans fonts-cantarell fonts-lato fonts-comic-neue fonts-cascadia-code \
+    fontconfig \
     # Utilities
     wget curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Windows core fonts, cloned from the open faces installed above.
+#
+# The container's UA claims Windows. A real Windows Chrome exposes Segoe UI,
+# Tahoma, Consolas and friends, and any page can test for them from JS by
+# measuring text width. We exposed 5 of 20 — CloakBrowser warns about exactly
+# this at every launch ("Incomplete Windows font set ... when spoofing Windows
+# on Linux"), and it is the MIXED-OS-TELL the fingerprint probe reports.
+#
+# Verified on this base image with the bot's own Chromium: 5/20 before, 20/20
+# after. fontconfig aliases were tried first and do not work — see the script.
+COPY scripts/make-windows-metric-clones.py /tmp/make-windows-metric-clones.py
+RUN apt-get update && apt-get install -y --no-install-recommends python3-fonttools \
+    && python3 /tmp/make-windows-metric-clones.py \
+    && apt-get purge -y python3-fonttools \
+    && rm -f /tmp/make-windows-metric-clones.py \
     && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,15 +138,19 @@ export PULSE_RUNTIME_PATH=/tmp/pulse\n\
 export XDG_RUNTIME_DIR=/tmp/pulse\n\
 mkdir -p $PULSE_RUNTIME_PATH\n\
 \n# Determine resolution from RESOLUTION env var (default: 720p)\n\
+\n# X11_* is the virtual MONITOR and must be a resolution real monitors have:\n\
+\n# the page reads it as screen.width/height and CloakBrowser does not spoof it.\n\
+\n# The browser WINDOW stays 1280x860 / 1920x1220 (set by browser.ts), anchored\n\
+\n# at 0,0, so the x11grab region and its 140px chrome crop are unchanged.\n\
 RESOLUTION=${RESOLUTION:-720}\n\
 if [ "$RESOLUTION" = "1080" ]; then\n\
-    X11_WIDTH=1920\n\
-    X11_HEIGHT=1220\n\
-    echo "📐 Using 1080p resolution: ${X11_WIDTH}x${X11_HEIGHT}"\n\
+    X11_WIDTH=2560\n\
+    X11_HEIGHT=1440\n\
+    echo "📐 Using 1080p: 1920x1220 window on a ${X11_WIDTH}x${X11_HEIGHT} display"\n\
 else\n\
-    X11_WIDTH=1280\n\
-    X11_HEIGHT=860\n\
-    echo "📐 Using 720p resolution: ${X11_WIDTH}x${X11_HEIGHT}"\n\
+    X11_WIDTH=1920\n\
+    X11_HEIGHT=1080\n\
+    echo "📐 Using 720p: 1280x860 window on a ${X11_WIDTH}x${X11_HEIGHT} display"\n\
 fi\n\
 \n# Start virtual display with enhanced cursor hiding\n\
 Xvfb :99 -screen 0 ${X11_WIDTH}x${X11_HEIGHT}x24 -ac +extension GLX +render -noreset -nocursor -nolisten tcp &\n\

--- a/scripts/make-windows-metric-clones.py
+++ b/scripts/make-windows-metric-clones.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Emit Windows-named font files whose glyphs come from open metric clones.
+
+Why this exists, and why the obvious approach does not work.
+
+The container claims Windows in its UA. A real Windows Chrome exposes the Windows
+core fonts, and a page can test for them from JavaScript by measuring text width
+with the font requested and comparing against a generic fallback. Ours exposed
+almost none, which is the "Linux under a Windows UA" tell — CloakBrowser prints a
+warning about it at every launch.
+
+The tempting fix is fontconfig aliases (Segoe UI -> Open Sans). It does not work.
+`fc-match "Segoe UI"` happily reports Open Sans, but Chromium's canvas still
+falls through to the next family in the list and the font measures as ABSENT.
+Verified on Ubuntu 24.04 with the same Chromium the bot runs, in both
+/etc/fonts/local.conf and /etc/fonts/conf.d/, with one-way and bidirectional
+aliases. The five that already pass (Arial, Times New Roman, Courier New,
+Calibri, Cambria) pass because Liberation/Carlito/Caladea are installed as real
+files, not because of the aliases in 30-metric-aliases.conf.
+
+So the family has to genuinely exist. This rewrites the name table of an open
+substitute and installs it under the Windows family name. Glyphs, hinting and
+licence stay those of the source font; only the name changes.
+
+NOTE ON METRICS: only some of these are true metric clones (Liberation for
+Arial/Times/Courier, Carlito for Calibri, Caladea for Cambria). The rest are
+visual stand-ins. That closes "is the family present", which is what the common
+enumeration probes test. It does NOT survive a detector that compares glyph
+advance widths against real Windows metrics.
+"""
+
+import os
+import subprocess
+import sys
+
+from fontTools.ttLib import TTFont
+
+OUT_DIR = "/usr/share/fonts/truetype/win-metric-clones"
+
+# (Windows family, source family). Source must already be installed as its own
+# family — a style within another family (e.g. "DejaVu Sans Condensed") does not
+# qualify, because fc-match resolves it to the parent and the guard rejects it.
+CLONES = [
+    ("Segoe UI", "Open Sans"),
+    ("Tahoma", "DejaVu Sans"),
+    ("Verdana", "Noto Sans"),
+    ("Georgia", "DejaVu Serif"),
+    ("Trebuchet MS", "FreeSans"),
+    ("Consolas", "Cascadia Mono"),
+    ("Lucida Console", "DejaVu Sans Mono"),
+    ("Comic Sans MS", "Comic Neue"),
+    ("Impact", "Liberation Sans Narrow"),
+    ("Bahnschrift", "Open Sans Condensed"),
+    ("Candara", "Cantarell"),
+    ("Corbel", "Carlito"),
+    ("Franklin Gothic Medium", "Lato"),
+    ("Segoe UI Emoji", "Noto Color Emoji"),
+    ("MS Gothic", "IPAGothic"),
+]
+
+
+def source_file(family: str) -> str | None:
+    """Resolve an installed source font to a file, refusing a fallback match."""
+    got = subprocess.run(
+        ["fc-match", "-f", "%{family[0]}\t%{file}", family],
+        capture_output=True, text=True, check=False
+    ).stdout.strip()
+    if "\t" not in got:
+        return None
+    matched_family, path = got.split("\t", 1)
+    # fc-match ALWAYS returns something. If it fell back to a different family the
+    # source is not installed, and silently cloning the fallback would produce a
+    # "Windows" font that is really DejaVu — the exact failure this script exists
+    # to avoid. Refuse it.
+    if matched_family.strip().lower() != family.strip().lower():
+        print(f"  ✗ {family:<24} not installed (fc-match fell back to {matched_family})")
+        return None
+    # urw-base35 and friends ship Type1 (.pfb), which fontTools cannot open as an
+    # sfnt. Reject by extension rather than letting the exception kill the build.
+    if not path.lower().endswith((".ttf", ".otf", ".ttc")):
+        print(f"  ✗ {family:<24} source is not sfnt ({os.path.basename(path)})")
+        return None
+    return path
+
+
+def clone(win_family: str, src_path: str) -> None:
+    font = TTFont(src_path)
+    postscript = win_family.replace(" ", "")
+    for rec in font["name"].names:
+        # 1 = family, 4 = full name, 16 = typographic family, 6 = PostScript name.
+        if rec.nameID in (1, 4, 16):
+            rec.string = win_family
+        elif rec.nameID == 6:
+            rec.string = postscript
+    font.save(os.path.join(OUT_DIR, f"{postscript}.ttf"))
+
+
+def main() -> int:
+    os.makedirs(OUT_DIR, exist_ok=True)
+    made, missing = 0, []
+    for win_family, src_family in CLONES:
+        path = source_file(src_family)
+        if path is None:
+            missing.append(win_family)
+            continue
+        try:
+            clone(win_family, path)
+        except Exception as exc:  # noqa: BLE001 — never fail an image build over a font
+            print(f"  ✗ {win_family:<24} clone failed: {exc}")
+            missing.append(win_family)
+            continue
+        print(f"  ✓ {win_family:<24} <- {src_family} ({os.path.basename(path)})")
+        made += 1
+    subprocess.run(["fc-cache", "-f"], check=False, capture_output=True)
+    print(f"[win-fonts] {made}/{len(CLONES)} generated into {OUT_DIR}")
+    if missing:
+        # Loud, but not fatal: a partial set is still better than none, and a
+        # failed image build over a font is worse than a slightly weaker spoof.
+        print(f"[win-fonts] WARNING missing sources for: {', '.join(missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/make-windows-metric-clones.py
+++ b/scripts/make-windows-metric-clones.py
@@ -42,19 +42,41 @@ OUT_DIR = "/usr/share/fonts/truetype/win-metric-clones"
 # family — a style within another family (e.g. "DejaVu Sans Condensed") does not
 # qualify, because fc-match resolves it to the parent and the guard rejects it.
 CLONES = [
+    # --- CloakBrowser's own gate --------------------------------------------
+    # cloakbrowser/dist/fonts.js WINDOWS_FONT_TELLS. It shells out to `fc-list`
+    # and substring-matches the RAW listing, then warns unless ALL eight are
+    # found. Two consequences worth spelling out:
+    #
+    #  1. Fontconfig aliases are invisible to it. Carlito satisfies "Calibri"
+    #     for a canvas measurement but the string "calibri" never appears in
+    #     fc-list, so the gate counted it missing. Same for Courier New via
+    #     Liberation Mono. Both must be cloned as real files.
+    #  2. It is a substring match, so "Franklin Gothic Medium" already satisfies
+    #     the "Franklin Gothic" tell.
     ("Segoe UI", "Open Sans"),
+    ("Segoe UI Light", "Cantarell"),
+    ("Calibri", "Carlito"),
+    ("Marlett", "FreeSerif"),
+    ("MS UI Gothic", "IPAPGothic"),
+    ("Franklin Gothic Medium", "Lato"),
+    ("Consolas", "Cascadia Mono"),
+    ("Courier New", "Liberation Mono"),
+    # --- the rest of the Windows core set ------------------------------------
+    # Not gated by CloakBrowser, but enumerated by the common JS font probes
+    # (and by our own fingerprint-probe.ts WINDOWS_FONTS list).
+    ("Arial", "Liberation Sans"),
+    ("Times New Roman", "Liberation Serif"),
+    ("Cambria", "Caladea"),
     ("Tahoma", "DejaVu Sans"),
     ("Verdana", "Noto Sans"),
     ("Georgia", "DejaVu Serif"),
     ("Trebuchet MS", "FreeSans"),
-    ("Consolas", "Cascadia Mono"),
     ("Lucida Console", "DejaVu Sans Mono"),
     ("Comic Sans MS", "Comic Neue"),
     ("Impact", "Liberation Sans Narrow"),
     ("Bahnschrift", "Open Sans Condensed"),
     ("Candara", "Cantarell"),
     ("Corbel", "Carlito"),
-    ("Franklin Gothic Medium", "Lato"),
     ("Segoe UI Emoji", "Noto Color Emoji"),
     ("MS Gothic", "IPAGothic"),
 ]

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -329,7 +329,18 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
   if (timezoneId) console.log(`[Browser] Aligning timezone with exit IP: ${timezoneId}`)
 
   const sharedArgs = [
-    // Window size and position - must match Xvfb display exactly
+    // Browser WINDOW geometry. It no longer matches the Xvfb display, and that
+    // is the point: the display is now a real monitor size (1920x1080 /
+    // 2560x1440) because the page reads it as screen.width/height and
+    // CloakBrowser does not spoof it — "Screen and window size come from the
+    // real display, not this flag" (cloakbrowser/dist/config.js). Sizing the
+    // display to the window gave every bot screen=1280x860, a resolution no
+    // monitor has ever had, which is one property read away from blowing the
+    // Windows persona.
+    //
+    // Position MUST stay 0,0. The recorder x11grabs windowWidth x windowHeight
+    // from the display origin and crops the top 140px of browser chrome; move
+    // the window and the recording captures the wrong pixels.
     `--window-size=${windowWidth},${windowHeight}`,
     "--window-position=0,0",
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -407,7 +407,33 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
   // Zoom Web renders via SwiftShader software-WebGL + a software video decoder;
   // the standalone gpu-process measured ~357% CPU. --in-process-gpu
   // folds that into the renderer and drops per-bot demand from ~4.4 cores to
-  // ~115%. Meet/Teams don't need it, so scope it to Zoom.
+  // ~115%. Teams doesn't need it, so it stays on the plain no-GPU set.
+  //
+  // Meet is the exception, and for fingerprint reasons rather than rendering
+  // ones. With --disable-gpu AND --disable-software-rasterizer there is no GL
+  // backend at all, so every WebGL context request fails and the page reports
+  // no renderer string. A browser with no WebGL whatsoever is close to extinct
+  // among real users, which makes "WebGL absent" a stronger signal than any
+  // renderer string we could present. Meet gets a software GL backend so the
+  // context succeeds.
+  //
+  // Cost is bounded by what Meet actually draws, which is very little: the bot
+  // sends no camera, so there is no background-blur pipeline, and remote tiles
+  // are <video> elements the browser composites — not GL draw calls. Creating a
+  // context is cheap; only drawing is not. --disable-gpu-compositing is KEPT so
+  // page compositing stays exactly where it is today, and --in-process-gpu
+  // folds GL into the renderer instead of spawning the separate gpu-process
+  // that cost Zoom ~357%.
+  const meetGpuArgs = [
+    // Compositing path unchanged — this only re-enables a GL backend.
+    "--disable-gpu-compositing",
+    "--in-process-gpu",
+    // Chromium >= M128 refuses to back WebGL with SwiftShader unless this is
+    // set, so without it dropping --disable-gpu buys nothing. Ignored as an
+    // unknown switch on older builds, so it is safe to pass unconditionally.
+    "--enable-unsafe-swiftshader"
+  ]
+
   const gpuArgs =
     platform === "zoom"
       ? [
@@ -416,7 +442,9 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
         "--disable-gpu-compositing",
         "--in-process-gpu"
       ]
-      : ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
+      : platform === "meet"
+        ? meetGpuArgs
+        : ["--disable-gpu", "--disable-software-rasterizer", "--disable-gpu-compositing"]
 
   // Local dev (e.g. macOS) has no PulseAudio/v4l2loopback virtual devices, so
   // Chromium finds no real mic/camera and Teams gets stuck on its pre-join

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -282,6 +282,34 @@ async function openFirefoxBrowser(proxyUrl?: string | null): Promise<{ browser: 
   }
 }
 
+// Every Chromium feature we disable, in ONE list.
+//
+// These MUST be passed as a single --disable-features switch. Chromium's
+// command line keeps one value per switch name, so a second --disable-features
+// replaces the first outright rather than adding to it.
+const DISABLED_FEATURES: readonly string[] = [
+  "AudioServiceSandbox", // virtual PulseAudio devices need the sandbox off
+  // Chrome's "Sign in to Chrome?" / sync / promo surfaces. These are native
+  // browser UI, unreachable by Playwright, and they block a Workspace join.
+  "SigninInterception", // DICE web sign-in intercept bubble
+  "IdentityConsistency", // auto-links cookie-jar identity to a Chrome profile
+  "ChromeBrowserCloudManagement",
+  "SignInPromo",
+  "ChromeWhatsNewUI",
+  "AccountConsistency",
+  "TranslateUI", // translation prompts we never want
+  "AutofillServerCommunication", // stops autofill phoning home
+  "MediaRouter", // Cast discovery we never use
+  // Trusted Types: Meet/Teams injection scripts assign raw strings to sinks.
+  "TrustedScriptTypes",
+  "TrustedHTML"
+]
+
+// Same rule for --disable-blink-features. AutomationControlled is the one that
+// matters for detection: leaving it enabled keeps navigator.webdriver true and
+// no amount of downstream spoofing hides that.
+const DISABLED_BLINK_FEATURES: readonly string[] = ["AutomationControlled", "TrustedDOMTypes"]
+
 async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: BrowserContext }> {
   // Resolution configuration from environment variable
   // Defaults to 720p if RESOLUTION is not set or invalid
@@ -317,7 +345,6 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
     "--use-pulseaudio", // Force Chromium to use PulseAudio
     "--enable-audio-service-sandbox=false", // Disable audio service sandbox for virtual devices
     "--audio-buffer-size=8192", // ~170ms at 48kHz — absorbs CPU contention xruns
-    "--disable-features=AudioServiceSandbox", // Additional sandbox disable
     "--autoplay-policy=no-user-gesture-required", // Allow autoplay for meeting platforms
 
     // WebRTC optimizations (required for meeting audio/video capture)
@@ -338,10 +365,8 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
     // IdentityConsistency = browser auto-linking cookie-jar identity to a Chrome profile
     // --disable-signin = fully disables browser sign-in at the policy level
     "--disable-signin",
-    "--disable-features=SigninInterception,IdentityConsistency,ChromeBrowserCloudManagement,SignInPromo,ChromeWhatsNewUI,AccountConsistency",
 
     // Performance and resource management optimizations
-    "--disable-blink-features=AutomationControlled",
     "--disable-background-timer-throttling",
     "--enable-features=SharedArrayBuffer",
     "--memory-pressure-off", // Disable memory pressure handling for consistent performance
@@ -349,21 +374,25 @@ async function openCloakBrowser(proxyUrl?: string | null): Promise<{ browser: Br
     // --max_old_space_size argument is not a Chromium switch and is silently ignored.
     "--js-flags=--max-old-space-size=4096",
     "--disable-background-networking", // Reduce background network activity
-    "--disable-features=TranslateUI", // Disable translation features to save resources
-    "--disable-features=AutofillServerCommunication", // Disable autofill to reduce network usage
     "--disable-component-extensions-with-background-pages", // Reduce background extension overhead
     "--disable-default-apps", // Disable default Chrome apps
     "--renderer-process-limit=4", // Limit renderer processes to prevent resource exhaustion
     "--disable-ipc-flooding-protection", // Improve IPC performance for high-frequency operations
     "--aggressive-cache-discard", // Enable aggressive cache management for memory efficiency
-    "--disable-features=MediaRouter", // Disable media router for reduced overhead
 
     // Certificate and security optimizations for meeting platforms
     "--ignore-certificate-errors",
     "--allow-insecure-localhost",
-    "--disable-blink-features=TrustedDOMTypes",
-    "--disable-features=TrustedScriptTypes",
-    "--disable-features=TrustedHTML",
+
+    // Chromium keeps ONE value per switch name — a repeated --disable-features
+    // or --disable-blink-features silently discards every earlier occurrence
+    // instead of merging them. This file used to pass --disable-features seven
+    // times and --disable-blink-features twice, so only the last of each
+    // survived: everything else, INCLUDING AutomationControlled, was dropped on
+    // the floor and navigator.webdriver was left in its automation state. Both
+    // switches must stay single, comma-joined, and appear exactly once.
+    `--disable-blink-features=${DISABLED_BLINK_FEATURES.join(",")}`,
+    `--disable-features=${DISABLED_FEATURES.join(",")}`,
 
     // Additional audio debugging (remove in production)
     "--enable-logging=stderr",

--- a/src/browser/fingerprint-probe.ts
+++ b/src/browser/fingerprint-probe.ts
@@ -344,6 +344,17 @@ async function evaluateFingerprint(page: Page): Promise<RawFingerprint | null> {
               (document as unknown as { fonts?: { size?: number } }).fonts?.size ?? null
           },
           geometry: {
+            // Where the browser WINDOW actually sits on the X display. The
+            // recorder x11grabs from the display ORIGIN and crops a fixed 140px
+            // of browser chrome, so a window that is not at 0,0 records the
+            // wrong pixels. Chromium is pinned there by --window-position=0,0;
+            // Firefox/stealthfox gets no such flag and no window manager exists
+            // in the container to place it, which only became a live question
+            // once the X display grew larger than the window. Non-zero here
+            // means the capture region is wrong — check this before trusting a
+            // stealthfox recording.
+            screenX: window.screenX,
+            screenY: window.screenY,
             dpr: window.devicePixelRatio,
             screen: `${screen.width}x${screen.height}`,
             avail: `${screen.availWidth}x${screen.availHeight}`,

--- a/src/browser/fingerprint-probe.ts
+++ b/src/browser/fingerprint-probe.ts
@@ -77,6 +77,14 @@ type RawFingerprint = {
     [k: string]: unknown
   }
   cdp: { runtimeEnableLeak: boolean | null }
+  patches: {
+    createEncodedStreamsPresent: boolean | null
+    getContributingSourcesNative: boolean | null
+    fetchNative: boolean | null
+    rtcPeerConnectionNative: boolean | null
+    getUserMediaNative: boolean | null
+    exposedBindings: string[]
+  }
   webgl: { renderer?: unknown; unmaskedRenderer?: unknown } | null
   webgl2: { renderer?: unknown; unmaskedRenderer?: unknown } | null
   fonts: {
@@ -100,8 +108,16 @@ type RawFingerprint = {
  * correlated against detected_as_bot. Keep it small — one row per bot join.
  */
 export type FingerprintSummary = {
-  verdict: "CDP-RUNTIME-LEAK" | "MIXED-OS-TELL" | "ok"
+  verdict: "CDP-RUNTIME-LEAK" | "PATCHED-NATIVE-API" | "MIXED-OS-TELL" | "ok"
   cdp_runtime_leak: boolean | null
+  // Tells we inflict on ourselves, one field per patch so each can be fixed and
+  // A/B'd independently. self_patch_count is the roll-up for a first cut at the
+  // data; the individual fields say which patch to go after.
+  self_patch_count: number
+  encoded_streams_deleted: boolean | null
+  fetch_patched: boolean | null
+  contributing_sources_patched: boolean | null
+  exposed_bindings: string[]
   claims_windows: boolean
   platform: string | null
   webdriver: boolean | null
@@ -213,6 +229,81 @@ async function evaluateFingerprint(page: Page): Promise<RawFingerprint | null> {
           return { present }
         }
 
+        // --- Self-inflicted tells ---
+        //
+        // Everything above measures what the CONTAINER looks like. This block
+        // measures what WE did to the page, which is a different and more
+        // specific class of tell: our own injected scripts patch native WebRTC
+        // and network APIs that Meet's client itself feature-detects, and
+        // nothing masks Function.prototype.toString, so each patch is one line
+        // for a detector to find.
+        //
+        //   createEncodedStreams  — deleted outright by setupForceNativeAudioPipeline,
+        //                           so a UA claiming a Chrome that ships the API
+        //                           meets a page where the API is missing.
+        //   getContributingSources / fetch
+        //                         — replaced with plain JS functions by the
+        //                           network-interception bundle.
+        //   exposed bindings      — page.exposeFunction() leaves a uniquely named
+        //                           global (e.g. meetSpeakersChanged) on window.
+        //
+        // Reported per-tell rather than as one boolean so a fix can be A/B'd one
+        // patch at a time.
+        const isNative = (fn: unknown): boolean | null => {
+          if (typeof fn !== "function") return null
+          try {
+            return /\{\s*\[native code\]\s*\}/.test(Function.prototype.toString.call(fn))
+          } catch {
+            return null
+          }
+        }
+
+        const rtcReceiverProto = (
+          window as unknown as { RTCRtpReceiver?: { prototype?: Record<string, unknown> } }
+        ).RTCRtpReceiver?.prototype
+
+        // Every name we hand to page.exposeFunction(), across all platforms.
+        // Playwright installs each as a real property on `window`, so a detector
+        // enumerating globals sees a function named after the product it is
+        // defending. The names are ours, so an exact list beats a heuristic scan.
+        //
+        // onNetworkSpeakerUpdate and onChatMessageReceived matter most on Meet:
+        // both are installed BEFORE page.goto, so they are present on window at
+        // the moment CreateMeetingDevice decides. The *SpeakersChanged bindings
+        // arrive later, in-call.
+        const EXPOSED_BINDINGS = [
+          "onNetworkSpeakerUpdate", // meet + teams + zoom, pre-goto
+          "onChatMessageReceived", // meet, pre-goto
+          "meetSpeakersChanged",
+          "teamsSpeakersChanged",
+          "onTeamsChatMessage",
+          "zoomSpeakersChanged",
+          "zoomSpeakerForensics",
+          "zoomCleanerLog",
+          "zoomChatMessage"
+        ]
+
+        const patches = {
+          // null = the API does not exist in this build at all, which is not the
+          // same as us having removed it. Only `false` means we deleted it.
+          createEncodedStreamsPresent: rtcReceiverProto
+            ? "createEncodedStreams" in rtcReceiverProto
+            : null,
+          getContributingSourcesNative: rtcReceiverProto
+            ? isNative(rtcReceiverProto.getContributingSources)
+            : null,
+          fetchNative: isNative(window.fetch),
+          // Baselines. If these ever read false we are patching something we
+          // did not intend to, or a dependency is.
+          rtcPeerConnectionNative: isNative(
+            (window as unknown as { RTCPeerConnection?: unknown }).RTCPeerConnection
+          ),
+          getUserMediaNative: isNative(navigator.mediaDevices?.getUserMedia),
+          exposedBindings: EXPOSED_BINDINGS.filter(
+            (n) => typeof (window as unknown as Record<string, unknown>)[n] !== "undefined"
+          )
+        }
+
         // --- CDP Runtime.enable leak self-test ---
         // The dominant modern bot tell, and fingerprint-INDEPENDENT: if the
         // automation layer has sent Runtime.enable (vanilla Playwright/Puppeteer
@@ -241,6 +332,7 @@ async function evaluateFingerprint(page: Page): Promise<RawFingerprint | null> {
         return {
           navigator: navigatorInfo,
           cdp: { runtimeEnableLeak },
+          patches,
           webgl: readGl("webgl"),
           webgl2: readGl("webgl2"),
           fonts: {
@@ -278,17 +370,41 @@ function summarizeFingerprint(fp: RawFingerprint): FingerprintSummary {
     String(fp.navigator.platform).startsWith("Win")
   const winFontCount = fp.fonts.windowsPresent.length
   const linFontCount = fp.fonts.linuxPresent.length
+  // A deleted or re-implemented native API is a harder tell than a font mix —
+  // it contradicts the UA on a capability Meet's own client feature-detects —
+  // so it outranks MIXED-OS-TELL. The CDP leak still wins overall: it defeats
+  // every other disguise on the page.
+  const encodedStreamsDeleted =
+    fp.patches.createEncodedStreamsPresent === null ? null : !fp.patches.createEncodedStreamsPresent
+  const fetchPatched = fp.patches.fetchNative === null ? null : !fp.patches.fetchNative
+  const contributingSourcesPatched =
+    fp.patches.getContributingSourcesNative === null ? null : !fp.patches.getContributingSourcesNative
+  const selfPatchCount =
+    (encodedStreamsDeleted === true ? 1 : 0) +
+    (fetchPatched === true ? 1 : 0) +
+    (contributingSourcesPatched === true ? 1 : 0) +
+    (fp.patches.rtcPeerConnectionNative === false ? 1 : 0) +
+    (fp.patches.getUserMediaNative === false ? 1 : 0) +
+    fp.patches.exposedBindings.length
+
   const verdict =
     fp.cdp.runtimeEnableLeak === true
       ? "CDP-RUNTIME-LEAK"
-      : claimsWindows && winFontCount === 0 && linFontCount > 0
-        ? "MIXED-OS-TELL"
-        : "ok"
+      : selfPatchCount > 0
+        ? "PATCHED-NATIVE-API"
+        : claimsWindows && winFontCount === 0 && linFontCount > 0
+          ? "MIXED-OS-TELL"
+          : "ok"
 
   const renderer = fp.webgl?.unmaskedRenderer ?? fp.webgl?.renderer ?? null
   return {
     verdict,
     cdp_runtime_leak: fp.cdp.runtimeEnableLeak,
+    self_patch_count: selfPatchCount,
+    encoded_streams_deleted: encodedStreamsDeleted,
+    fetch_patched: fetchPatched,
+    contributing_sources_patched: contributingSourcesPatched,
+    exposed_bindings: fp.patches.exposedBindings,
     claims_windows: claimsWindows,
     platform: fp.navigator.platform == null ? null : String(fp.navigator.platform),
     webdriver: typeof fp.navigator.webdriver === "boolean" ? fp.navigator.webdriver : null,
@@ -347,6 +463,11 @@ export async function captureFingerprint(page: Page, label: string): Promise<voi
     console.log(
       `[FingerprintProbe:${label}] verdict=${summary.verdict} ` +
         `cdpRuntimeLeak=${summary.cdp_runtime_leak} ` +
+        `selfPatches=${summary.self_patch_count} ` +
+        `(encodedStreamsDeleted=${summary.encoded_streams_deleted} ` +
+        `fetchPatched=${summary.fetch_patched} ` +
+        `contributingSourcesPatched=${summary.contributing_sources_patched} ` +
+        `exposed=[${summary.exposed_bindings.join(",")}]) ` +
         `platform=${summary.platform} webdriver=${summary.webdriver} ` +
         `winFonts=${summary.win_fonts_present}/${fp.fonts.windowsProbed} ` +
         `linFonts=${summary.lin_fonts_present}/${fp.fonts.linuxProbed} ` +

--- a/src/meeting/meet.ts
+++ b/src/meeting/meet.ts
@@ -1,6 +1,5 @@
 import type { BrowserContext, Page } from "@playwright/test"
 import { Api } from "../api/methods"
-import { brandingReady } from "../branding"
 import { listenPage } from "../browser/page-logger"
 import { SimpleDialogObserver } from "../services/dialog-observer/simple-dialog-observer"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
@@ -102,11 +101,28 @@ export class MeetProvider implements MeetingProviderInterface {
       listenPage(page)
       console.log("[Meet] Page logger set up")
 
-      // Set permissions based on streaming_input
-      if (streaming_input) {
-        await browserContext.grantPermissions(["microphone", "camera"])
+      // grantPermissions(["microphone","camera"]) is a Chromium-only API —
+      // Firefox rejects those permission names outright ("Unknown permission:
+      // camera"), which threw out of openMeetingPage and failed the join the
+      // moment STEALTHFOX_PLATFORMS was widened to include meet. stealthfox
+      // grants media through its launch prefs instead
+      // (permissions.default.camera/microphone = 1 and
+      // media.navigator.permission.disabled — see buildFirefoxLaunchConfig), so
+      // there is nothing to grant here and skipping is not a downgrade.
+      // Same guard zoom.ts already carries; kept in sync deliberately.
+      const browserName = browserContext.browser()?.browserType().name()
+      if (browserName === "chromium") {
+        try {
+          await browserContext.grantPermissions(
+            streaming_input ? ["microphone", "camera"] : ["camera"]
+          )
+        } catch (e) {
+          console.warn("[Meet] grantPermissions failed (continuing):", formatError(e))
+        }
       } else {
-        await browserContext.grantPermissions(["camera"])
+        console.log(
+          `[Meet] Skipping grantPermissions (browser=${browserName ?? "unknown"}; granted via launch prefs)`
+        )
       }
 
       // Audio track layer for network diarization
@@ -340,9 +356,27 @@ export class MeetProvider implements MeetingProviderInterface {
         await deactivateMicrophone(page)
       }
 
-      // Control camera based on whether branding was actually generated successfully
-      if (brandingReady) {
-        console.log("Camera will be used for branding, keeping it on")
+      // Key the camera on CONFIGURED INTENT, not branding readiness.
+      //
+      // setupBranding() is fire-and-forget (initialization-state.ts does not
+      // await it), and the image download runs over the residential proxy, so
+      // whether generation beats the pre-join screen is a race decided by
+      // network luck. Losing it used to call deactivateCamera() here — and
+      // nothing ever turns the camera back on, so the branding image never
+      // appeared even though the MJPEG landed on /dev/video10 seconds later.
+      //
+      // zoom.ts already fixed exactly this and says so in its own comment:
+      // "Key the decision on the configured intent, NOT branding readiness --
+      // the branding pipeline is fire-and-forget and often isn't ready yet at
+      // preview (this is exactly why the image 'usually doesn't show'
+      // locally)". This is that fix, ported to Meet.
+      //
+      // Camera-on with the warmup placeholder is strictly better than
+      // camera-off: playBranding() switches the same VideoContext over to the
+      // real image the moment it is ready, with no v4l2 gap.
+      const wantsCameraImage = !!GLOBAL.get().bot_image
+      if (wantsCameraImage) {
+        console.log("Camera will be used for branding, keeping it on (bot_image configured)")
       } else {
         await deactivateCamera(page)
       }
@@ -574,8 +608,13 @@ async function performCriticalSetupActions(
   page: Page,
   dialogObserver?: SimpleDialogObserver
 ): Promise<void> {
-  // Re-enforce camera/mic state — Google Meet resets devices during waiting room → in-call transition
-  if (brandingReady) {
+  // Re-enforce camera/mic state — Google Meet resets devices during waiting room → in-call transition.
+  // Same reasoning as the pre-join gate above: keyed on configured intent, not
+  // branding readiness. This is the second gate that could silently kill the
+  // image — passing pre-join was never enough, because Meet re-mutes devices on
+  // the waiting-room -> in-call transition and this ran with brandingReady
+  // still false.
+  if (GLOBAL.get().bot_image) {
     await ensureCameraOn(page)
   } else {
     await ensureCameraOff(page)

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -204,19 +204,42 @@ export function browserInterceptionLogic(schema: any[]) {
         md.enumerateDevices = async function (...args: any[]) {
           const devices = await originalEnumerate(...args)
           try {
-            return devices.map((d: any) => {
-              const clone = Object.create(Object.getPrototypeOf(d))
-              Object.defineProperty(clone, "deviceId", { value: d.deviceId, enumerable: true })
-              Object.defineProperty(clone, "groupId", { value: d.groupId, enumerable: true })
-              Object.defineProperty(clone, "kind", { value: d.kind, enumerable: true })
+            // Shadow `label` as an own property on the REAL device object.
+            //
+            // Do NOT clone. Object.create(Object.getPrototypeOf(d)) produces an
+            // object that passes `instanceof MediaDeviceInfo` and reads deviceId
+            // fine -- which is exactly why the clone looked safe -- but it has no
+            // internal slot, so EVERY native method on it throws
+            // "TypeError: Illegal invocation". Verified in the bot's own Chromium:
+            //
+            //   real videoinput ctor:            InputDeviceInfo
+            //   real  getCapabilities():         OK
+            //   clone instanceof MediaDeviceInfo: true
+            //   clone getCapabilities():         TypeError: Illegal invocation
+            //   clone toJSON():                  TypeError: Illegal invocation
+            //
+            // Video inputs are InputDeviceInfo and Meet calls getCapabilities()
+            // on cameras to pick a resolution. With the clone that threw, Meet
+            // could not resolve the camera and the bot joined with no video, so
+            // the branding image never appeared. Audio was unaffected, which is
+            // why only the image broke.
+            //
+            // Defining an own `label` on the original instance shadows the
+            // prototype getter while leaving the internal slot intact, so
+            // getCapabilities(), toJSON() and getUserMedia({deviceId}) all keep
+            // working. enumerateDevices() returns fresh objects per call, so
+            // mutating them here is local to this call.
+            for (const d of devices) {
               // Leave devices with no label (permission not yet granted) untouched
               // -- a filled-in label before permission is itself a coherence tell.
-              Object.defineProperty(clone, "label", {
-                value: d.label ? stableLabel(d.kind, d.deviceId) : d.label,
-                enumerable: true
+              if (!d.label) continue
+              Object.defineProperty(d, "label", {
+                value: stableLabel(d.kind, d.deviceId),
+                enumerable: true,
+                configurable: true
               })
-              return clone
-            })
+            }
+            return devices
           } catch (_e) {
             return devices
           }

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page } from "@playwright/test"
 import { envVars } from "../config/env-vars"
 import { captureFingerprint } from "../browser/fingerprint-probe"
 import { listenPage } from "../browser/page-logger"
+import { setZoomJoinHost } from "../proxy/toggle-proxy"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
@@ -115,6 +116,18 @@ export class ZoomProvider implements MeetingProviderInterface {
     const page = await browserContext.newPage()
     page.setDefaultTimeout(30_000)
     page.setDefaultNavigationTimeout(60_000)
+
+    // Tell the proxy which host is making the join decision, so that host — and
+    // only that host — is eligible for the residential exit. Usually
+    // app.zoom.us, but Zoom Events, ?tk= webinar links and pre-formed /wc/ URLs
+    // each navigate somewhere else. Everything else under zoom.us (the asset
+    // CDN, telemetry, the RWG media relays) goes direct from the pod IP.
+    try {
+      setZoomJoinHost(new URL(link).hostname)
+    } catch {
+      // Unparseable link: leave the static list to cover it. goto will fail
+      // below and report the real problem rather than a proxy-shaped one.
+    }
 
     // Pin the viewport to the exact ffmpeg capture size. The page provably
     // renders full-width (single-main-container__video-frame = 1280x720, right

--- a/src/proxy/toggle-proxy.test.ts
+++ b/src/proxy/toggle-proxy.test.ts
@@ -1,0 +1,118 @@
+import { setZoomJoinHost, shouldProxy } from "./toggle-proxy"
+
+// toggle-proxy pulls in the singleton for the geo/rotation helpers. Nothing
+// under test reads it — the allowlist is a flat constant, not platform-scoped —
+// but the import has to resolve.
+jest.mock("../singleton", () => ({
+  GLOBAL: { get: () => ({ bot_uuid: "test-bot", proxy_countries: [] }) }
+}))
+
+// Module-level state: every test declares the join host it is testing under, so
+// one test's registration can never leak into the next.
+beforeEach(() => setZoomJoinHost("app.zoom.us"))
+
+describe("residential proxy host selection", () => {
+  describe("zoom", () => {
+    it("proxies the hosts that make the join decision", () => {
+      expect(shouldProxy("app.zoom.us")).toBe(true)
+      expect(shouldProxy("zoom.us")).toBe(true)
+      expect(shouldProxy("www.zoom.us")).toBe(true)
+      expect(shouldProxy("events.zoom.us")).toBe(true)
+    })
+
+    it("does NOT proxy the asset CDN", () => {
+      // Measured on a real local run: us04st1.zoom.us alone was 15.46 MB of a
+      // bot's 16.77 MB residential spend — 92%. The anti-bot check never looks
+      // at it.
+      expect(shouldProxy("us04st1.zoom.us")).toBe(false)
+      expect(shouldProxy("us05st1.zoom.us")).toBe(false)
+      expect(shouldProxy("st1.zoom.us")).toBe(false)
+      expect(shouldProxy("source.zoom.us")).toBe(false)
+      expect(shouldProxy("ssrweb.zoom.us")).toBe(false)
+      expect(shouldProxy("us04st-cf.zoom.us")).toBe(false)
+    })
+
+    it("does NOT proxy media relays or telemetry", () => {
+      // Real hostnames, taken from the Decodo billing export and local runs.
+      expect(shouldProxy("zoomiad206247100214rwg.iad.zoom.us")).toBe(false)
+      expect(shouldProxy("rwciad.iad.zoom.us")).toBe(false)
+      expect(shouldProxy("us.telemetry.zoom.us")).toBe(false)
+      expect(shouldProxy("log-gateway.zoom.us")).toBe(false)
+      expect(shouldProxy("das.zoom.us")).toBe(false)
+    })
+  })
+
+  describe("the join host, registered at runtime", () => {
+    it("proxies a regional web host the static list does not name", () => {
+      setZoomJoinHost("us06web.zoom.us")
+      expect(shouldProxy("us06web.zoom.us")).toBe(true)
+      // …and only that one. Its neighbours stay direct.
+      expect(shouldProxy("us05web.zoom.us")).toBe(false)
+    })
+
+    it("proxies a white-label portal host", () => {
+      setZoomJoinHost("meet.acmecorp.com")
+      expect(shouldProxy("meet.acmecorp.com")).toBe(true)
+      expect(shouldProxy("cdn.acmecorp.com")).toBe(false)
+    })
+
+    it("replaces rather than accumulates, and an empty host clears it", () => {
+      setZoomJoinHost("us06web.zoom.us")
+      setZoomJoinHost("")
+      expect(shouldProxy("us06web.zoom.us")).toBe(false)
+      // The static list is unaffected by clearing the join host.
+      expect(shouldProxy("app.zoom.us")).toBe(true)
+    })
+
+    it("is case-insensitive", () => {
+      setZoomJoinHost("US06Web.Zoom.US")
+      expect(shouldProxy("us06web.zoom.us")).toBe(true)
+      expect(shouldProxy("US06WEB.ZOOM.US")).toBe(true)
+    })
+  })
+
+  describe("shared anti-bot infrastructure", () => {
+    it("proxies reCAPTCHA, which is what Zoom's wall actually is", () => {
+      // Regression test. Scoping these hosts to Meet sent them out of the pod's
+      // datacenter IP on a Zoom join and every Zoom bot was walled with
+      // zoomAnonymousJoinNotAllowed, while a bot from the old build joined the
+      // same meeting four seconds earlier. reCAPTCHA scores the IP that fetches
+      // it — it must never be behind a platform branch.
+      expect(shouldProxy("google.com")).toBe(true)
+      expect(shouldProxy("www.google.com")).toBe(true)
+    })
+
+    it("does not pull in the rest of google.com", () => {
+      // Exact match, not suffix — these are push/telemetry, not anti-bot.
+      expect(shouldProxy("play.google.com")).toBe(false)
+      expect(shouldProxy("mtalk.google.com")).toBe(false)
+    })
+
+    it("proxies the exit-IP probe", () => {
+      expect(shouldProxy("ip.decodo.com")).toBe(true)
+    })
+  })
+
+  describe("meet", () => {
+    it("keeps the existing suffix behaviour", () => {
+      expect(shouldProxy("meet.google.com")).toBe(true)
+      expect(shouldProxy("accounts.google.com")).toBe(true)
+      expect(shouldProxy("apis.google.com")).toBe(true)
+      expect(shouldProxy("hangouts.clients6.google.com")).toBe(true)
+    })
+
+    it("still excludes the asset hosts that were never allowlisted", () => {
+      expect(shouldProxy("www.gstatic.com")).toBe(false)
+      expect(shouldProxy("ssl.gstatic.com")).toBe(false)
+      expect(shouldProxy("lh3.googleusercontent.com")).toBe(false)
+    })
+  })
+
+  it("routes anything unlisted direct", () => {
+    expect(shouldProxy("example.com")).toBe(false)
+    expect(shouldProxy("teams.microsoft.com")).toBe(false)
+    // Suffix matching must not be fooled by a lookalike registrable domain.
+    expect(shouldProxy("notzoom.us")).toBe(false)
+    expect(shouldProxy("evil-app.zoom.us.attacker.com")).toBe(false)
+  })
+})

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -10,13 +10,24 @@ import { Server } from "proxy-chain"
 import { envVars } from "../config/env-vars"
 import { GLOBAL } from "../singleton"
 
-// Allowlist of hosts that route through the residential upstream. Everything
-// else goes direct from the pod IP. Default-direct is intentional: if Google
-// adds a new asset CDN tomorrow, it goes direct automatically and doesn't
-// surprise us with a residential bandwidth balloon. The trade-off vs a
-// deny-list is that a missing entry here costs detection rate rather than
-// money — re-check the Decodo dashboard + the [Meet] 🚨/✅ signal after
-// adjusting this list.
+// Hosts that route through the residential upstream. Everything else goes
+// direct from the pod IP.
+//
+// Default-direct is intentional: a host we forget to list goes direct
+// automatically rather than surprising us with a residential bandwidth
+// balloon. The trade-off is that a missing entry costs detection rate rather
+// than money — re-check the Decodo dashboard and the [Meet] 🚨/✅ signal after
+// adjusting either list.
+//
+// ONE FLAT LIST, not scoped per platform. An earlier version of this file split
+// it into a Meet set and a Zoom set, which quietly moved reCAPTCHA
+// (www.google.com) out of the Zoom bot's set — and reCAPTCHA is precisely what
+// Zoom's anti-bot wall is. Every Zoom bot was then walled with "automated bots
+// aren't allowed" while a bot from the old build joined the same meeting four
+// seconds earlier (prod 3de61a8a joined 77376218875 at 11:27:31; preprod
+// 5b33d261 was walled on it at 11:27:35). The two sets are disjoint by domain
+// anyway — a Meet bot never resolves app.zoom.us — so the scoping bought
+// nothing and cost joins. Keep it flat.
 //
 // Suffix matches cover the host itself AND any subdomain. Exact matches do
 // not — `google.com` exact is intentional so we don't pull `play.google.com`
@@ -25,28 +36,60 @@ const PROXY_ALLOWLIST_SUFFIXES: readonly string[] = [
   "meet.google.com", // SPA + the $rpc scoring endpoints
   "accounts.google.com", // OAuth / login flow
   "apis.google.com", // Google APIs the Meet client calls during join
-  "clients6.google.com", // Meet signaling — hangouts., feedback-pa., scone-pa.
-  // Zoom web client — one suffix covers every host the join touches:
-  // app.zoom.us (the /wc/ web client), us05web./<region>.zoom.us and
-  // zoom.us (invite hosts we rewrite from), events.zoom.us. Testing whether
-  // residential egress moves the browser-join anti-bot / RTMS wall.
-  // Bandwidth trade-off: Zoom's pre-join assets are heavier than Meet's, so
-  // this costs more Decodo bytes per join — but setDirectMode() flips the
-  // upstream off at admission, so in-call media stays off the residential link.
-  "zoom.us"
+  "clients6.google.com" // Meet signaling — hangouts., feedback-pa., scone-pa.
 ]
 
+// Zoom is exact-match only, and deliberately so.
+//
+// This used to be a single `zoom.us` SUFFIX, which enrolled three things the
+// anti-bot check never looks at: the asset CDN (source.zoom.us, *st1.zoom.us —
+// the JS + WASM decoder bundle, refetched cold on every one of the up-to-12
+// launches a Zoom bot can make from a throwaway profile), client telemetry, and
+// the RWG relays that carry ALL in-call audio and video. Measured on a local
+// run: us04st1.zoom.us alone was 15.46 MB of a bot's 16.77 MB residential
+// spend — 92% of the bill, for bytes no anti-bot check reads.
+//
+// Meet's numbers look good next to Zoom's largely by luck of architecture:
+// Google serves its assets off gstatic (never allowlisted) and its media over
+// UDP, which cannot enter a CONNECT proxy at all. Zoom hands us neither split
+// for free — its own firewall doc is a flat `*.zoom.us` wildcard — so we take
+// the split by hand.
 const PROXY_ALLOWLIST_EXACT: ReadonlySet<string> = new Set([
+  // Shared anti-bot infrastructure. reCAPTCHA scores the IP that fetches it,
+  // and it is what stands between a Zoom bot and the meeting, so it must see
+  // the residential exit on every platform. Do not move these into a branch.
   "google.com",
   "www.google.com",
-  "ip.decodo.com" // our own residential-IP probe
+  "ip.decodo.com", // our own residential-IP probe
+  // Zoom: the hosts that actually make the join decision, and nothing else.
+  "app.zoom.us", // the /wc/ web client buildZoomWebClientUrl rewrites to
+  "zoom.us",
+  "www.zoom.us",
+  "events.zoom.us" // Zoom Events links self-redirect into the web client
 ])
 
-function shouldProxy(target: string): boolean {
-  if (PROXY_ALLOWLIST_EXACT.has(target)) return true
-  return PROXY_ALLOWLIST_SUFFIXES.some(
-    (suffix) => target === suffix || target.endsWith(`.${suffix}`)
-  )
+// Host of the URL the bot actually navigates to for the join. Usually
+// app.zoom.us — buildZoomWebClientUrl rewrites canonical invites to it, vanity
+// tenants included — but ?tk= webinar links, pre-formed /wc/ URLs and
+// white-label portals each navigate somewhere else, and whichever host we
+// navigate to is by definition the one making the join decision. So it is
+// proxied whatever it turns out to be.
+let zoomJoinHost: string | null = null
+
+/** Register the join URL's host as proxy-eligible. Call before page.goto(). */
+export function setZoomJoinHost(hostname: string): void {
+  const h = hostname.trim().toLowerCase()
+  zoomJoinHost = h || null
+  if (zoomJoinHost && !PROXY_ALLOWLIST_EXACT.has(zoomJoinHost)) {
+    console.log(`[ToggleProxy] Join host ${zoomJoinHost} added to the residential set`)
+  }
+}
+
+export function shouldProxy(target: string): boolean {
+  const host = target.toLowerCase()
+  if (PROXY_ALLOWLIST_EXACT.has(host)) return true
+  if (zoomJoinHost !== null && host === zoomJoinHost) return true
+  return PROXY_ALLOWLIST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))
 }
 
 let server: Server | null = null
@@ -186,9 +229,16 @@ function inferProxyProvider(): string {
   }
 }
 
-// Set of connectionIds that were routed through the residential upstream.
-// Used to filter stats so only Decodo-billed traffic is counted.
-const proxiedConnectionIds = new Set<number>()
+// connectionId → hostname, for connections currently routed through the
+// residential upstream. Used to filter stats so only Decodo-billed traffic is
+// counted, and to attribute those bytes to a host: the per-connection numbers
+// were always available on connectionClosed, we simply threw the hostname away
+// and kept two scalars — which is why every conversation about this cost was a
+// conversation about one opaque number.
+const proxiedConnectionIds = new Map<number, string>()
+
+// Residential bytes per host, accumulated as proxied connections close.
+const perHost = new Map<string, { tx: number; rx: number; conns: number }>()
 
 // Accumulated byte counts from closed upstream-proxied connections only.
 // trgTxBytes/trgRxBytes are the bytes over the Decodo link (what Decodo bills).
@@ -210,16 +260,27 @@ function logStats(label: string): void {
   let trgRx = stats.trgRxBytes
   let count = stats.connectionCount
 
+  // Per-host totals, seeded from closed connections. The still-open ones are
+  // folded in below and they are the ones that matter: a long-lived H2 or
+  // WebSocket tunnel is exactly the connection carrying the bytes worth finding.
+  const byHost = new Map<string, { bytes: number; conns: number }>()
+  for (const [host, h] of perHost) byHost.set(host, { bytes: h.tx + h.rx, conns: h.conns })
+
   // Add bytes from proxied connections still open at log time — long-lived
   // keep-alive/H2 tunnels carry most traffic but may not have closed yet.
   if (server) {
-    for (const id of proxiedConnectionIds) {
+    for (const [id, host] of proxiedConnectionIds) {
       const cs = server.getConnectionStats(id)
-      if (cs) {
-        trgTx += cs.trgTxBytes ?? 0
-        trgRx += cs.trgRxBytes ?? 0
-        count++
-      }
+      if (!cs) continue
+      const tx = cs.trgTxBytes ?? 0
+      const rx = cs.trgRxBytes ?? 0
+      trgTx += tx
+      trgRx += rx
+      count++
+      const e = byHost.get(host) ?? { bytes: 0, conns: 0 }
+      e.bytes += tx + rx
+      e.conns++
+      byHost.set(host, e)
     }
   }
 
@@ -233,6 +294,40 @@ function logStats(label: string): void {
       `total (Decodo billed): ${formatBytes(trgTx + trgRx)}` +
       ipSuffix
   )
+  // Per-host breakdown. Without this the total is unactionable: it cannot tell
+  // an anti-bot check we are paying for on purpose from an asset bundle or a
+  // media socket we are paying for by accident.
+  for (const [host, e] of [...byHost].sort((a, b) => b[1].bytes - a[1].bytes)) {
+    console.log(
+      `[ToggleProxy] 📊   ${host.padEnd(34)} ${formatBytes(e.bytes).padStart(11)}  (${e.conns} conn)`
+    )
+  }
+}
+
+/**
+ * Close every connection currently routed through the residential upstream.
+ *
+ * This is the only way to detach traffic from the paid link once it is
+ * flowing. prepareRequestFunction runs ONCE per connection, so flipping
+ * `useUpstream` cannot move a tunnel that is already open — it only governs
+ * the next one. Closing forces the client to reconnect, and that reconnect is
+ * evaluated fresh, by which point the flag (or a demotion) sends it direct.
+ */
+function closeProxiedConnections(reason: string): number {
+  if (!server) return 0
+  let closed = 0
+  for (const id of [...proxiedConnectionIds.keys()]) {
+    try {
+      server.closeConnection(id)
+      closed++
+    } catch {
+      // already gone — nothing to do
+    }
+  }
+  if (closed > 0) {
+    console.log(`[ToggleProxy] ✂️  Closed ${closed} residential connection(s) — ${reason}`)
+  }
+  return closed
 }
 
 export async function startToggleProxy(
@@ -288,6 +383,7 @@ export async function startToggleProxy(
   stats.trgRxBytes = 0
   stats.connectionCount = 0
   proxiedConnectionIds.clear()
+  perHost.clear()
   exitIp = null
   exitAsn = null
   exitGeo = null
@@ -315,7 +411,7 @@ export async function startToggleProxy(
           return {}
         }
         if (useUpstream) {
-          proxiedConnectionIds.add(connectionId)
+          proxiedConnectionIds.set(connectionId, target)
           console.log(`[ToggleProxy] PROXIED → ${target}`)
           return { upstreamProxyUrl: upstreamUrl, ignoreUpstreamProxyCertificate: true }
         }
@@ -331,11 +427,19 @@ export async function startToggleProxy(
     server.on(
       "connectionClosed",
       ({ connectionId, stats: cs }: { connectionId: number; stats: ConnectionStats }) => {
-        if (!proxiedConnectionIds.has(connectionId)) return
+        const host = proxiedConnectionIds.get(connectionId)
+        if (host === undefined) return
         proxiedConnectionIds.delete(connectionId)
+        const tx = cs.trgTxBytes ?? 0
+        const rx = cs.trgRxBytes ?? 0
         stats.connectionCount++
-        stats.trgTxBytes += cs.trgTxBytes ?? 0
-        stats.trgRxBytes += cs.trgRxBytes ?? 0
+        stats.trgTxBytes += tx
+        stats.trgRxBytes += rx
+        const h = perHost.get(host) ?? { tx: 0, rx: 0, conns: 0 }
+        h.tx += tx
+        h.rx += rx
+        h.conns++
+        perHost.set(host, h)
       }
     )
 
@@ -422,11 +526,26 @@ async function logExitIp(upstreamProxyUrl: string): Promise<boolean> {
 }
 
 export function setDirectMode(): void {
+  // Idempotent: a retry path and the in-call callback can both reach here,
+  // and the second call must not re-log or re-close.
+  if (!useUpstream) return
   useUpstream = false
-  // Log residential proxy usage at the moment we stop routing through the upstream.
-  // Connections that were still open at this point close shortly after, so the count
-  // here is a near-complete picture of residential bandwidth consumed during join.
+  // Log residential usage at the moment we stop routing through the upstream.
+  // NOTE this figure covers the JOIN ONLY. It is not the bot's bill — compare it
+  // against the shutdown line in stopToggleProxy() before drawing conclusions
+  // about cost per meeting.
   logStats("Residential upstream disabled (join complete)")
+  // Flipping the flag only governs connections opened from here on.
+  // prepareRequestFunction runs once per connection, so anything already
+  // tunnelled keeps its residential route until it closes on its own — and on
+  // Zoom web that includes the RWG socket carrying all in-call audio and video,
+  // which opens at the Join click and lives for the whole meeting. Closing
+  // forces a reconnect that is evaluated with useUpstream already false, i.e.
+  // direct. Zoom's client reconnects its own sockets as a matter of course (it
+  // is built for flaky home networks), so the cost of this is far below the
+  // bytes it saves. Meet is unaffected: its media is WebRTC over UDP and never
+  // enters a CONNECT proxy in the first place.
+  closeProxiedConnections("bot is in the meeting — forcing reconnect over the direct path")
   console.log("[ToggleProxy] Switched to direct mode (no upstream proxy)")
 }
 

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -8,6 +8,7 @@ import { HtmlCleaner } from "../../meeting/htmlCleaner"
 import { verifyMeetAudioCapture } from "../../meeting/meet/audio-capture"
 import type { NetworkPayload, NetworkUser } from "../../meeting/meet/network-interception/types"
 import { startUIBasedObserver } from "../../meeting/meet/ui-observer"
+import { setDirectMode } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { GLOBAL } from "../../singleton"
 import { SpeakerManager } from "../../speaker-manager"
@@ -168,6 +169,13 @@ export class InCallState extends BaseState {
 
     // Notify that recording has started
     Events.inCallRecording({ start_time: this.context.startTime })
+
+    // The bot is definitively INSIDE: admitted, recording, speaker observation
+    // live, entry message sent. Only now does the residential exit stop paying.
+    // Everything Zoom looked at while deciding whether to let us in went out
+    // through the residential IP exactly as it always has, so this cannot cost
+    // a join — it only stops us renting a home connection to carry meeting media.
+    setDirectMode()
   }
 
   /**

--- a/src/state-machine/states/initialization-state.ts
+++ b/src/state-machine/states/initialization-state.ts
@@ -28,10 +28,32 @@ export class InitializationState extends BaseState {
 
       // Setup branding if needed - non-bloquant
       if (GLOBAL.get().bot_image) {
+        // Warm the camera for EVERY bot_image, not just multi-image.
+        //
+        // brandingReady is only ever set true by warmUpCamera() or, much later,
+        // by startPlayback() at the end of the generate->play chain. setupBranding()
+        // below is deliberately not awaited, so on the single-image path nothing
+        // set brandingReady before the join flow reached
+        //
+        //   if (brandingReady) keep camera on   else   deactivateCamera(page)
+        //
+        // in meet.ts. Whenever image download + resize + MJPEG encode lost that
+        // race — a slow fetch, or pod contention under a burst of bots — the
+        // camera was switched OFF at the pre-join screen and nothing ever turned
+        // it back on, so the branding image never appeared even though the file
+        // generated fine seconds later. Measured on a healthy run the margin was
+        // only ~14s, so it is a coin flip under load, which is exactly how it
+        // presented: intermittent, and worse the more bots were launched at once.
+        //
+        // warmUpCamera() streams a baked placeholder to the v4l2 device and sets
+        // brandingReady synchronously; startPlayback() then switches the same
+        // VideoContext over to the real branding (it explicitly handles the
+        // already-exists case). Costs nothing when the file is missing — it warns
+        // and leaves brandingReady false, i.e. today's behaviour.
+        warmUpCamera()
         if (GLOBAL.get().bot_image.includes("|")) {
-          // Multi-image: warm up camera immediately, defer playback until
-          // the bot is in the waiting room (avoids switch gaps during join flow)
-          warmUpCamera()
+          // Multi-image only: defer playback until the bot is in the waiting room
+          // so the image switches don't land mid-join.
           deferBrandingPlayback()
         }
 

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -6,7 +6,6 @@ import {
 } from "../../browser/browser-session"
 import { IN_PROCESS_RETRY_MAX } from "../../config/retry-config"
 import { Events } from "../../events"
-import { setDirectMode } from "../../proxy/toggle-proxy"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { HtmlSnapshotService } from "../../services/html-snapshot-service"
 import { GLOBAL } from "../../singleton"
@@ -440,7 +439,6 @@ export class WaitingRoomState extends BaseState {
             if (this.context.playwrightPage) {
               dehumanize(this.context.playwrightPage)
             }
-            setDirectMode()
           },
           this.context.dialogObserver,
           onAdmissionDetected


### PR DESCRIPTION
## Summary
 
Twelve commits on top of the #315 merge. Four threads.
 
### The bot image stopped rendering
 
#315 shadowed device labels by cloning each `MediaDeviceInfo` through `Object.create(getPrototypeOf(d))`. The clone passes `instanceof`, keeps `deviceId`, and looks correct under every check we'd normally run — but the internal slots don't come along, so every native method throws `TypeError: Illegal invocation`. Video inputs are `InputDeviceInfo` and Meet calls `getCapabilities()` on the camera, so the camera died silently at enumeration.
 
Verified against the bot's own Chromium build:
 
```
real videoinput ctor:             InputDeviceInfo
real  getCapabilities():          OK
clone instanceof MediaDeviceInfo: true
clone deviceId preserved:         true
clone getCapabilities():          TypeError: Illegal invocation
clone toJSON():                   TypeError: Illegal invocation
```
 
`570550e` shadows the label in place with `defineProperty` instead:
 
```ts
for (const d of devices) {
  if (!d.label) continue
  Object.defineProperty(d, "label", {
    value: stableLabel(d.kind, d.deviceId),
    enumerable: true,
    configurable: true,
  })
}
return devices
```
 
After:
 
```
label now: HD Webcam
deviceId intact: true
getCapabilities(): OK
toJSON(): OK
gUM by deviceId: OK, tracks=1
```
 
Stealth intent is preserved — enumeration still reads `HD Webcam`, not `virtual_mic`.
 
`264e026` and the `initialization-state` change then key the camera on `bot_image` rather than on branding readiness, so `warmUpCamera()` runs for every image instead of only the multi-image path.
 
### Windows persona tells
 
The image claims Windows in its UA but shipped 5 of the 20 core font families. Any page can enumerate them from JS by measuring text width against a generic fallback, and CloakBrowser's own launch check greps `fc-list` for eight specific names — it warned "Incomplete Windows font set" on every launch.
 
Fontconfig aliases do not close this. `fc-match "Segoe UI"` reports a substitute while Chromium's canvas still measures the font as absent — tested both as `local.conf` and `conf.d`, one-way and bidirectional. Only a real file carrying the family name works.
 
`8e64090` / `c0d0d71` add `scripts/make-windows-metric-clones.py`, which re-emits open faces under the Windows names via fontTools name-table rewriting. 23 clones, 8/8 on CloakBrowser's own predicate. No Microsoft files enter the image.
 
`11c9999` separates the Xvfb display from the browser window. The display used to be sized to the window — 1280x860 at 720p — which is not a resolution any monitor has ever shipped at, and the page reads it directly as `screen.width`/`screen.height`. CloakBrowser does not spoof it; its own source says screen and window size come from the real display, not the flag.
 
### Launch flags
 
`d885345`: `--disable-features` was passed 7 times and `--disable-blink-features` twice. Chromium's `base::CommandLine` is last-wins, so `AutomationControlled` was never actually disabled and 12 other features were silently discarded. Now one flag each.
 
`bb56715`: Meet gets `--enable-unsafe-swiftshader` so WebGL contexts succeed instead of failing outright — required since M128 for WebGL on SwiftShader.
 
### Proxy cost
 
`8ac4596` narrows Zoom from a blanket `.zoom.us` suffix to the exact hosts the join decision reads. `3129ccb` holds the residential exit until the bot is confirmed in-call rather than merely admitted.
 
---
 
## Testing
 
- 254 unit tests pass; `tsc --noEmit` clean.
- Device fix proven empirically under Playwright against the bot's own Chromium — before/after transcripts above.
- Font coverage verified by running CloakBrowser's own `fc-list` predicate in node: 8/8.
- Capture region verified byte-identical across both display sizes. An earlier apparent difference isolated to ffmpeg's `draw_mouse` (X parks the pointer at screen centre), not geometry — production runs `-nocursor` plus `unclutter -root`.
- ~165 bots across preprod Meet meetings.
---
 
## Release notes
 
Fixes the bot image not appearing on Google Meet. Reduces residential-proxy egress on Zoom joins. No config or API changes.
 