### PR TITLE
feat(meet): shadow-log muted UI-bridge observations to speaker_separation.log

### DIFF
--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -250,6 +250,42 @@ describe("SpeakerManager network updates after fallback", () => {
     expect(registeredSpeakers).toEqual(["During Fallback"])
   })
 
+  it("shadow-logs a muted UI observation without committing attribution", async () => {
+    const fs = require("node:fs")
+    const appendSpy = jest.spyOn(fs.promises, "appendFile").mockResolvedValue(undefined)
+    const manager = SpeakerManager.getInstance()
+
+    // Network owns the floor → bridge is muted.
+    ;(manager as any).networkSpeakerActive = true
+    const before = [...registeredSpeakers]
+
+    await manager.handleUiBridgeUpdate([uiSpeaker("Shadow Only", true)])
+
+    // Attribution untouched…
+    expect(registeredSpeakers).toEqual(before)
+    // …but the observation was written to the speaker log as a ui-shadow line.
+    const shadowCalls = appendSpy.mock.calls.filter(([, line]) =>
+      String(line).includes('"src":"ui-shadow"')
+    )
+    expect(shadowCalls.length).toBe(1)
+    expect(String(shadowCalls[0]![1])).toContain("Shadow Only")
+
+    // Identical consecutive observation is deduped (no second line).
+    await manager.handleUiBridgeUpdate([uiSpeaker("Shadow Only", true)])
+    expect(
+      appendSpy.mock.calls.filter(([, line]) => String(line).includes('"src":"ui-shadow"')).length
+    ).toBe(1)
+
+    // A change in the speaking set writes again.
+    await manager.handleUiBridgeUpdate([uiSpeaker("Shadow Only", false)])
+    expect(
+      appendSpy.mock.calls.filter(([, line]) => String(line).includes('"src":"ui-shadow"')).length
+    ).toBe(2)
+
+    appendSpy.mockRestore()
+    ;(manager as any).networkSpeakerActive = false
+  })
+
   it("gives a UI speaker the id the network already assigned to that name", async () => {
     const manager = SpeakerManager.getInstance()
 

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -191,6 +191,17 @@ export class SpeakerManager {
         this.uiBridgeMuteLogged = true
         console.log("[SpeakerBridge] Network path owns attribution — UI bridge muted")
       }
+      // Shadow-log the muted observation instead of discarding it. The DOM
+      // observer keeps running for the whole call and Meet's own UI shows the
+      // true active speaker, so this stream is a per-call cross-check of the
+      // network path: a real two-sided call where network:audio pinned ~all
+      // speech on one participant was only diagnosable from video frames
+      // because the (correct) UI signal had been dropped here. Attribution is
+      // unchanged — these lines are written to speaker_separation.log (same
+      // PII redaction as the committed stream, uploaded to S3 with the other
+      // logs) as JSON objects, distinguishable from the committed stream's
+      // bare arrays.
+      await this.logShadowSpeakers(observed)
       return
     }
 
@@ -390,6 +401,44 @@ export class SpeakerManager {
       if (speaker.isSpeaking === true) {
         GLOBAL.addSpeakerIfNotExists(participant)
       }
+    }
+  }
+
+  // Speaking-set key of the last shadow line, so identical consecutive
+  // observations are written once (the observer can re-emit on unrelated DOM
+  // churn; only changes are informative).
+  private lastShadowKey = ""
+
+  /**
+   * Append a muted UI-bridge observation to speaker_separation.log as a JSON
+   * OBJECT line ({"src":"ui-shadow",...}), distinguishable from the committed
+   * stream's bare-array lines. Same PiiRedactor treatment as logSpeakers; never
+   * touches attribution. See handleUiBridgeUpdate for why this stream exists.
+   */
+  private async logShadowSpeakers(speakers: SpeakerData[]): Promise<void> {
+    try {
+      const key = speakers
+        .map((s) => `${s.name}:${s.isSpeaking ? 1 : 0}`)
+        .sort()
+        .join("|")
+      if (key === this.lastShadowKey) return
+      this.lastShadowKey = key
+
+      for (const speaker of speakers) {
+        if (speaker.name) {
+          PiiRedactor.registerSpeaker(speaker.name)
+        }
+      }
+      const line = PiiRedactor.redact(
+        JSON.stringify({ src: "ui-shadow", t: Date.now(), speakers })
+      )
+      await fs.promises.appendFile(
+        PathManager.getInstance().getSpeakerLogPath(),
+        `${line}\n`
+      )
+    } catch (e) {
+      // Shadow telemetry must never affect the meeting.
+      console.error("Cannot append ui-shadow speaker log:", e)
     }
   }
 


### PR DESCRIPTION
## Why

The Meet DOM speakers observer runs the **whole call**, but once the network path claims the floor, the bridge arbiter mutes it and every observation is **discarded unrecorded** (`speaker-manager.ts` muted branch: bare `return`).

On a real two-sided Meet call (bot `acf4eecf`), `network:audio` pinned ~all speech on one participant (**31 vs 5271** speaking samples) while both people demonstrably talked — Gladia's raw diarization had them balanced (432/537 utterances), and video frames show each person mid-speech in their own windows. The one in-process signal that had the right answer the entire time — Meet's own UI active-speaker indication — left **no trace**, and the collapse had to be diagnosed from video frames.

## What

- Keep the mute (attribution/UX **unchanged**), but append muted observations to `speaker_separation.log` as JSON **object** lines: `{"src":"ui-shadow","t":…,"speakers":[…]}` — distinguishable from the committed stream's bare-array lines.
- Same `PiiRedactor` treatment as the committed stream (names → `<SPEAKER_N>`), consistent with that file's existing policy.
- **S3 for free**: `speaker_separation.log` already uploads to the logs bucket at meeting end → per-call reconstruction + offline network-vs-UI divergence analysis with no new upload code.
- Consecutive identical speaking-sets deduped (only changes are recorded); errors swallowed — shadow telemetry can never affect the meeting.
- No page interaction, nothing new rendered — the People panel is already open and hidden by the HTML cleaner; recording is unaffected (verified on prod frames).

## Not in scope
Live divergence *detection* (auto-flagging when ui-shadow and network:audio disagree for a sustained window) — builds on this stream as a follow-up. Related: the reconciliation-side fix is meeting-baas-v2 #454.

Tests: 12/12 (new: shadow line written when muted, attribution untouched, dedupe, change re-logs). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)