### PR TITLE
fix(streaming): reconnect external input websocket after drop

### DIFF
--- a/src/streaming.test.ts
+++ b/src/streaming.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for the streaming input WebSocket:
+ * - binary PCM is piped into the FFmpeg stdin
+ * - the audio stream is ended when the socket closes (no orphaned FFmpeg
+ *   processes across reconnects)
+ * - the input socket reconnects with exponential backoff after a drop
+ * - stop() clears any pending reconnect
+ */
+
+const mockStdin = {
+  writes: 0,
+  ended: false,
+  write: () => {
+    mockStdin.writes++
+  },
+  end: () => {
+    mockStdin.ended = true
+  }
+}
+
+const mockWsInstances: MockWebSocket[] = []
+
+class MockWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  url: string
+  readyState = MockWebSocket.CONNECTING
+  private handlers: Record<string, Array<(...args: unknown[]) => void>> = {}
+
+  constructor(url: string) {
+    this.url = url
+    mockWsInstances.push(this)
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    if (!this.handlers[event]) {
+      this.handlers[event] = []
+    }
+    this.handlers[event].push(handler)
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const handler of this.handlers[event] ?? []) {
+      handler(...args)
+    }
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.emit("open")
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.emit("close")
+  }
+}
+
+jest.mock("ws", () => ({ WebSocket: MockWebSocket }))
+jest.mock("./config/env-vars", () => ({ envVars: {} }))
+jest.mock("./media_context", () => ({
+  SoundContext: class {
+    static instance: unknown
+    constructor() {
+      ;(this.constructor as unknown as { instance: unknown }).instance = this
+    }
+    play_stdin() {
+      return mockStdin
+    }
+  }
+}))
+jest.mock("./utils/Logger", () => ({ formatError: (e: unknown) => String(e) }))
+jest.mock("./utils/PathManager", () => ({
+  PathManager: { getInstance: () => ({ getDebugStreamedAudioPath: () => "/tmp/streaming-test.wav" }) }
+}))
+jest.mock("./utils/S3Uploader", () => ({ S3Uploader: class {} }))
+
+import { Streaming } from "./streaming"
+
+function createStreaming(input = "ws://in/input", output?: string) {
+  return new Streaming(input, output, 24000, "bot-123")
+}
+
+/** Int16LE PCM buffer with `samples` samples of `value` amplitude */
+function pcmBuffer(samples: number, value = 1000): Buffer {
+  const buf = Buffer.alloc(samples * 2)
+  for (let i = 0; i < samples; i++) {
+    buf.writeInt16LE(value, i * 2)
+  }
+  return buf
+}
+
+describe("Streaming input WebSocket", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] })
+    mockWsInstances.length = 0
+    mockStdin.writes = 0
+    mockStdin.ended = false
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("connects to the input URL on start", () => {
+    createStreaming()
+    expect(mockWsInstances).toHaveLength(1)
+    expect(mockWsInstances[0]?.url).toBe("ws://in/input")
+  })
+
+  it("pipes incoming PCM into the FFmpeg stdin and ends it when the socket closes", async () => {
+    createStreaming()
+    const ws = mockWsInstances[0]!
+    ws.open()
+
+    ws.emit("message", pcmBuffer(100))
+    // Flowing-mode 'data' events fire on the next tick.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(mockStdin.writes).toBeGreaterThan(0)
+
+    ws.close()
+    // Stream 'end' (and therefore stdin.end()) fires on the next tick.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(mockStdin.ended).toBe(true)
+  })
+
+  it("reconnects the input socket after it closes", () => {
+    createStreaming()
+    const ws0 = mockWsInstances[0]!
+    ws0.open()
+    ws0.close()
+
+    jest.advanceTimersByTime(1000) // initial backoff = 1s
+    expect(mockWsInstances).toHaveLength(2)
+    expect(mockWsInstances[1]?.url).toBe("ws://in/input")
+  })
+
+  it("backs off exponentially between input reconnect attempts", () => {
+    createStreaming()
+
+    let ws = mockWsInstances[0]!
+    ws.open()
+    ws.close()
+    jest.advanceTimersByTime(1000) // attempt 2 (1s backoff)
+    expect(mockWsInstances).toHaveLength(2)
+
+    // Do NOT open the new socket: a successful open resets the backoff
+    // counter, so exponential growth only applies across failed attempts.
+    ws = mockWsInstances[1]!
+    ws.close()
+    jest.advanceTimersByTime(1000) // 1s into the 2s backoff — nothing yet
+    expect(mockWsInstances).toHaveLength(2)
+
+    jest.advanceTimersByTime(1000) // total 2s — attempt 3
+    expect(mockWsInstances).toHaveLength(3)
+  })
+
+  it("does not reconnect once streaming is stopped", async () => {
+    const streaming = createStreaming()
+    const ws = mockWsInstances[0]!
+    ws.open()
+    ws.close()
+
+    await streaming.stop()
+    jest.advanceTimersByTime(120_000)
+    expect(mockWsInstances).toHaveLength(1)
+  })
+})

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -725,6 +725,13 @@ export class Streaming {
       }
     })
 
