### PR TITLE
feat(meet): always-log UI speakers + final speaker-timeline assembly (best source per stretch)

### DIFF
--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -276,3 +276,52 @@ describe("DiarizationTracker recording-clock clamp", () => {
     expect(segments.every((s) => s.end_time > s.start_time)).toBe(true)
   })
 })
+
+describe("DiarizationTracker final re-assembly", () => {
+  it("fills the leading hole from a UI fallback source and writes a chronological file", async () => {
+    const tracker = freshTracker()
+
+    // The committed timeline is contiguous from its FIRST event (every update
+    // closes the previous segment at the new event's time), so the only
+    // structural hole a live meeting produces is the leading one: network's
+    // first event here lands at 90s, leaving 0→90 uncovered. The muted UI
+    // observer saw Jonny speaking at 40→80 inside that window.
+    tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 90), MEETING_START)
+
+    await tracker.end(MEETING_START + 100_000, MEETING_START, undefined, undefined, [
+      {
+        kind: "ui",
+        segments: [{ speaker: "Jonny", user_id: 0, start_time: 40, end_time: 80 }]
+      }
+    ])
+
+    const segments = readSegments()
+    const jonny = segments.find((s) => s.speaker === "Jonny")
+    // Filled from UI, then the boot-gap retrofit stretched the earliest named
+    // segment (Jonny's) back to 0.
+    expect(jonny).toEqual({ speaker: "Jonny", user_id: 0, start_time: 0, end_time: 80 })
+    expect(segments.find((s) => s.speaker === "Amr El Shimy")).toEqual({
+      speaker: "Amr El Shimy",
+      user_id: 0,
+      start_time: 90,
+      end_time: 100
+    })
+    // Chronological artifact.
+    const starts = segments.map((s) => s.start_time)
+    expect(starts).toEqual([...starts].sort((a, b) => a - b))
+  })
+
+  it("keeps the whole meeting attributable when network never produced a segment", async () => {
+    const tracker = freshTracker()
+
+    await tracker.end(MEETING_START + 60_000, MEETING_START, undefined, undefined, [
+      {
+        kind: "ui",
+        segments: [{ speaker: "Jonny", user_id: 0, start_time: 5, end_time: 40 }]
+      }
+    ])
+
+    const segments = readSegments()
+    expect(segments).toEqual([{ speaker: "Jonny", user_id: 0, start_time: 0, end_time: 40 }])
+  })
+})

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -1,10 +1,11 @@
 import { createWriteStream, type WriteStream } from "node:fs"
 import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
+import { assembleSpeakerTimeline, type TimelineSource } from "./speaker-timeline-assembler"
 import { type SpeakerData, UNKNOWN_SPEAKER } from "./types"
 import { PathManager } from "./utils/PathManager"
 
