### PR TITLE
fix(zoom): rotate regions across retries

### DIFF
--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process"
 import type { BrowserContext } from "@playwright/test"
 import { fetchBurnedAsns, isBurnedExit } from "../api/methods"
+import { getZoomJoinAttemptIndex } from "../proxy/country-rotation"
 import {
   getExitAsn,
   getExitGeo,
@@ -10,7 +11,7 @@ import {
 } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
-import { MAX_RETRY_COUNT } from "../config/retry-config"
+import { IN_PROCESS_RETRY_MAX, MAX_RETRY_COUNT } from "../config/retry-config"
 import { formatError } from "../utils/Logger"
 import { openBrowser } from "./browser"
 
@@ -55,10 +56,14 @@ type BrowserSession = { proxyUrl?: string; browserContext?: BrowserContext }
  */
 export async function establishBrowserSession(
   session: BrowserSession,
-  opts: { sessionSuffix?: string } = {}
+  opts: { sessionSuffix?: string; inProcessAttempt?: number } = {}
 ): Promise<void> {
   const platform = GLOBAL.get().meeting_platform
   const retryCount = GLOBAL.getRetryCount()
+  const countryOffset =
+    platform === "zoom"
+      ? getZoomJoinAttemptIndex(retryCount, opts.inProcessAttempt ?? 0, IN_PROCESS_RETRY_MAX + 1)
+      : 0
 
   if (!session.proxyUrl && (platform === "meet" || platform === "zoom")) {
     // On the last retry, Meet used to run WITHOUT a proxy — but a datacenter/pod
@@ -81,7 +86,8 @@ export async function establishBrowserSession(
       const proxyUrl = await startToggleProxy(
         GLOBAL.get().bot_uuid,
         retryCount,
-        opts.sessionSuffix
+        opts.sessionSuffix,
+        { countryOffset }
       )
       if (proxyUrl) session.proxyUrl = proxyUrl
 

--- a/src/proxy/country-rotation.test.ts
+++ b/src/proxy/country-rotation.test.ts
@@ -1,0 +1,34 @@
+import { getZoomJoinAttemptIndex, rotateCountriesForAttempt } from "./country-rotation"
+
+describe("Zoom proxy country rotation", () => {
+  const countries = ["it", "fr", "de", "nl", "gb", "se"]
+  const attemptsPerPod = 3
+
+  it("uses a different region for every in-process and outer retry", () => {
+    const selected = [
+      [0, 0],
+      [0, 1],
+      [0, 2],
+      [1, 0],
+      [1, 1],
+      [1, 2],
+      [2, 0]
+    ].map(([outerRetry, inProcessAttempt]) => {
+      const attemptIndex = getZoomJoinAttemptIndex(outerRetry, inProcessAttempt, attemptsPerPod)
+      return rotateCountriesForAttempt(countries, attemptIndex)[0]
+    })
+
+    expect(selected).toEqual(["it", "fr", "de", "nl", "gb", "se", "it"])
+  })
+
+  it("preserves one-region and empty pools", () => {
+    expect(rotateCountriesForAttempt(["it"], 8)).toEqual(["it"])
+    expect(rotateCountriesForAttempt([], 8)).toEqual([])
+  })
+
+  it("does not mutate the bot-stable country order", () => {
+    const original = [...countries]
+    expect(rotateCountriesForAttempt(countries, 2)).toEqual(["de", "nl", "gb", "se", "it", "fr"])
+    expect(countries).toEqual(original)
+  })
+})

--- a/src/proxy/country-rotation.ts
+++ b/src/proxy/country-rotation.ts
@@ -1,0 +1,31 @@
+/**
+ * Rotate an ordered country pool so one join attempt starts in the next region.
+ * The input order is already bot-stable; this adds attempt-level diversity
+ * without changing how separate bots are spread across the pool.
+ */
+export function rotateCountriesForAttempt(
+  countries: readonly string[],
+  attemptIndex: number
+): string[] {
+  if (countries.length <= 1) return [...countries]
+
+  const safeAttempt = Number.isFinite(attemptIndex) ? Math.max(0, Math.trunc(attemptIndex)) : 0
+  const offset = safeAttempt % countries.length
+  return [...countries.slice(offset), ...countries.slice(0, offset)]
+}
+
+/**
+ * Flatten SQS pod retries and in-process browser relaunches into one monotonic
+ * join-attempt index. This prevents every fresh pod from restarting at the
+ * same country.
+ */
+export function getZoomJoinAttemptIndex(
+  outerRetryCount: number,
+  inProcessAttempt: number,
+  attemptsPerPod: number
+): number {
+  const safeOuterRetry = Math.max(0, Math.trunc(outerRetryCount))
+  const safeInProcessAttempt = Math.max(0, Math.trunc(inProcessAttempt))
+  const safeAttemptsPerPod = Math.max(1, Math.trunc(attemptsPerPod))
+  return safeOuterRetry * safeAttemptsPerPod + safeInProcessAttempt
+}

--- a/src/proxy/toggle-proxy.test.ts
+++ b/src/proxy/toggle-proxy.test.ts
@@ -1,8 +1,6 @@
-import { setZoomJoinHost, shouldProxy } from "./toggle-proxy"
+import { resolveProxyCountriesForAttempt, setZoomJoinHost, shouldProxy } from "./toggle-proxy"
 
-// toggle-proxy pulls in the singleton for the geo/rotation helpers. Nothing
-// under test reads it — the allowlist is a flat constant, not platform-scoped —
-// but the import has to resolve.
+// Keep country rotation deterministic. Allowlist tests remain platform-agnostic.
 jest.mock("../singleton", () => ({
   GLOBAL: { get: () => ({ bot_uuid: "test-bot", proxy_countries: [] }) }
 }))
@@ -12,6 +10,13 @@ jest.mock("../singleton", () => ({
 beforeEach(() => setZoomJoinHost("app.zoom.us"))
 
 describe("residential proxy host selection", () => {
+  it("advances the bot-stable country order for each join attempt", () => {
+    const initial = resolveProxyCountriesForAttempt(0)
+
+    expect(resolveProxyCountriesForAttempt(1)).toEqual([...initial.slice(1), initial[0]])
+    expect(resolveProxyCountriesForAttempt(initial.length)).toEqual(initial)
+  })
+
   describe("zoom", () => {
     it("proxies the hosts that make the join decision", () => {
       expect(shouldProxy("app.zoom.us")).toBe(true)

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -9,6 +9,7 @@ import type { ConnectionStats } from "proxy-chain"
 import { Server } from "proxy-chain"
 import { envVars } from "../config/env-vars"
 import { GLOBAL } from "../singleton"
+import { rotateCountriesForAttempt } from "./country-rotation"
 
 // Hosts that route through the residential upstream. Everything else goes
 // direct from the pod IP.
@@ -193,6 +194,11 @@ export function resolveProxyCountries(): string[] {
   return rotateByBot(DEFAULT_PROXY_COUNTRIES)
 }
 
+/** Bot-stable country order, advanced for this specific join attempt. */
+export function resolveProxyCountriesForAttempt(countryOffset = 0): string[] {
+  return rotateCountriesForAttempt(resolveProxyCountries(), countryOffset)
+}
+
 /**
  * Spread a multi-region pin across the team's selected regions instead of
  * funneling every bot through the first entry. When a customer batch-launches
@@ -215,8 +221,9 @@ function rotateByBot(countries: string[]): string[] {
 }
 
 /** First selected region not yet tried this attempt, or "" if none remain. */
-function pickProxyCountry(exclude: readonly string[]): string {
-  return resolveProxyCountries().find((c) => !exclude.includes(c)) ?? ""
+function pickProxyCountry(exclude: readonly string[], countryOffset = 0): string {
+  const countries = resolveProxyCountriesForAttempt(countryOffset)
+  return countries.find((c) => !exclude.includes(c)) ?? ""
 }
 
 function inferProxyProvider(): string {
@@ -334,10 +341,9 @@ export async function startToggleProxy(
   sessionId: string,
   retryCount = 0,
   sessionSuffix = "",
-  // Internal recursion state (not passed by external callers): skipGeoPin drops
-  // pinning entirely; triedCountries are the selected regions already attempted
-  // this join, so an outage falls through to the next selected region.
-  opts: { skipGeoPin?: boolean; triedCountries?: string[] } = {}
+  // countryOffset selects a different first region for each Zoom join attempt.
+  // skipGeoPin and triedCountries carry internal regional-outage recursion state.
+  opts: { skipGeoPin?: boolean; triedCountries?: string[]; countryOffset?: number } = {}
 ): Promise<string | null> {
   if (!envVars.RESIDENTIAL_PROXY_TEMPLATE) {
     currentSessionId = null
@@ -365,7 +371,10 @@ export async function startToggleProxy(
   // Treat as unpinned up front so a failed probe below falls straight through
   // to "give up", not a country-by-country retry loop that can't ever help.
   const hasGeoPlaceholder = envVars.RESIDENTIAL_PROXY_TEMPLATE.includes("{GEO}")
-  const country = opts.skipGeoPin || !hasGeoPlaceholder ? "" : pickProxyCountry(opts.triedCountries ?? [])
+  const country =
+    opts.skipGeoPin || !hasGeoPlaceholder
+      ? ""
+      : pickProxyCountry(opts.triedCountries ?? [], opts.countryOffset)
   const geoParam = country ? `-country-${country}` : ""
   const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session).replaceAll(
     "{GEO}",
@@ -460,12 +469,15 @@ export async function startToggleProxy(
       // Terminates: each step either adds to triedCountries or sets skipGeoPin.
       if (country) {
         const tried = [...(opts.triedCountries ?? []), country]
-        const nextCountry = pickProxyCountry(tried)
+        const nextCountry = pickProxyCountry(tried, opts.countryOffset)
         if (nextCountry) {
           console.warn(
             `[ToggleProxy] region ${country} exit unreachable — trying next selected region ${nextCountry}`
           )
-          return startToggleProxy(sessionId, retryCount, sessionSuffix, { triedCountries: tried })
+          return startToggleProxy(sessionId, retryCount, sessionSuffix, {
+            triedCountries: tried,
+            countryOffset: opts.countryOffset
+          })
         }
         console.warn(
           "[ToggleProxy] all selected regions unreachable — retrying without a region pin"

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -287,9 +287,12 @@ export class WaitingRoomState extends BaseState {
         // doesn't leak into the next join or the final wasRecordingSuccessful check.
         GLOBAL.resetErrorState()
         // Recycle browser + proxy onto a new Decodo session id (suffix "x<n>") →
-        // a different residential exit IP for the next launch.
+        // the next configured region and a different residential exit IP.
         await teardownBrowserSession(this.context)
-        await establishBrowserSession(this.context, { sessionSuffix: `x${attempt + 1}` })
+        await establishBrowserSession(this.context, {
+          sessionSuffix: `x${attempt + 1}`,
+          inProcessAttempt: attempt + 1
+        })
       }
     }
   }


### PR DESCRIPTION
## Summary

- flatten outer SQS retries and in-process browser retries into one join-attempt index
- advance each Zoom attempt to the next team-selected proxy region
- preserve bot-level initial spreading, regional-outage fallthrough, and single-region behavior

For a six-region pool, pod 1 tries regions 1-3 and pod 2 tries regions 4-6 before wrapping.

## Validation

- focused proxy suites: 17 tests passed
- TypeScript release config: passed
- full Jest run: 20 suites / 288 tests passed; remaining two suites fail from existing host Chromium libraries and Axios ts-jest augmentation, unrelated to this diff