+    // The connection is gone (clean close or after an error). End the stream
+    // so the 'end' handler in play_incoming_audio_chunks closes the FFmpeg
+    // stdin and the old process exits instead of lingering across reconnects.
+    input_ws.on("close", () => {
+      stream.push(null)
+    })
+
     return stream
   }
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -60,6 +60,13 @@ export class Streaming {
   private lastWsNotReadyLogTime = 0
   private readonly WS_NOT_READY_LOG_INTERVAL_MS: number = 10000 // Log at most every 10 seconds
 
+  // Input WebSocket reconnection with exponential backoff (mirrors the output
+  // socket. Without it, a dropped input connection (e.g. the client's app
+  // restarting) is never re-established while the output socket recovers.)
+  private isInputReconnecting = false
+  private inputReconnectAttempts = 0
+  private inputReconnectTimeoutId: NodeJS.Timeout | null = null
+
   // Fixed-size output buffer (accumulates Int16 into consistent chunks)
   private static readonly OUTPUT_CHUNK_MS = 100 // 100ms chunks
   private outputBuffer: Int16Array | null = null
@@ -391,20 +398,83 @@ export class Streaming {
    */
   private setupExternalInputWS(): void {
     try {
+      console.log(`[Streaming] Connecting to external input WebSocket: ${this.inputUrl}`)
       this.input_ws = new WebSocket(this.inputUrl!)
 
       this.input_ws.on("open", () => {
         console.log("[Streaming] External input WebSocket connected")
+        // Reset reconnection state on successful connection
+        this.isInputReconnecting = false
+        this.inputReconnectAttempts = 0
       })
 
       this.input_ws.on("error", (err: Error) => {
         console.error("[Streaming] External input WebSocket error:", formatError(err))
+        this.scheduleInputReconnect()
+      })
+
+      this.input_ws.on("close", () => {
+        console.log("[Streaming] External input WebSocket closed")
+        if (this.isInitialized) {
+          this.scheduleInputReconnect()
+        }
       })
 
       this.play_incoming_audio_chunks(this.input_ws)
     } catch (error) {
       console.error("[Streaming] Failed to setup external input WebSocket:", formatError(error))
+      this.scheduleInputReconnect()
     }
+  }
+
+  /**
+   * Schedule input WebSocket reconnection with exponential backoff.
+   * Mirrors the output-socket reconnect so a dropped input connection is
+   * re-established (e.g. after the client's app restarts). Max delay is
+   * 1 minute between attempts.
+   */
+  private scheduleInputReconnect(): void {
+    if (!this.isInitialized || !this.inputUrl) return
+    if (this.isInputReconnecting) return
+
+    if (
+      this.input_ws &&
+      (this.input_ws.readyState === WebSocket.OPEN ||
+        this.input_ws.readyState === WebSocket.CONNECTING)
+    ) {
+      return
+    }
+
+    this.isInputReconnecting = true
+    this.inputReconnectAttempts++
+
+    const delay = Math.min(
+      this.INITIAL_RECONNECT_DELAY_MS * 2 ** (this.inputReconnectAttempts - 1),
+      this.MAX_RECONNECT_DELAY_MS
+    )
+
+    console.log(
+      `[Streaming] Scheduling input WebSocket reconnection attempt ${this.inputReconnectAttempts} in ${(delay / 1000).toFixed(1)}s`
+    )
+
+    if (this.inputReconnectTimeoutId) {
+      clearTimeout(this.inputReconnectTimeoutId)
+    }
+
+    this.inputReconnectTimeoutId = setTimeout(() => {
+      this.inputReconnectTimeoutId = null
+
+      if (!this.isInitialized || !this.inputUrl) {
+        this.isInputReconnecting = false
+        return
+      }
+
+      console.log(
+        `[Streaming] Attempting input WebSocket reconnection (attempt ${this.inputReconnectAttempts})...`
+      )
+      this.isInputReconnecting = false
+      this.setupExternalInputWS()
+    }, delay)
   }
 
   /**
@@ -525,6 +595,13 @@ export class Streaming {
     }
     this.isReconnecting = false
     this.reconnectAttempts = 0
+
+    if (this.inputReconnectTimeoutId) {
+      clearTimeout(this.inputReconnectTimeoutId)
+      this.inputReconnectTimeoutId = null
+    }
+    this.isInputReconnecting = false
+    this.inputReconnectAttempts = 0
 
     try {
       if (this.output_ws) {


### PR DESCRIPTION
## Summary

Adds reconnection for the **input** streaming WebSocket (client → bot audio injection).

The input socket had no reconnection logic: on error/close it was never re-established, while the **output** socket reconnects with exponential backoff. If the client's app restarts, the bot's input socket stayed dead forever — reported by a customer (ticket 48111788254932) and reproduced live:

- Closed the bot's input connection mid-meeting → 3+ minutes later it had not reconnected
- Closed the bot's output connection → reconnected automatically within seconds

This mirrors the output reconnect path for the input socket: independent backoff state, `error`/`close` handlers schedule reconnection, and the stop/teardown path clears the timer and resets state.

## Changes

- `setupExternalInputWS` now reconnects on `error`/`close` with independent exponential backoff (1s → 60s), mirroring the output socket
- The input audio stream is ended when its socket closes, so the `end` handler closes the FFmpeg stdin and the old process exits instead of lingering across reconnects
- Reconnect timers/state are cleared on stop

## Testing

- `tsc --noEmit` passes
- `biome lint src/streaming.ts` passes
- New regression tests in `src/streaming.test.ts` (5/5 passing): PCM piping into FFmpeg stdin, stream end on socket close, reconnect after drop, exponential backoff across failed attempts, and stop() clearing pending reconnects
- Bot test suite run: 17/20 suites pass; the 3 failing suites (`meeting-state-detector.test.ts`, `meet.test.ts`, and one other) fail identically on the base branch without this change — pre-existing
- Verified live on prod: input injection works end-to-end (440 Hz tone injected via input socket was audible in the meeting and detected in the bot's output stream); the missing reconnection was the confirmed defect

## Release Notes

Operational: streaming clients that disconnect and reconnect (e.g. app restarts) now recover the bot's audio-input socket automatically, matching the output socket's behavior. No user-facing API changes.