-interface DiarizationSegment {
+export interface DiarizationSegment {
   speaker: string
   user_id: number // Sequential user ID (0 for UI-based detection, 1+ for network-based)
   start_time: number
@@ -216,7 +217,8 @@ export class DiarizationTracker {
     lastTimestamp: number,
     meetingStartTime: number,
     resolveSpeaker?: SpeakerResolver,
-    resolveUserId?: UserIdResolver
+    resolveUserId?: UserIdResolver,
+    fallbackSources?: TimelineSource[]
   ): Promise<void> {
     if (this.isEnded) {
       return
@@ -254,24 +256,43 @@ export class DiarizationTracker {
       )
     }
 
+    // Final pass: re-assemble the artifact from every source, best source per
+    // stretch. The repaired network timeline stays authoritative wherever it
+    // produced data; the fallback sources (UI observer, transcription-system
+    // turns when one ran) only contribute inside sufficiently large holes, and
+    // the boot gap (recording start → first diarization signal) is retrofitted
+    // onto the first identified speaker. See speaker-timeline-assembler.ts.
+    const meetingEndRel = Math.max(0, (lastTimestamp - meetingStartTime) / 1000)
+    const { segments: assembled, filledBySource } = assembleSpeakerTimeline(
+      [
+        { kind: "network" as const, segments: this.allSegments.map((e) => e.segment) },
+        ...(fallbackSources ?? [])
+      ],
+      meetingEndRel
+    )
+    for (const [kind, count] of Object.entries(filledBySource)) {
+      console.log(
+        `[DiarizationTracker] Filled ${count} timeline gap segment(s) from the ${kind} fallback`
+      )
+    }
+
     await this.closeStream()
 
-    // Rewrite from the in-memory buffer, which is authoritative. Appending as we
-    // go keeps a usable file if the pod dies mid-meeting, but the append log can
-    // contain names that were still unresolved at the time they were flushed.
+    // Rewrite from the assembled timeline, which is authoritative. Appending as
+    // we go keeps a usable file if the pod dies mid-meeting, but the append log
+    // can contain names that were still unresolved at the time they were
+    // flushed, and none of the fallback contributions.
     try {
-      const body = this.allSegments.map((e) => `${JSON.stringify(e.segment)}\n`).join("")
+      const body = assembled.map((segment) => `${JSON.stringify(segment)}\n`).join("")
       await writeFile(this.filePath, body)
     } catch (error) {
       console.error(`DiarizationTracker: Failed to rewrite ${this.filePath}: ${error}`)
     }
 
-    const stillUnknown = this.allSegments.filter(
-      (e) => e.segment.speaker === UNKNOWN_SPEAKER
-    ).length
+    const stillUnknown = assembled.filter((s) => s.speaker === UNKNOWN_SPEAKER).length
     if (stillUnknown > 0) {
       console.warn(
-        `[DiarizationTracker] ${stillUnknown}/${this.allSegments.length} segment(s) remain "${UNKNOWN_SPEAKER}" — the roster never resolved those devices`
+        `[DiarizationTracker] ${stillUnknown}/${assembled.length} segment(s) remain "${UNKNOWN_SPEAKER}" — no source ever resolved those stretches`
       )
     }
     console.log(`Diarization tracking completed: ${this.filePath}`)

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -256,12 +256,9 @@ export class DiarizationTracker {
       )
     }
 
-    // Final pass: re-assemble the artifact from every source, best source per
-    // stretch. The repaired network timeline stays authoritative wherever it
-    // produced data; the fallback sources (UI observer, transcription-system
-    // turns when one ran) only contribute inside sufficiently large holes, and
-    // the boot gap (recording start → first diarization signal) is retrofitted
-    // onto the first identified speaker. See speaker-timeline-assembler.ts.
+    // Final pass: re-assemble the artifact best-source-per-stretch (repaired
+    // network authoritative; fallbacks fill large holes; boot gap retrofitted
+    // onto the first identified speaker). See speaker-timeline-assembler.ts.
     const meetingEndRel = Math.max(0, (lastTimestamp - meetingStartTime) / 1000)
     const { segments: assembled, filledBySource } = assembleSpeakerTimeline(
       [
@@ -278,10 +275,8 @@ export class DiarizationTracker {
 
     await this.closeStream()
 
-    // Rewrite from the assembled timeline, which is authoritative. Appending as
-    // we go keeps a usable file if the pod dies mid-meeting, but the append log
-    // can contain names that were still unresolved at the time they were
-    // flushed, and none of the fallback contributions.
+    // Rewrite from the assembled timeline — the append log can hold unresolved
+    // names and none of the fallback contributions.
     try {
       const body = assembled.map((segment) => `${JSON.stringify(segment)}\n`).join("")
       await writeFile(this.filePath, body)

--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -311,6 +311,46 @@ describe("SpeakerManager network updates after fallback", () => {
     ])
   })
 
+  it("silences the recording bot in the shadow buffer like the committed path", async () => {
+    const manager = SpeakerManager.getInstance()
+    ;(manager as any).networkSpeakerActive = true
+    const T0 = 1785941000000
+
+    // Meet falsely lights the bot as the sole speaker for 30s.
+    await manager.handleUiBridgeUpdate([
+      { name: "SPEAKER SEP Test", id: 0, timestamp: T0 + 5_000, isSpeaking: true }
+    ])
+    await manager.handleUiBridgeUpdate([
+      { name: "SPEAKER SEP Test", id: 0, timestamp: T0 + 35_000, isSpeaking: false }
+    ])
+
+    // No customer speech may be attributed to the bot by the fallback.
+    expect(manager.buildUiFallbackSegments(T0, T0 + 60_000)).toEqual([])
+  })
+
+  it("ends the fallback timeline at the last retained observation once the buffer truncates", async () => {
+    const manager = SpeakerManager.getInstance()
+    ;(manager as any).networkSpeakerActive = true
+    const T0 = 1785941000000
+
+    await manager.handleUiBridgeUpdate([
+      { name: "X", id: 0, timestamp: T0 + 10_000, isSpeaking: true }
+    ])
+    // Simulate a full buffer: the next (different) observation is refused.
+    const buffer = (manager as any).shadowObservations as unknown[]
+    const retained = buffer[buffer.length - 1]
+    while (buffer.length < 20000) buffer.push(retained)
+    await manager.handleUiBridgeUpdate([
+      { name: "Y", id: 0, timestamp: T0 + 20_000, isSpeaking: true }
+    ])
+    expect((manager as any).shadowBufferTruncated).toBe(true)
+
+    // X's open interval must close at the last retained observation (10s),
+    // not at meeting end (60s) — the unobserved tail belongs to nobody.
+    const segments = manager.buildUiFallbackSegments(T0, T0 + 60_000)
+    expect(segments).toEqual([])
+  })
+
   it("gives a UI speaker the id the network already assigned to that name", async () => {
     const manager = SpeakerManager.getInstance()
 

--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -351,6 +351,21 @@ describe("SpeakerManager network updates after fallback", () => {
     expect(segments).toEqual([])
   })
 
+  it("caps the trailing extension of an interval the observer never closed", async () => {
+    const manager = SpeakerManager.getInstance()
+    ;(manager as any).networkSpeakerActive = true
+    const T0 = 1785941000000
+
+    // One observation, then the observer stalls: change-dedupe means no close
+    // ever arrives. The interval must not stretch to meeting end (10min).
+    await manager.handleUiBridgeUpdate([
+      { name: "X", id: 0, timestamp: T0 + 10_000, isSpeaking: true }
+    ])
+
+    const segments = manager.buildUiFallbackSegments(T0, T0 + 600_000)
+    expect(segments).toEqual([{ speaker: "X", user_id: 0, start_time: 10, end_time: 130 }])
+  })
+
   it("gives a UI speaker the id the network already assigned to that name", async () => {
     const manager = SpeakerManager.getInstance()
 

--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -286,6 +286,31 @@ describe("SpeakerManager network updates after fallback", () => {
     ;(manager as any).networkSpeakerActive = false
   })
 
+  it("rebuilds single-speaker intervals from the muted observations for the finalize fallback", async () => {
+    const manager = SpeakerManager.getInstance()
+    ;(manager as any).networkSpeakerActive = true
+    const T0 = 1785941000000
+
+    const at = (name: string, isSpeaking: boolean, sec: number): SpeakerData => ({
+      name,
+      id: 0,
+      timestamp: T0 + sec * 1000,
+      isSpeaking
+    })
+
+    // X speaks 10→30, then two speaking at once (ambiguous — dropped), then Y
+    // speaks 40→(meeting end at 60).
+    await manager.handleUiBridgeUpdate([at("X", true, 10)])
+    await manager.handleUiBridgeUpdate([at("X", true, 30), at("Y", true, 30)])
+    await manager.handleUiBridgeUpdate([at("Y", true, 40)])
+
+    const segments = manager.buildUiFallbackSegments(T0, T0 + 60_000)
+    expect(segments).toEqual([
+      { speaker: "X", user_id: 0, start_time: 10, end_time: 30 },
+      { speaker: "Y", user_id: 0, start_time: 40, end_time: 60 }
+    ])
+  })
+
   it("gives a UI speaker the id the network already assigned to that name", async () => {
     const manager = SpeakerManager.getInstance()
 

--- a/src/speaker-manager.test.ts
+++ b/src/speaker-manager.test.ts
@@ -250,6 +250,42 @@ describe("SpeakerManager network updates after fallback", () => {
     expect(registeredSpeakers).toEqual(["During Fallback"])
   })
 
+  it("shadow-logs a muted UI observation without committing attribution", async () => {
+    const fs = require("node:fs")
+    const appendSpy = jest.spyOn(fs.promises, "appendFile").mockResolvedValue(undefined)
+    const manager = SpeakerManager.getInstance()
+
+    // Network owns the floor → bridge is muted.
+    ;(manager as any).networkSpeakerActive = true
+    const before = [...registeredSpeakers]
+
+    await manager.handleUiBridgeUpdate([uiSpeaker("Shadow Only", true)])
+
+    // Attribution untouched…
+    expect(registeredSpeakers).toEqual(before)
+    // …but the observation was written to the speaker log as a ui-shadow line.
+    const shadowCalls = appendSpy.mock.calls.filter(([, line]) =>
+      String(line).includes('"src":"ui-shadow"')
+    )
+    expect(shadowCalls.length).toBe(1)
+    expect(String(shadowCalls[0]![1])).toContain("Shadow Only")
+
+    // Identical consecutive observation is deduped (no second line).
+    await manager.handleUiBridgeUpdate([uiSpeaker("Shadow Only", true)])
+    expect(
+      appendSpy.mock.calls.filter(([, line]) => String(line).includes('"src":"ui-shadow"')).length
+    ).toBe(1)
+
+    // A change in the speaking set writes again.
+    await manager.handleUiBridgeUpdate([uiSpeaker("Shadow Only", false)])
+    expect(
+      appendSpy.mock.calls.filter(([, line]) => String(line).includes('"src":"ui-shadow"')).length
+    ).toBe(2)
+
+    appendSpy.mockRestore()
+    ;(manager as any).networkSpeakerActive = false
+  })
+
   it("gives a UI speaker the id the network already assigned to that name", async () => {
     const manager = SpeakerManager.getInstance()
 

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -191,6 +191,17 @@ export class SpeakerManager {
         this.uiBridgeMuteLogged = true
         console.log("[SpeakerBridge] Network path owns attribution — UI bridge muted")
       }
+      // Shadow-log the muted observation instead of discarding it. The DOM
+      // observer keeps running for the whole call and Meet's own UI shows the
+      // true active speaker, so this stream is a per-call cross-check of the
+      // network path: a real two-sided call where network:audio pinned ~all
+      // speech on one participant was only diagnosable from video frames
+      // because the (correct) UI signal had been dropped here. Attribution is
+      // unchanged — these lines are written to speaker_separation.log (same
+      // PII redaction as the committed stream, uploaded to S3 with the other
+      // logs) as JSON objects, distinguishable from the committed stream's
+      // bare arrays.
+      await this.logShadowSpeakers(observed)
       return
     }
 
@@ -390,6 +401,44 @@ export class SpeakerManager {
       if (speaker.isSpeaking === true) {
         GLOBAL.addSpeakerIfNotExists(participant)
       }
+    }
+  }
+
+  // Speaking-set key of the last shadow line, so identical consecutive
+  // observations are written once (the observer can re-emit on unrelated DOM
+  // churn; only changes are informative).
+  private lastShadowKey = ""
+
+  /**
+   * Append a muted UI-bridge observation to speaker_separation.log as a JSON
+   * OBJECT line ({"src":"ui-shadow",...}), distinguishable from the committed
+   * stream's bare-array lines. Same PiiRedactor treatment as logSpeakers; never
+   * touches attribution. See handleUiBridgeUpdate for why this stream exists.
+   */
+  private async logShadowSpeakers(speakers: SpeakerData[]): Promise<void> {
+    try {
+      const key = speakers
+        .map((s) => `${s.name}:${s.isSpeaking ? 1 : 0}`)
+        .sort()
+        .join("|")
+      if (key === this.lastShadowKey) return
+      this.lastShadowKey = key
+
+      for (const speaker of speakers) {
+        if (speaker.name) {
+          PiiRedactor.registerSpeaker(speaker.name)
+        }
+      }
+      const line = PiiRedactor.redact(
+        JSON.stringify({ src: "ui-shadow", t: Date.now(), speakers })
+      )
+      await fs.promises.appendFile(
+        PathManager.getInstance().getSpeakerLogPath(),
+        `${line}\n`
+      )
+    } catch (e) {
+      // Shadow telemetry must never affect the meeting.
+      console.error("Cannot append ui-shadow speaker log:", e)
     }
   }
 

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -420,6 +420,9 @@ export class SpeakerManager {
   // True once the buffer refused an observation; the fallback timeline must
   // then end at the last retained one, not attribute the unobserved tail.
   private shadowBufferTruncated = false
+  // A single observation cannot vouch for an unbounded stretch: the observer
+  // can stall, and change-dedupe means no further observation ever arrives.
+  private static readonly SHADOW_OPEN_MAX_MS = 120_000
 
   /**
    * Conservative timeline from the muted UI observations: only stretches with
@@ -458,10 +461,15 @@ export class SpeakerManager {
       }
     }
     // A truncated buffer stops reflecting the meeting — close there, not at
-    // meeting end.
-    const lastObserved =
-      this.shadowObservations[this.shadowObservations.length - 1]?.t ?? lastTimestamp
-    close(this.shadowBufferTruncated ? lastObserved : lastTimestamp)
+    // meeting end — and never extend an open interval more than
+    // SHADOW_OPEN_MAX_MS past the observation that opened it.
+    const lastObserved = this.shadowObservations[this.shadowObservations.length - 1]?.t
+    const boundary = this.shadowBufferTruncated && lastObserved ? lastObserved : lastTimestamp
+    close(
+      lastObserved === undefined
+        ? boundary
+        : Math.min(boundary, lastObserved + SpeakerManager.SHADOW_OPEN_MAX_MS)
+    )
     return segments
   }
 

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import { enablePrintPageLogs } from "./browser/page-logger"
-import { DiarizationTracker } from "./diarization-tracker"
+import { type DiarizationSegment, DiarizationTracker } from "./diarization-tracker"
 import type { NetworkUser } from "./meeting/meet/network-interception/types"
 import { GLOBAL } from "./singleton"
 import { MeetingStateMachine } from "./state-machine/machine"
@@ -111,7 +111,17 @@ export class SpeakerManager {
             lastTimestamp,
             meetingStartTime,
             (deviceId) => instance.resolveDeviceForBackfill(deviceId),
-            (userId) => instance.userIdNames.get(userId)
+            (userId) => instance.userIdNames.get(userId),
+            // Fallback sources for the final re-assembly, highest trust first:
+            // UI observations shadow-buffered while the bridge was muted fill
+            // long holes the network path left. A "transcription" source (live
+            // transcription-system speaker turns) plugs in here when present.
+            [
+              {
+                kind: "ui",
+                segments: instance.buildUiFallbackSegments(meetingStartTime, lastTimestamp)
+              }
+            ]
           )
         }
       }
@@ -408,6 +418,57 @@ export class SpeakerManager {
   // observations are written once (the observer can re-emit on unrelated DOM
   // churn; only changes are informative).
   private lastShadowKey = ""
+  // In-memory copy of the muted UI-bridge observations (change-deduped, same
+  // stream as the ui-shadow log lines). Consumed at finalize to fill holes the
+  // network path left in the committed timeline. Bounded so a pathological
+  // DOM-churn meeting cannot grow it without limit.
+  private static readonly SHADOW_BUFFER_MAX = 20000
+  private shadowObservations: Array<{
+    t: number
+    speakers: Array<{ name: string; isSpeaking: boolean }>
+  }> = []
+
+  /**
+   * Rebuild a conservative speaker timeline from the muted UI observations:
+   * only stretches where the UI showed EXACTLY ONE participant speaking are
+   * emitted — ambiguity is left for the committed timeline (or nobody) to own.
+   * Times are clamped to the recording clock like every committed segment.
+   */
+  public buildUiFallbackSegments(
+    meetingStartTime: number,
+    lastTimestamp: number
+  ): DiarizationSegment[] {
+    const segments: DiarizationSegment[] = []
+    let open: { name: string; start: number } | null = null
+    const close = (at: number) => {
+      if (!open) return
+      const start = Math.max(0, (open.start - meetingStartTime) / 1000)
+      const end = Math.max(0, (at - meetingStartTime) / 1000)
+      if (end > start) {
+        segments.push({
+          speaker: open.name,
+          user_id: this.resolveUiUserId(open.name),
+          start_time: start,
+          end_time: end
+        })
+      }
+      open = null
+    }
+    for (const observation of this.shadowObservations) {
+      const speaking = observation.speakers.filter(
+        (s) => s.isSpeaking && s.name && s.name !== UNKNOWN_SPEAKER
+      )
+      if (speaking.length === 1) {
+        const name = speaking[0].name
+        if (open && open.name !== name) close(observation.t)
+        if (!open) open = { name, start: observation.t }
+      } else {
+        close(observation.t)
+      }
+    }
+    close(lastTimestamp)
+    return segments
+  }
 
   /**
    * Append a muted UI-bridge observation to speaker_separation.log as a JSON
@@ -423,6 +484,21 @@ export class SpeakerManager {
         .join("|")
       if (key === this.lastShadowKey) return
       this.lastShadowKey = key
+
+      // Buffer for the finalize-time gap fill. Timestamped with the
+      // observation's own clock when it carries one, like the committed path.
+      if (this.shadowObservations.length < SpeakerManager.SHADOW_BUFFER_MAX) {
+        const timestamps = speakers
+          .map((s) => s.timestamp)
+          .filter((t) => Number.isFinite(t) && t > 0)
+        this.shadowObservations.push({
+          t: timestamps.length > 0 ? Math.max(...timestamps) : Date.now(),
+          speakers: speakers.map((s) => ({
+            name: s.name,
+            isSpeaking: s.isSpeaking === true
+          }))
+        })
+      }
 
       for (const speaker of speakers) {
         if (speaker.name) {

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -112,10 +112,8 @@ export class SpeakerManager {
             meetingStartTime,
             (deviceId) => instance.resolveDeviceForBackfill(deviceId),
             (userId) => instance.userIdNames.get(userId),
-            // Fallback sources for the final re-assembly, highest trust first:
-            // UI observations shadow-buffered while the bridge was muted fill
-            // long holes the network path left. A "transcription" source (live
-            // transcription-system speaker turns) plugs in here when present.
+            // Fallback sources for the final re-assembly, highest trust
+            // first; a "transcription" source plugs in here when present.
             [
               {
                 kind: "ui",
@@ -201,16 +199,10 @@ export class SpeakerManager {
         this.uiBridgeMuteLogged = true
         console.log("[SpeakerBridge] Network path owns attribution — UI bridge muted")
       }
-      // Shadow-log the muted observation instead of discarding it. The DOM
-      // observer keeps running for the whole call and Meet's own UI shows the
-      // true active speaker, so this stream is a per-call cross-check of the
-      // network path: a real two-sided call where network:audio pinned ~all
-      // speech on one participant was only diagnosable from video frames
-      // because the (correct) UI signal had been dropped here. Attribution is
-      // unchanged — these lines are written to speaker_separation.log (same
-      // PII redaction as the committed stream, uploaded to S3 with the other
-      // logs) as JSON objects, distinguishable from the committed stream's
-      // bare arrays.
+      // Shadow-log instead of discarding: the DOM observer runs all call and
+      // is a per-call cross-check of the network path (a prod collapse where
+      // the UI had the right answer was only diagnosable from video frames).
+      // Attribution unchanged; lines go to speaker_separation.log redacted.
       await this.logShadowSpeakers(observed)
       return
     }
@@ -418,26 +410,20 @@ export class SpeakerManager {
   // observations are written once (the observer can re-emit on unrelated DOM
   // churn; only changes are informative).
   private lastShadowKey = ""
-  // In-memory copy of the muted UI-bridge observations (change-deduped, same
-  // stream as the ui-shadow log lines). Consumed at finalize to fill holes the
-  // network path left in the committed timeline. Bounded so a pathological
-  // DOM-churn meeting cannot grow it without limit.
+  // In-memory copy of the muted UI observations (change-deduped, same stream
+  // as the ui-shadow log lines), consumed at finalize to fill timeline holes.
   private static readonly SHADOW_BUFFER_MAX = 20000
   private shadowObservations: Array<{
     t: number
     speakers: Array<{ name: string; isSpeaking: boolean }>
   }> = []
-  // True once the buffer refused an observation. From that point the buffered
-  // stream no longer reflects the meeting, so the fallback timeline must end
-  // at the last retained observation — closing an open interval at meeting end
-  // would attribute the whole unobserved tail to a stale participant.
+  // True once the buffer refused an observation; the fallback timeline must
+  // then end at the last retained one, not attribute the unobserved tail.
   private shadowBufferTruncated = false
 
   /**
-   * Rebuild a conservative speaker timeline from the muted UI observations:
-   * only stretches where the UI showed EXACTLY ONE participant speaking are
-   * emitted — ambiguity is left for the committed timeline (or nobody) to own.
-   * Times are clamped to the recording clock like every committed segment.
+   * Conservative timeline from the muted UI observations: only stretches with
+   * EXACTLY ONE participant speaking are emitted — ambiguity is dropped.
    */
   public buildUiFallbackSegments(
     meetingStartTime: number,
@@ -471,9 +457,8 @@ export class SpeakerManager {
         close(observation.t)
       }
     }
-    // A truncated buffer stopped reflecting the meeting at its last retained
-    // observation — close there, never at meeting end, or the whole unobserved
-    // tail would be attributed to whoever happened to be speaking last.
+    // A truncated buffer stops reflecting the meeting — close there, not at
+    // meeting end.
     const lastObserved =
       this.shadowObservations[this.shadowObservations.length - 1]?.t ?? lastTimestamp
     close(this.shadowBufferTruncated ? lastObserved : lastTimestamp)
@@ -481,10 +466,9 @@ export class SpeakerManager {
   }
 
   /**
-   * Append a muted UI-bridge observation to speaker_separation.log as a JSON
-   * OBJECT line ({"src":"ui-shadow",...}), distinguishable from the committed
-   * stream's bare-array lines. Same PiiRedactor treatment as logSpeakers; never
-   * touches attribution. See handleUiBridgeUpdate for why this stream exists.
+   * Append a muted UI observation to speaker_separation.log as a JSON OBJECT
+   * line ({"src":"ui-shadow",...}) — the committed stream uses bare arrays.
+   * Same PiiRedactor treatment; never touches attribution.
    */
   private async logShadowSpeakers(speakers: SpeakerData[]): Promise<void> {
     try {
@@ -495,11 +479,8 @@ export class SpeakerManager {
       if (key === this.lastShadowKey) return
       this.lastShadowKey = key
 
-      // Buffer for the finalize-time gap fill. Timestamped with the
-      // observation's own clock when it carries one, like the committed path.
-      // The bot is silenced exactly as on the committed path — Meet can falsely
-      // light the recording bot as the sole speaker, and a fallback built from
-      // the raw state would hand customer speech to the bot.
+      // Buffer for the finalize-time gap fill, bot silenced like the committed
+      // path (Meet can falsely light the bot as sole speaker).
       if (this.shadowObservations.length < SpeakerManager.SHADOW_BUFFER_MAX) {
         const params = GLOBAL.get()
         const silenced = silenceBotSpeaker(

--- a/src/speaker-manager.ts
+++ b/src/speaker-manager.ts
@@ -427,6 +427,11 @@ export class SpeakerManager {
     t: number
     speakers: Array<{ name: string; isSpeaking: boolean }>
   }> = []
+  // True once the buffer refused an observation. From that point the buffered
+  // stream no longer reflects the meeting, so the fallback timeline must end
+  // at the last retained observation — closing an open interval at meeting end
+  // would attribute the whole unobserved tail to a stale participant.
+  private shadowBufferTruncated = false
 
   /**
    * Rebuild a conservative speaker timeline from the muted UI observations:
@@ -466,7 +471,12 @@ export class SpeakerManager {
         close(observation.t)
       }
     }
-    close(lastTimestamp)
+    // A truncated buffer stopped reflecting the meeting at its last retained
+    // observation — close there, never at meeting end, or the whole unobserved
+    // tail would be attributed to whoever happened to be speaking last.
+    const lastObserved =
+      this.shadowObservations[this.shadowObservations.length - 1]?.t ?? lastTimestamp
+    close(this.shadowBufferTruncated ? lastObserved : lastTimestamp)
     return segments
   }
 
@@ -487,17 +497,31 @@ export class SpeakerManager {
 
       // Buffer for the finalize-time gap fill. Timestamped with the
       // observation's own clock when it carries one, like the committed path.
+      // The bot is silenced exactly as on the committed path — Meet can falsely
+      // light the recording bot as the sole speaker, and a fallback built from
+      // the raw state would hand customer speech to the bot.
       if (this.shadowObservations.length < SpeakerManager.SHADOW_BUFFER_MAX) {
+        const params = GLOBAL.get()
+        const silenced = silenceBotSpeaker(
+          speakers,
+          params.bot_name,
+          Boolean(params.streaming_input)
+        )
         const timestamps = speakers
           .map((s) => s.timestamp)
           .filter((t) => Number.isFinite(t) && t > 0)
         this.shadowObservations.push({
           t: timestamps.length > 0 ? Math.max(...timestamps) : Date.now(),
-          speakers: speakers.map((s) => ({
+          speakers: silenced.map((s) => ({
             name: s.name,
             isSpeaking: s.isSpeaking === true
           }))
         })
+      } else if (!this.shadowBufferTruncated) {
+        this.shadowBufferTruncated = true
+        console.warn(
+          "[SpeakerBridge] ui-shadow buffer full — later observations are not buffered; the fallback timeline stops at the last retained one"
+        )
       }
 
       for (const speaker of speakers) {

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -1,0 +1,135 @@
+import type { DiarizationSegment } from "./diarization-tracker"
+import {
+  assembleSpeakerTimeline,
+  GAP_FILL_MIN_SECONDS,
+  LEADING_RETROFIT_MAX_SECONDS
+} from "./speaker-timeline-assembler"
+
+function seg(
+  speaker: string,
+  start: number,
+  end: number,
+  userId = 2
+): DiarizationSegment {
+  return { speaker, user_id: userId, start_time: start, end_time: end }
+}
+
+describe("assembleSpeakerTimeline", () => {
+  it("keeps the primary (network) timeline untouched when it has no holes", () => {
+    const network = [seg("Amr", 0, 50), seg("Jonny", 50, 100)]
+    const { segments, filledBySource } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        { kind: "ui", segments: [seg("Impostor", 10, 90, 0)] }
+      ],
+      100
+    )
+    expect(segments).toEqual(network)
+    expect(filledBySource.ui).toBeUndefined()
+  })
+
+  it("fills a mid-call hole from the UI source, clipped to the hole", () => {
+    // Network went quiet 100→160; UI saw Jonny speaking 90→150.
+    const { segments, filledBySource } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Amr", 20, 100), seg("Amr", 160, 200)] },
+        { kind: "ui", segments: [seg("Jonny", 90, 150, 0)] }
+      ],
+      200
+    )
+    expect(filledBySource.ui).toBe(1)
+    const filled = segments.find((s) => s.speaker === "Jonny")
+    expect(filled).toEqual(seg("Jonny", 100, 150, 0))
+  })
+
+  it("ignores holes shorter than the gap threshold (ordinary turn-taking silence)", () => {
+    const shortGapEnd = 100 + GAP_FILL_MIN_SECONDS - 1
+    const { segments } = assembleSpeakerTimeline(
+      [
+        {
+          kind: "network",
+          segments: [seg("Amr", 0, 100), seg("Amr", shortGapEnd, 200)]
+        },
+        { kind: "ui", segments: [seg("Jonny", 100, shortGapEnd, 0)] }
+      ],
+      200
+    )
+    expect(segments.some((s) => s.speaker === "Jonny")).toBe(false)
+  })
+
+  it("consults sources in trust order: transcription only fills what UI left", () => {
+    const { segments, filledBySource } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Amr", 0, 100)] },
+        { kind: "ui", segments: [seg("Jonny", 100, 150, 0)] },
+        // Overlaps UI's contribution AND the still-open 150→200 hole: only the
+        // uncovered part survives.
+        { kind: "transcription", segments: [seg("Speaker 1", 120, 200, 0)] }
+      ],
+      200
+    )
+    expect(filledBySource.ui).toBe(1)
+    expect(filledBySource.transcription).toBe(1)
+    const fromTranscription = segments.find((s) => s.speaker === "Speaker 1")
+    expect(fromTranscription).toEqual(seg("Speaker 1", 150, 200, 0))
+  })
+
+  it("never lets a fallback contribute an Unknown segment", () => {
+    const { segments } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Amr", 100, 200)] },
+        { kind: "ui", segments: [seg("Unknown", 0, 90, 0)] }
+      ],
+      200
+    )
+    // Unknown was rejected, so only the retrofit covers the leading window.
+    expect(segments.every((s) => s.speaker === "Amr")).toBe(true)
+  })
+
+  it("retrofits the boot gap onto the first identified speaker", () => {
+    // Prod case 8db02fee: first utterance ("Grazie.") at 6.1s, first
+    // diarization segment much later — the greeting surfaced as Unknown.
+    const { segments } = assembleSpeakerTimeline(
+      [{ kind: "network", segments: [seg("Stefano", 144, 300), seg("Elisa", 300, 400)] }],
+      400
+    )
+    expect(segments[0]).toEqual(seg("Stefano", 0, 300))
+  })
+
+  it("does not retrofit past the cap — a first segment that late means something broke", () => {
+    const lateStart = LEADING_RETROFIT_MAX_SECONDS + 1
+    const { segments } = assembleSpeakerTimeline(
+      [{ kind: "network", segments: [seg("Amr", lateStart, lateStart + 60)] }],
+      lateStart + 60
+    )
+    expect(segments[0].start_time).toBe(lateStart)
+  })
+
+  it("retrofits onto the first NAMED segment, skipping a leading Unknown", () => {
+    const { segments } = assembleSpeakerTimeline(
+      [
+        {
+          kind: "network",
+          segments: [seg("Unknown", 5, 20, 0), seg("Amr", 30, 100)]
+        }
+      ],
+      100
+    )
+    const amr = segments.find((s) => s.speaker === "Amr")
+    expect(amr?.start_time).toBe(0)
+    const unknown = segments.find((s) => s.speaker === "Unknown")
+    expect(unknown).toEqual(seg("Unknown", 5, 20, 0))
+  })
+
+  it("handles an empty network timeline: the UI source fills the whole meeting", () => {
+    const { segments, filledBySource } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [] },
+        { kind: "ui", segments: [seg("Jonny", 5, 60, 0)] }
+      ],
+      120
+    )
+    expect(filledBySource.ui).toBe(1)
+    expect(segments).toEqual([seg("Jonny", 0, 60, 0)])
+  })
+})

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -105,7 +105,7 @@ describe("assembleSpeakerTimeline", () => {
     expect(segments[0].start_time).toBe(lateStart)
   })
 
-  it("retrofits onto the first NAMED segment, skipping a leading Unknown", () => {
+  it("retrofits onto the first NAMED segment and clips the Unknown it now covers", () => {
     const { segments } = assembleSpeakerTimeline(
       [
         {
@@ -115,10 +115,45 @@ describe("assembleSpeakerTimeline", () => {
       ],
       100
     )
-    const amr = segments.find((s) => s.speaker === "Amr")
-    expect(amr?.start_time).toBe(0)
-    const unknown = segments.find((s) => s.speaker === "Unknown")
-    expect(unknown).toEqual(seg("Unknown", 5, 20, 0))
+    // The retrofit stretches Amr over the Unknown; leaving the Unknown in
+    // place would still win the opening words downstream (overlap pick).
+    expect(segments).toEqual([seg("Amr", 0, 100)])
+  })
+
+  it("lets a named fallback win a stretch the network only knew as Unknown", () => {
+    const { segments, filledBySource } = assembleSpeakerTimeline(
+      [
+        {
+          kind: "network",
+          segments: [seg("Amr", 0, 100), seg("Unknown", 100, 160, 0), seg("Amr", 160, 200)]
+        },
+        { kind: "ui", segments: [seg("Jonny", 110, 150, 0)] }
+      ],
+      200
+    )
+    expect(filledBySource.ui).toBe(1)
+    expect(segments.find((s) => s.speaker === "Jonny")).toEqual(seg("Jonny", 110, 150, 0))
+    // The Unknown keeps only its uncovered remainders — Jonny's span is
+    // Unknown-free.
+    for (const s of segments.filter((x) => x.speaker === "Unknown")) {
+      expect(s.end_time <= 110 || s.start_time >= 150).toBe(true)
+    }
+  })
+
+  it("keeps the uncovered remainder of a partially covered Unknown", () => {
+    const { segments } = assembleSpeakerTimeline(
+      [
+        {
+          kind: "network",
+          // Named coverage [0..50] overlaps the Unknown's head only.
+          segments: [seg("Amr", 0, 50), seg("Unknown", 40, 90, 0), seg("Amr", 320, 400)]
+        }
+      ],
+      400
+    )
+    // First named segment starts at 0 → no retrofit. Unknown survives as its
+    // uncovered tail.
+    expect(segments.find((s) => s.speaker === "Unknown")).toEqual(seg("Unknown", 50, 90, 0))
   })
 
   it("handles an empty network timeline: the UI source fills the whole meeting", () => {

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -2,24 +2,12 @@ import type { DiarizationSegment } from "./diarization-tracker"
 import { UNKNOWN_SPEAKER } from "./types"
 
 /**
- * Final speaker-timeline assembly: one pure function that re-assembles the
- * diarization artifact from every source we have, taking the best source for
- * each stretch of the meeting.
- *
- * Sources, in trust order:
- *  - "network"       — WebRTC interception (CSRC/dcrpc/roster). Carries device
- *                      ids, survives DOM changes: authoritative wherever it
- *                      produced data.
- *  - "ui"            — the platform's own UI active-speaker indicator,
- *                      shadow-buffered for the whole call. Fills holes the
- *                      network path left.
- *  - "transcription" — speaker turns from the live transcription system, when
- *                      one ran. Last resort for stretches neither of the
- *                      above covered.
- *
- * A lower-trust source NEVER overwrites a higher-trust one: it only
- * contributes the parts of its segments that fall inside a sufficiently large
- * hole of everything assembled before it.
+ * Final speaker-timeline assembly: re-assembles the diarization artifact from
+ * every source, best source per stretch. Trust order: network (WebRTC
+ * interception — authoritative wherever it produced data) > ui (the platform's
+ * own active-speaker indicator, shadow-buffered whole-call) > transcription
+ * (live transcription-system turns, when one ran). A lower-trust source never
+ * overwrites a higher-trust one — it only fills sufficiently large holes.
  */
 
 export type TimelineSourceKind = "network" | "ui" | "transcription"
@@ -29,16 +17,13 @@ export interface TimelineSource {
   segments: DiarizationSegment[]
 }
 
-// A hole in the assembled timeline must be at least this long before a
-// lower-trust source is consulted — shorter holes are ordinary turn-taking
-// silence.
+// Minimum hole size before a lower-trust source is consulted — anything
+// shorter is ordinary turn-taking silence.
 export const GAP_FILL_MIN_SECONDS = 10
-// A clipped contribution must keep at least this much of itself to be worth
-// emitting.
+// Minimum length a clipped contribution must keep to be emitted.
 export const MIN_SEGMENT_SECONDS = 1
-// How far back the first segment may be stretched to cover the boot gap
-// (recording start → first diarization signal). Beyond this something else is
-// broken, and claiming the whole leading window would mislabel real speech.
+// Cap on stretching the first segment back over the boot gap; a first segment
+// later than this means something else broke.
 export const LEADING_RETROFIT_MAX_SECONDS = 300
 
 /** Positive-length segments, chronological. */
@@ -102,9 +87,8 @@ function clipIntoGaps(
 
 /**
  * Stretch the earliest NAMED segment back to 0 so speech recorded before any
- * diarization source was live (the boot gap — typically the "thanks for
- * letting the bot in" greeting, observed in prod as a leading "Unknown" run of
- * 1-4 utterances) inherits the first identified speaker.
+ * diarization source was live (the boot-gap greeting, the prod leading-
+ * "Unknown" class) inherits the first identified speaker.
  */
 function retrofitLeadingGap(segments: DiarizationSegment[]): DiarizationSegment[] {
   let firstNamed: DiarizationSegment | null = null
@@ -124,12 +108,10 @@ function retrofitLeadingGap(segments: DiarizationSegment[]): DiarizationSegment[
 }
 
 /**
- * Remove the parts of Unknown segments that named coverage overlaps. Runs
- * last: the retrofit (and a named fallback filling a stretch the network only
- * knew as Unknown) can leave a named segment on top of an Unknown one, and
- * downstream mapping picks by overlap — an Unknown left in place would still
- * win the very words the repair exists to name. Uncovered Unknown remainders
- * are kept: they still mark real speech nothing ever named.
+ * Clip Unknown segments down to what named coverage does not overlap.
+ * Downstream mapping picks by overlap, so an Unknown left under a named
+ * segment would still win the words the repair names. Uncovered remainders
+ * are kept — they mark real speech nothing ever named.
  */
 function suppressCoveredUnknowns(segments: DiarizationSegment[]): DiarizationSegment[] {
   const namedCoverage = coverageOf(segments.filter((s) => s.speaker !== UNKNOWN_SPEAKER))
@@ -174,15 +156,12 @@ export function assembleSpeakerTimeline(
 
   for (const [index, source] of sources.entries()) {
     if (index === 0) {
-      // The primary source is taken as-is (Unknowns included — the repair
-      // passes upstream had their chance to name them, and downstream mapping
-      // still uses their spans).
+      // Primary source taken as-is, Unknowns included.
       assembled = normalize(source.segments)
       continue
     }
-    // Holes are measured against NAMED coverage only: a stretch the network
-    // could only call "Unknown" is exactly one a named fallback observation
-    // should win. The covered Unknown is clipped away at the end.
+    // Holes are measured against NAMED coverage only — a named fallback wins
+    // a stretch the network could only call "Unknown" (clipped away at the end).
     const clipped = clipIntoGaps(
       normalize(source.segments),
       gapsIn(coverageOf(assembled.filter((s) => s.speaker !== UNKNOWN_SPEAKER)), meetingEnd)

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -1,0 +1,156 @@
+import type { DiarizationSegment } from "./diarization-tracker"
+import { UNKNOWN_SPEAKER } from "./types"
+
+/**
+ * Final speaker-timeline assembly: one pure function that re-assembles the
+ * diarization artifact from every source we have, taking the best source for
+ * each stretch of the meeting.
+ *
+ * Sources, in trust order:
+ *  - "network"       — WebRTC interception (CSRC/dcrpc/roster). Carries device
+ *                      ids, survives DOM changes: authoritative wherever it
+ *                      produced data.
+ *  - "ui"            — the platform's own UI active-speaker indicator,
+ *                      shadow-buffered for the whole call. Fills holes the
+ *                      network path left.
+ *  - "transcription" — speaker turns from the live transcription system, when
+ *                      one ran. Last resort for stretches neither of the
+ *                      above covered.
+ *
+ * A lower-trust source NEVER overwrites a higher-trust one: it only
+ * contributes the parts of its segments that fall inside a sufficiently large
+ * hole of everything assembled before it.
+ */
+
+export type TimelineSourceKind = "network" | "ui" | "transcription"
+
+export interface TimelineSource {
+  kind: TimelineSourceKind
+  segments: DiarizationSegment[]
+}
+
+// A hole in the assembled timeline must be at least this long before a
+// lower-trust source is consulted — shorter holes are ordinary turn-taking
+// silence.
+export const GAP_FILL_MIN_SECONDS = 10
+// A clipped contribution must keep at least this much of itself to be worth
+// emitting.
+export const MIN_SEGMENT_SECONDS = 1
+// How far back the first segment may be stretched to cover the boot gap
+// (recording start → first diarization signal). Beyond this something else is
+// broken, and claiming the whole leading window would mislabel real speech.
+export const LEADING_RETROFIT_MAX_SECONDS = 300
+
+/** Positive-length segments, chronological. */
+function normalize(segments: DiarizationSegment[]): DiarizationSegment[] {
+  return segments
+    .filter((s) => s.end_time > s.start_time)
+    .slice()
+    .sort((a, b) => a.start_time - b.start_time)
+}
+
+/** Union of the segments' spans as merged, sorted intervals. */
+function coverageOf(segments: DiarizationSegment[]): Array<[number, number]> {
+  const merged: Array<[number, number]> = []
+  for (const s of normalize(segments)) {
+    const last = merged[merged.length - 1]
+    if (last && s.start_time <= last[1]) {
+      last[1] = Math.max(last[1], s.end_time)
+    } else {
+      merged.push([s.start_time, s.end_time])
+    }
+  }
+  return merged
+}
+
+/** Holes of at least GAP_FILL_MIN_SECONDS in [0, meetingEnd] left by coverage. */
+function gapsIn(coverage: Array<[number, number]>, meetingEnd: number): Array<[number, number]> {
+  const gaps: Array<[number, number]> = []
+  let cursor = 0
+  for (const [start, end] of coverage) {
+    if (start - cursor >= GAP_FILL_MIN_SECONDS) {
+      gaps.push([cursor, start])
+    }
+    cursor = Math.max(cursor, end)
+  }
+  if (meetingEnd - cursor >= GAP_FILL_MIN_SECONDS) {
+    gaps.push([cursor, meetingEnd])
+  }
+  return gaps
+}
+
+/** The parts of the candidates that fall inside the gaps. */
+function clipIntoGaps(
+  candidates: DiarizationSegment[],
+  gaps: Array<[number, number]>
+): DiarizationSegment[] {
+  const clipped: DiarizationSegment[] = []
+  for (const candidate of candidates) {
+    if (!candidate.speaker || candidate.speaker === UNKNOWN_SPEAKER) {
+      continue
+    }
+    for (const [gapStart, gapEnd] of gaps) {
+      const start = Math.max(candidate.start_time, gapStart)
+      const end = Math.min(candidate.end_time, gapEnd)
+      if (end - start >= MIN_SEGMENT_SECONDS) {
+        clipped.push({ ...candidate, start_time: start, end_time: end })
+      }
+    }
+  }
+  return clipped
+}
+
+/**
+ * Stretch the earliest NAMED segment back to 0 so speech recorded before any
+ * diarization source was live (the boot gap — typically the "thanks for
+ * letting the bot in" greeting, observed in prod as a leading "Unknown" run of
+ * 1-4 utterances) inherits the first identified speaker.
+ */
+function retrofitLeadingGap(segments: DiarizationSegment[]): DiarizationSegment[] {
+  let firstNamed: DiarizationSegment | null = null
+  for (const s of segments) {
+    if (s.speaker === UNKNOWN_SPEAKER) continue
+    if (!firstNamed || s.start_time < firstNamed.start_time) firstNamed = s
+  }
+  if (
+    !firstNamed ||
+    firstNamed.start_time <= 0 ||
+    firstNamed.start_time > LEADING_RETROFIT_MAX_SECONDS
+  ) {
+    return segments
+  }
+  const target = firstNamed
+  return segments.map((s) => (s === target ? { ...s, start_time: 0 } : s))
+}
+
+/**
+ * Assemble the final timeline. `sources` must be ordered highest-trust first;
+ * each source contributes only where everything before it left a hole.
+ */
+export function assembleSpeakerTimeline(
+  sources: TimelineSource[],
+  meetingEnd: number
+): { segments: DiarizationSegment[]; filledBySource: Partial<Record<TimelineSourceKind, number>> } {
+  let assembled: DiarizationSegment[] = []
+  const filledBySource: Partial<Record<TimelineSourceKind, number>> = {}
+
+  for (const [index, source] of sources.entries()) {
+    if (index === 0) {
+      // The primary source is taken as-is (Unknowns included — the repair
+      // passes upstream had their chance to name them, and downstream mapping
+      // still uses their spans).
+      assembled = normalize(source.segments)
+      continue
+    }
+    const clipped = clipIntoGaps(
+      normalize(source.segments),
+      gapsIn(coverageOf(assembled), meetingEnd)
+    )
+    if (clipped.length > 0) {
+      filledBySource[source.kind] = clipped.length
+      assembled = normalize([...assembled, ...clipped])
+    }
+  }
+
+  return { segments: retrofitLeadingGap(assembled), filledBySource }
+}

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -124,6 +124,44 @@ function retrofitLeadingGap(segments: DiarizationSegment[]): DiarizationSegment[
 }
 
 /**
+ * Remove the parts of Unknown segments that named coverage overlaps. Runs
+ * last: the retrofit (and a named fallback filling a stretch the network only
+ * knew as Unknown) can leave a named segment on top of an Unknown one, and
+ * downstream mapping picks by overlap — an Unknown left in place would still
+ * win the very words the repair exists to name. Uncovered Unknown remainders
+ * are kept: they still mark real speech nothing ever named.
+ */
+function suppressCoveredUnknowns(segments: DiarizationSegment[]): DiarizationSegment[] {
+  const namedCoverage = coverageOf(segments.filter((s) => s.speaker !== UNKNOWN_SPEAKER))
+  const out: DiarizationSegment[] = []
+  for (const segment of segments) {
+    if (segment.speaker !== UNKNOWN_SPEAKER) {
+      out.push(segment)
+      continue
+    }
+    let pieces: Array<[number, number]> = [[segment.start_time, segment.end_time]]
+    for (const [coverStart, coverEnd] of namedCoverage) {
+      const next: Array<[number, number]> = []
+      for (const [pieceStart, pieceEnd] of pieces) {
+        if (coverEnd <= pieceStart || coverStart >= pieceEnd) {
+          next.push([pieceStart, pieceEnd])
+          continue
+        }
+        if (coverStart > pieceStart) next.push([pieceStart, coverStart])
+        if (coverEnd < pieceEnd) next.push([coverEnd, pieceEnd])
+      }
+      pieces = next
+    }
+    for (const [pieceStart, pieceEnd] of pieces) {
+      if (pieceEnd - pieceStart >= MIN_SEGMENT_SECONDS) {
+        out.push({ ...segment, start_time: pieceStart, end_time: pieceEnd })
+      }
+    }
+  }
+  return normalize(out)
+}
+
+/**
  * Assemble the final timeline. `sources` must be ordered highest-trust first;
  * each source contributes only where everything before it left a hole.
  */
@@ -142,9 +180,12 @@ export function assembleSpeakerTimeline(
       assembled = normalize(source.segments)
       continue
     }
+    // Holes are measured against NAMED coverage only: a stretch the network
+    // could only call "Unknown" is exactly one a named fallback observation
+    // should win. The covered Unknown is clipped away at the end.
     const clipped = clipIntoGaps(
       normalize(source.segments),
-      gapsIn(coverageOf(assembled), meetingEnd)
+      gapsIn(coverageOf(assembled.filter((s) => s.speaker !== UNKNOWN_SPEAKER)), meetingEnd)
     )
     if (clipped.length > 0) {
       filledBySource[source.kind] = clipped.length
@@ -152,5 +193,8 @@ export function assembleSpeakerTimeline(
     }
   }
 
-  return { segments: retrofitLeadingGap(assembled), filledBySource }
+  return {
+    segments: suppressCoveredUnknowns(retrofitLeadingGap(assembled)),
+    filledBySource
+  }
 }


### PR DESCRIPTION
## Why

Two prod-verified failure classes, one instrument + one fix:

- **Leading "Unknown"**: team-level sweep Aug 25–31 — every remaining Unknown was the boot-gap class (4/67 transcripts, 1–4 utterances each — the "thanks for letting the bot in" greeting — first at +2..+21s, 100% attributed afterward). Fresh report today: `8db02fee…`, 1/732 utterances.
- **Mid-call collapse** (bot `acf4eecf`): network path pinned 5271-vs-31 speaking samples on one participant of a real two-sided call. The one signal with the right answer all call — Meet's own UI active-speaker indicator — was discarded unrecorded at the muted bridge; diagnosis required video frames.

## What

**1. Always-log UI speakers.** The muted branch of `handleUiBridgeUpdate` shadow-logs observations to `speaker_separation.log` as JSON object lines (`{"src":"ui-shadow",…}`, committed stream = bare arrays) instead of discarding them. Same PII redaction; the file already uploads to S3, so per-call reconstruction is free. Change-deduped; failures swallowed; attribution and recording untouched (People panel already open + cleaner-hidden).

**2. Final speaker-timeline assembly.** Finalize re-assembles `diarization.jsonl` through one pure function — `assembleSpeakerTimeline(sources, meetingEnd)` — best source per stretch, trust-ordered:

1. **network** — authoritative wherever it produced data; never overwritten
2. **ui** — the shadow buffer from (1); fills holes ≥ 10s, only stretches where exactly one participant was lit (ambiguity dropped), bot silenced like the committed path
3. **transcription** — typed + plumbed for live transcription-system turns; passes empty today

Plus: boot-gap retrofit (earliest named segment stretched to 0, capped 300s — zeroes every observed leading-Unknown case), holes measured against *named* coverage (a named fallback wins a stretch the network only knew as Unknown), covered Unknowns clipped to their uncovered remainders, truncated shadow buffer ends the fallback timeline at its last retained observation.

## Scope boundary

The committed timeline is contiguous from its first event (each update closes the previous segment at the next event's time), so the holes fallbacks can fill are the leading gap and the network-never-produced case. Mid-call **wrong** (not missing) attribution stays with reconciliation — Meeting-BaaS/meeting-baas-v2#454 — with the ui-shadow stream as its evidence. Deliberately not here: VAD-aware CSRC detection (root cause, needs flag + preprod A/B) and a divergence-override assembler rule (needs the divergence data this PR starts collecting).

## Tests

39 across the three touched suites — shadow line written when muted / dedupe / attribution untouched; assembler trust order, clipping, gap threshold, Unknown rejection + suppression, retrofit + cap, empty network; bot-silenced buffer; truncation. tsc clean. (`meet.test.ts` / `meeting-state-detector.test.ts` fail identically on the clean tree — env, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)