### PR TITLE
fix(zoom): classify failures and harden retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,16 +72,16 @@ UPLOAD_AUDIO_CHUNKS=true
 # Boolean (true/false) - Whether the bot should upload the raw video captured in the logs bucket. This is useful for debugging
 UPLOAD_RAW_VIDEO=false
 
-# Decodo (or similar) backconnect residential proxy used only for Google Meet
+# Decodo (or similar) backconnect residential proxy used for Meet and Zoom
 # during the join phase. After the bot is admitted the proxy switches off and
 # the session goes direct (see src/proxy/toggle-proxy.ts).
 #
-# The {SESSION} placeholder is substituted at runtime with the bot's UUID
-# (hyphens stripped). Each bot pod gets a sticky residential IP while
-# different bots naturally land on different IPs from the pool.
+# The {GEO} placeholder is substituted with `-country-<ISO2>` from the bot's
+# region pool. {SESSION} becomes the bot UUID plus its retry index, keeping an
+# attempt sticky while moving later attempts to fresh exits.
 #
-# Example (Decodo, EU continent):
-# RESIDENTIAL_PROXY_TEMPLATE=http://user-<USER>-continent-eu-session-{SESSION}:<PASS>@gate.decodo.com:7000
+# Example (Decodo):
+# RESIDENTIAL_PROXY_TEMPLATE=http://user-<USER>{GEO}-session-{SESSION}:<PASS>@isp.decodo.com:10000
 #
 # Leave empty to disable residential proxy (bot joins direct from the pod IP).
 RESIDENTIAL_PROXY_TEMPLATE=

--- a/src/meeting/zoom-join-failure.test.ts
+++ b/src/meeting/zoom-join-failure.test.ts
@@ -1,0 +1,32 @@
+import { MeetingEndReason } from "../state-machine/types"
+import { resolveZoomJoinFailureReason } from "./zoom-join-failure"
+
+describe("Zoom join failure evidence", () => {
+  const wall = MeetingEndReason.ZoomAnonymousJoinNotAllowed
+
+  it.each([
+    MeetingEndReason.CannotJoinMeeting,
+    MeetingEndReason.TimeoutWaitingToStart,
+    MeetingEndReason.ExitingMeetingBeforeRecord,
+    MeetingEndReason.ProxyUnavailable,
+    MeetingEndReason.Internal,
+    null
+  ])("preserves a confirmed bot wall over %s", (latestReason) => {
+    expect(resolveZoomJoinFailureReason(wall, latestReason)).toBe(wall)
+  })
+
+  it.each([
+    MeetingEndReason.LoginRequired,
+    MeetingEndReason.InvalidMeetingUrl,
+    MeetingEndReason.ZoomPasscodeRequired,
+    MeetingEndReason.ZoomWebinarRegistrationRequired
+  ])("keeps a later deterministic outcome %s", (latestReason) => {
+    expect(resolveZoomJoinFailureReason(wall, latestReason)).toBe(latestReason)
+  })
+
+  it("does not manufacture bot-wall evidence", () => {
+    expect(resolveZoomJoinFailureReason(null, MeetingEndReason.CannotJoinMeeting)).toBe(
+      MeetingEndReason.CannotJoinMeeting
+    )
+  })
+})

--- a/src/meeting/zoom-join-failure.test.ts
+++ b/src/meeting/zoom-join-failure.test.ts
@@ -19,6 +19,7 @@ describe("Zoom join failure evidence", () => {
     MeetingEndReason.LoginRequired,
     MeetingEndReason.InvalidMeetingUrl,
     MeetingEndReason.ZoomPasscodeRequired,
+    MeetingEndReason.ZoomInvalidPasscode,
     MeetingEndReason.ZoomWebinarRegistrationRequired
   ])("keeps a later deterministic outcome %s", (latestReason) => {
     expect(resolveZoomJoinFailureReason(wall, latestReason)).toBe(latestReason)

--- a/src/meeting/zoom-join-failure.ts
+++ b/src/meeting/zoom-join-failure.ts
@@ -1,0 +1,31 @@
+import { MeetingEndReason } from "../state-machine/types"
+
+const DOWNGRADEABLE_AFTER_ZOOM_BOT_WALL: ReadonlySet<MeetingEndReason> = new Set([
+  MeetingEndReason.CannotJoinMeeting,
+  MeetingEndReason.TimeoutWaitingToStart,
+  MeetingEndReason.ExitingMeetingBeforeRecord,
+  MeetingEndReason.ProxyUnavailable,
+  MeetingEndReason.Internal
+])
+
+/**
+ * Keep a confirmed Zoom anti-bot wall when a later relaunch only produces a
+ * less-specific transport/render failure. A successful relaunch never calls
+ * this helper, while deterministic outcomes such as login/registration remain
+ * authoritative.
+ */
+export function resolveZoomJoinFailureReason(
+  confirmedBotWall: MeetingEndReason.ZoomAnonymousJoinNotAllowed | null,
+  latestReason: MeetingEndReason | null
+): MeetingEndReason | null {
+  if (latestReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) {
+    return latestReason
+  }
+  if (
+    confirmedBotWall &&
+    (latestReason === null || DOWNGRADEABLE_AFTER_ZOOM_BOT_WALL.has(latestReason))
+  ) {
+    return confirmedBotWall
+  }
+  return latestReason
+}

--- a/src/meeting/zoom-passcode.test.ts
+++ b/src/meeting/zoom-passcode.test.ts
@@ -1,0 +1,52 @@
+import { MeetingEndReason } from "../state-machine/types"
+import {
+  classifyZoomPasscodeFailure,
+  type ZoomPasscodeDomState
+} from "./zoom-passcode"
+
+const state = (overrides: Partial<ZoomPasscodeDomState> = {}): ZoomPasscodeDomState => ({
+  present: true,
+  value: "",
+  invalid: false,
+  errorText: "",
+  ...overrides
+})
+
+describe("Zoom passcode failure classification", () => {
+  it("ignores pages without a passcode field", () => {
+    expect(classifyZoomPasscodeFailure(state({ present: false }), "")).toBeNull()
+  })
+
+  it("classifies a rendered field with no supplied passcode as required", () => {
+    expect(classifyZoomPasscodeFailure(state(), "")).toBe(
+      MeetingEndReason.ZoomPasscodeRequired
+    )
+  })
+
+  it.each(["Incorrect Password", "Invalid meeting passcode", "Password is wrong"])(
+    "classifies Zoom's explicit rejection: %s",
+    (errorText) => {
+      expect(
+        classifyZoomPasscodeFailure(
+          state({ value: "redacted", invalid: true, errorText }),
+          "redacted"
+        )
+      ).toBe(MeetingEndReason.ZoomInvalidPasscode)
+    }
+  )
+
+  it("uses aria-invalid when Zoom omits helper text", () => {
+    expect(
+      classifyZoomPasscodeFailure(state({ value: "redacted", invalid: true }), "redacted")
+    ).toBe(MeetingEndReason.ZoomInvalidPasscode)
+  })
+
+  it("allows a supplied passcode to be filled before classifying it", () => {
+    expect(
+      classifyZoomPasscodeFailure(
+        state({ invalid: true, errorText: "Meeting passcode is required" }),
+        "redacted"
+      )
+    ).toBeNull()
+  })
+})

--- a/src/meeting/zoom-passcode.test.ts
+++ b/src/meeting/zoom-passcode.test.ts
@@ -35,16 +35,19 @@ describe("Zoom passcode failure classification", () => {
     }
   )
 
-  it("uses aria-invalid when Zoom omits helper text", () => {
-    expect(
-      classifyZoomPasscodeFailure(state({ value: "redacted", invalid: true }), "redacted")
-    ).toBe(MeetingEndReason.ZoomInvalidPasscode)
-  })
-
-  it("allows a supplied passcode to be filled before classifying it", () => {
+  it("does not trust retained aria-invalid without explicit rejection text", () => {
     expect(
       classifyZoomPasscodeFailure(
-        state({ invalid: true, errorText: "Meeting passcode is required" }),
+        state({ value: "redacted", invalid: true, errorText: "Meeting passcode is required" }),
+        "redacted"
+      )
+    ).toBeNull()
+  })
+
+  it("allows a supplied passcode to be filled before validation clears", () => {
+    expect(
+      classifyZoomPasscodeFailure(
+        state({ value: "redacted", invalid: true }),
         "redacted"
       )
     ).toBeNull()

--- a/src/meeting/zoom-passcode.ts
+++ b/src/meeting/zoom-passcode.ts
@@ -32,11 +32,5 @@ export function classifyZoomPasscodeFailure(
     return MeetingEndReason.ZoomInvalidPasscode
   }
 
-  // aria-invalid is useful when Zoom omits/link-breaks its helper text. Do not
-  // treat an empty field as invalid: it may still be waiting for our force-fill.
-  if (state.invalid && state.value.trim()) {
-    return MeetingEndReason.ZoomInvalidPasscode
-  }
-
   return null
 }

--- a/src/meeting/zoom-passcode.ts
+++ b/src/meeting/zoom-passcode.ts
@@ -1,0 +1,42 @@
+import { MeetingEndReason } from "../state-machine/types"
+
+export interface ZoomPasscodeDomState {
+  present: boolean
+  value: string
+  invalid: boolean
+  errorText: string
+}
+
+export const ZOOM_INVALID_PASSCODE_PATTERN =
+  /\b(?:incorrect|invalid|wrong)\b[\s\S]{0,32}\b(?:passcode|password)\b|\b(?:passcode|password)\b[\s\S]{0,32}\b(?:incorrect|invalid|wrong)\b/i.source
+
+const INVALID_PASSCODE_TEXT = new RegExp(ZOOM_INVALID_PASSCODE_PATTERN, "i")
+
+export type ZoomPasscodeFailureReason =
+  | MeetingEndReason.ZoomPasscodeRequired
+  | MeetingEndReason.ZoomInvalidPasscode
+
+/**
+ * Classify Zoom's pre-join passcode form without depending on Playwright's
+ * visibility result. Zoom can render this form while Firefox reports it as
+ * invisible, so callers collect raw DOM state and classify it here.
+ */
+export function classifyZoomPasscodeFailure(
+  state: ZoomPasscodeDomState,
+  suppliedPasscode: string
+): ZoomPasscodeFailureReason | null {
+  if (!state.present) return null
+  if (!suppliedPasscode) return MeetingEndReason.ZoomPasscodeRequired
+
+  if (INVALID_PASSCODE_TEXT.test(state.errorText)) {
+    return MeetingEndReason.ZoomInvalidPasscode
+  }
+
+  // aria-invalid is useful when Zoom omits/link-breaks its helper text. Do not
+  // treat an empty field as invalid: it may still be waiting for our force-fill.
+  if (state.invalid && state.value.trim()) {
+    return MeetingEndReason.ZoomInvalidPasscode
+  }
+
+  return null
+}

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -5,7 +5,7 @@ import { listenPage } from "../browser/page-logger"
 import { setZoomJoinHost } from "../proxy/toggle-proxy"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
-import { MeetingEndReason } from "../state-machine/types"
+import { getErrorMessageFromCode, MeetingEndReason } from "../state-machine/types"
 import type { MeetingProviderInterface } from "../types"
 import {
   buildZoomWebClientUrl,
@@ -17,6 +17,12 @@ import { formatError } from "../utils/Logger"
 import { createStateDetector } from "../utils/meeting-state-detector"
 import { sleep } from "../utils/sleep"
 import { getZoomEntryMessageSentAt } from "./zoom/entry-message-timing"
+import {
+  classifyZoomPasscodeFailure,
+  type ZoomPasscodeDomState,
+  type ZoomPasscodeFailureReason,
+  ZOOM_INVALID_PASSCODE_PATTERN
+} from "./zoom-passcode"
 import { ZOOM_STATE_CONFIG } from "./zoom-state-config"
 
 // Zoom Web Client selectors (verified against the live DOM). Two client variants
@@ -34,7 +40,7 @@ const LEAVE_BUTTON = 'button[aria-label="Leave"]'
 const LEAVE_CONFIRM = "button.leave-meeting-options__btn--danger"
 const PERMISSION_DISMISS = 'button:has-text("Continue without microphone and camera")'
 const PASSCODE_INPUT =
-  'input[placeholder*="passcode" i], input[placeholder*="password" i], input[type="password"]'
+  '#input-for-pwd, #input-for-passcode, #inputpasscode, #inputpwd, input[placeholder*="passcode" i], input[placeholder*="password" i], input[type="password"]'
 
 // Post-Join anti-bot wall phrases — scanned case-insensitively against body text.
 //
@@ -350,18 +356,27 @@ export class ZoomProvider implements MeetingProviderInterface {
       throw new Error("[Zoom] Pre-join name input never appeared")
     }
 
-    // Passcode: usually auto-applied from ?pwd= in the URL. If a passcode field
-    // is still visible, fill from the cached value, else fail fast (Join would
-    // stay disabled forever).
-    const passField = page.locator(PASSCODE_INPUT).first()
-    if (await passField.isVisible({ timeout: 1000 }).catch(() => false)) {
-      if (this.passcode) {
-        await passField.fill(this.passcode)
-        console.log("[Zoom] Filled passcode field")
-      } else {
-        GLOBAL.setError(MeetingEndReason.ZoomPasscodeRequired)
-        throw new Error("[Zoom] zoom_passcode_required: passcode field present, none supplied")
-      }
+    // A visible CAPTCHA takes priority over a coexisting passcode field: it is
+    // IP-reputation-driven and may clear on a regional retry.
+    const initialWall = await this.detectBotWall(page)
+    if (initialWall) {
+      GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+      throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${initialWall}`)
+    }
+
+    // Zoom can render its passcode form while Firefox reports the input as not
+    // visible/actionable. Read raw DOM state instead of using isVisible(), then
+    // force-fill a supplied passcode or fail immediately when it is missing.
+    let passcodeState = await this.readPasscodeState(page)
+    this.throwIfPasscodeBlocked(passcodeState)
+    if (passcodeState.present && this.passcode && !passcodeState.value) {
+      await page.locator(PASSCODE_INPUT).first().fill(this.passcode, {
+        force: true,
+        timeout: 3000
+      })
+      console.log("[Zoom] Filled passcode field")
+      passcodeState = await this.readPasscodeState(page)
+      this.throwIfPasscodeBlocked(passcodeState)
     }
 
     // Name entry via REAL keyboard events. A synthetic setter/input event does
@@ -385,7 +400,7 @@ export class ZoomProvider implements MeetingProviderInterface {
     }
 
     // Wait for Join to enable (React enables within ~1-2s of valid name).
-    await page
+    const joinEnabled = await page
       .waitForFunction(
         (sel: string) => {
           const btn = document.querySelector(sel) as HTMLButtonElement | null
@@ -394,7 +409,12 @@ export class ZoomProvider implements MeetingProviderInterface {
         JOIN_BUTTON,
         { timeout: 8000 }
       )
-      .catch(() => console.warn("[Zoom] Join still disabled after wait; attempting click anyway"))
+      .then(() => true)
+      .catch(() => false)
+    if (!joinEnabled) {
+      this.throwIfPasscodeBlocked(await this.readPasscodeState(page))
+      console.warn("[Zoom] Join still disabled after wait; attempting click anyway")
+    }
 
     // Mic: a recorder bot only RECEIVES audio, so mute it. But a bot with
     // streaming_input speaks INTO the meeting (its audio is pumped to the
@@ -473,7 +493,9 @@ export class ZoomProvider implements MeetingProviderInterface {
     console.log("[Zoom] Clicking Join (humanized mouse)...")
     let clicked = await humanClick(page, page.locator(JOIN_BUTTON).first())
     if (clicked) {
-      console.log("[Zoom] Join clicked (humanized mouse)")
+      // Mouse dispatch is not proof Zoom accepted a click: disabled buttons still
+      // receive pointer input. Admission/passcode state below confirms progress.
+      console.log("[Zoom] Join mouse input dispatched (humanized)")
     } else {
       try {
         await page.locator(JOIN_BUTTON).first().click({ force: true, timeout: 5000 })
@@ -493,7 +515,7 @@ export class ZoomProvider implements MeetingProviderInterface {
         }, JOIN_BUTTON)
         .catch(() => false)
     }
-    console.log("[Zoom] Join clicked — waiting for admission...")
+    console.log("[Zoom] Join input dispatched — waiting for admission...")
     await sleep(3000)
 
     await this.waitForAdmission(page, cancelCheck)
@@ -696,7 +718,6 @@ export class ZoomProvider implements MeetingProviderInterface {
       // at the modal until timeout.
       await this.dismissDisclaimer(page)
 
-      // Terminal anti-bot wall — can stream in a beat after Join. Non-retryable.
       // Anti-bot wall — can stream in a beat after Join. Retried on a fresh
       // exit IP (see main.ts handleFailedRecording), since the wall is
       // IP-reputation-driven rather than deterministic for this meeting.
@@ -705,6 +726,10 @@ export class ZoomProvider implements MeetingProviderInterface {
         GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
         throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
       }
+
+      // Missing/invalid passcodes leave the browser on the pre-join form. Check
+      // every poll because Zoom can show the rejection only after Join input.
+      this.throwIfPasscodeBlocked(await this.readPasscodeState(page))
 
       // Rejected / meeting ended.
       const denied = await zoomStateDetector.isDenied(page)
@@ -799,6 +824,52 @@ export class ZoomProvider implements MeetingProviderInterface {
     } catch {
       return null
     }
+  }
+
+  /**
+   * Read Zoom's passcode form directly from DOM. Playwright visibility is not
+   * reliable for these Firefox-rendered controls; body.innerText supplies the
+   * visible rejection even when aria-describedby is missing.
+   */
+  private async readPasscodeState(page: Page): Promise<ZoomPasscodeDomState> {
+    return page
+      .evaluate(({ selector, invalidPattern }): ZoomPasscodeDomState => {
+        const field = document.querySelector(selector) as HTMLInputElement | null
+        if (!field) {
+          return { present: false, value: "", invalid: false, errorText: "" }
+        }
+
+        const describedText = (field.getAttribute("aria-describedby") || "")
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((id) => document.getElementById(id)?.textContent || "")
+          .join(" ")
+        const directError =
+          document.querySelector("#error-for-pwd, #error-for-passcode")?.textContent || ""
+        const bodyText = document.body?.innerText || ""
+        const explicitError =
+          bodyText.match(new RegExp(invalidPattern, "i"))?.[0] || ""
+
+        return {
+          present: true,
+          value: field.value || "",
+          invalid: field.getAttribute("aria-invalid") === "true",
+          errorText: [describedText, directError, explicitError].filter(Boolean).join(" ")
+        }
+      }, { selector: PASSCODE_INPUT, invalidPattern: ZOOM_INVALID_PASSCODE_PATTERN })
+      .catch(() => ({ present: false, value: "", invalid: false, errorText: "" }))
+  }
+
+  /** Route deterministic passcode failures through centralized end-reason handling. */
+  private throwIfPasscodeBlocked(state: ZoomPasscodeDomState): void {
+    const reason = classifyZoomPasscodeFailure(state, this.passcode)
+    if (!reason) return
+    this.throwPasscodeFailure(reason)
+  }
+
+  private throwPasscodeFailure(reason: ZoomPasscodeFailureReason): never {
+    GLOBAL.setError(reason)
+    throw new Error(`[Zoom] ${getErrorMessageFromCode(reason)}`)
   }
 
   /**

--- a/src/proxy/toggle-proxy.test.ts
+++ b/src/proxy/toggle-proxy.test.ts
@@ -1,4 +1,9 @@
-import { resolveProxyCountriesForAttempt, setZoomJoinHost, shouldProxy } from "./toggle-proxy"
+import {
+  resolveGeoAwareProxyTemplate,
+  resolveProxyCountriesForAttempt,
+  setZoomJoinHost,
+  shouldProxy
+} from "./toggle-proxy"
 
 // Keep country rotation deterministic. Allowlist tests remain platform-agnostic.
 jest.mock("../singleton", () => ({
@@ -10,6 +15,43 @@ jest.mock("../singleton", () => ({
 beforeEach(() => setZoomJoinHost("app.zoom.us"))
 
 describe("residential proxy host selection", () => {
+  describe("legacy Decodo geo templates", () => {
+    it("adds the geo slot before the session marker", () => {
+      expect(
+        resolveGeoAwareProxyTemplate(
+          "https://user-zone-session-{SESSION}:secret@isp.decodo.com:10000"
+        )
+      ).toBe("https://user-zone{GEO}-session-{SESSION}:secret@isp.decodo.com:10000")
+    })
+
+    it("preserves an explicit geo slot", () => {
+      const template =
+        "https://user-zone{GEO}-session-{SESSION}:secret@isp.decodo.com:10000"
+      expect(resolveGeoAwareProxyTemplate(template)).toBe(template)
+    })
+
+    it("does not rewrite unknown providers or username shapes", () => {
+      expect(
+        resolveGeoAwareProxyTemplate(
+          "https://user-zone-session-{SESSION}:secret@proxy.example.com:10000"
+        )
+      ).toBe("https://user-zone-session-{SESSION}:secret@proxy.example.com:10000")
+      expect(resolveGeoAwareProxyTemplate("https://user:secret@isp.decodo.com:10000")).toBe(
+        "https://user:secret@isp.decodo.com:10000"
+      )
+      expect(
+        resolveGeoAwareProxyTemplate(
+          "https://user:secret-session-{SESSION}@isp.decodo.com:10000"
+        )
+      ).toBe("https://user:secret-session-{SESSION}@isp.decodo.com:10000")
+      expect(
+        resolveGeoAwareProxyTemplate(
+          "https://user-zone-session-{SESSION}:secret@evildecodo.com:10000"
+        )
+      ).toBe("https://user-zone-session-{SESSION}:secret@evildecodo.com:10000")
+    })
+  })
+
   it("advances the bot-stable country order for each join attempt", () => {
     const initial = resolveProxyCountriesForAttempt(0)
 

--- a/src/proxy/toggle-proxy.ts
+++ b/src/proxy/toggle-proxy.ts
@@ -200,6 +200,38 @@ export function resolveProxyCountriesForAttempt(countryOffset = 0): string[] {
 }
 
 /**
+ * Older Decodo templates predate per-bot geo selection and only expose the
+ * session marker. Upgrade that known username shape in memory so deployed
+ * secrets keep working without silently disabling country rotation.
+ */
+export function resolveGeoAwareProxyTemplate(template: string): string {
+  if (!template || template.includes("{GEO}")) return template
+
+  try {
+    const hostname = new URL(template).hostname.toLowerCase()
+    if (hostname !== "decodo.com" && !hostname.endsWith(".decodo.com")) return template
+  } catch {
+    return template
+  }
+
+  const sessionMarker = "-session-{SESSION}"
+  const markerIndex = template.indexOf(sessionMarker)
+  const credentialsStart = template.indexOf("://") + 3
+  const passwordSeparator = template.indexOf(":", credentialsStart)
+  const credentialsEnd = template.lastIndexOf("@")
+  if (
+    markerIndex < credentialsStart ||
+    passwordSeparator < credentialsStart ||
+    credentialsEnd < passwordSeparator ||
+    markerIndex >= passwordSeparator
+  ) {
+    return template
+  }
+
+  return `${template.slice(0, markerIndex)}{GEO}${template.slice(markerIndex)}`
+}
+
+/**
  * Spread a multi-region pin across the team's selected regions instead of
  * funneling every bot through the first entry. When a customer batch-launches
  * hundreds of bots, all starting on regions[0] concentrates them on one
@@ -358,29 +390,27 @@ export async function startToggleProxy(
   const session = `${sessionId.replace(/-/g, "")}${retryCount}${sessionSuffix}`
 
   // Optional geo pinning. Decodo username params are dash-appended and go
-  // BEFORE `-session-`, so the template must carry a `{GEO}` placeholder there
+  // BEFORE `-session-`, so the template carries a `{GEO}` placeholder there
   // (e.g. `user-<u>{GEO}-session-{SESSION}`). Resolve the country from the
   // per-bot region the user picked in settings, falling back to the env
   // default, then to a rotated DEFAULT_PROXY_COUNTRIES candidate set (see
   // resolveProxyCountries) -- "no pinning" only happens via skipGeoPin, an
   // empty per-bot/env value no longer means unpinned. Only alpha-2 letters
   // are accepted so a bad value can't corrupt the auth string.
-  // Without a {GEO} placeholder, every country produces the identical
-  // upstreamUrl -- cycling countries on failure would just re-probe the same
-  // dead endpoint N times (up to len(DEFAULT_PROXY_COUNTRIES) retries, ~45s).
-  // Treat as unpinned up front so a failed probe below falls straight through
-  // to "give up", not a country-by-country retry loop that can't ever help.
-  const hasGeoPlaceholder = envVars.RESIDENTIAL_PROXY_TEMPLATE.includes("{GEO}")
+  // Legacy Decodo templates that only have `-session-{SESSION}` are upgraded in
+  // memory. Unknown provider/template shapes remain unpinned rather than being
+  // rewritten speculatively.
+  const proxyTemplate = resolveGeoAwareProxyTemplate(envVars.RESIDENTIAL_PROXY_TEMPLATE)
+  const hasGeoPlaceholder = proxyTemplate.includes("{GEO}")
   const country =
     opts.skipGeoPin || !hasGeoPlaceholder
       ? ""
       : pickProxyCountry(opts.triedCountries ?? [], opts.countryOffset)
   const geoParam = country ? `-country-${country}` : ""
-  const upstreamUrl = envVars.RESIDENTIAL_PROXY_TEMPLATE.replaceAll("{SESSION}", session).replaceAll(
-    "{GEO}",
-    geoParam
-  )
-  if (country && envVars.RESIDENTIAL_PROXY_TEMPLATE.includes("{GEO}")) {
+  const upstreamUrl = proxyTemplate
+    .replaceAll("{SESSION}", session)
+    .replaceAll("{GEO}", geoParam)
+  if (country && hasGeoPlaceholder) {
     console.log(`[ToggleProxy] 🌍 Pinning residential exit to country: ${country}`)
   }
   currentSessionId = session

--- a/src/singleton-error.test.ts
+++ b/src/singleton-error.test.ts
@@ -1,0 +1,18 @@
+import { GLOBAL } from "./singleton"
+import { getErrorMessageFromCode, MeetingEndReason } from "./state-machine/types"
+
+describe("Global error replacement", () => {
+  beforeEach(() => GLOBAL.resetErrorState())
+  afterEach(() => GLOBAL.resetErrorState())
+
+  it("replaces a protected terminal reason when stronger evidence exists", () => {
+    GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
+
+    GLOBAL.replaceError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+
+    expect(GLOBAL.getEndReason()).toBe(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+    expect(GLOBAL.getErrorMessage()).toBe(
+      getErrorMessageFromCode(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+    )
+  })
+})

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -161,6 +161,17 @@ class Global {
     console.log(`🔴 End reason set to: ${this.endReason}`)
   }
 
+  /**
+   * Replace an existing error even when its reason is normally protected from
+   * cleanup-time overrides. Use only when stronger evidence resolves the final
+   * failure reason; ordinary callers must keep using setError().
+   */
+  public replaceError(reason: MeetingEndReason, message?: string): void {
+    this.endReason = null
+    this.errorMessage = null
+    this.setError(reason, message)
+  }
+
   public setEndReason(reason: MeetingEndReason): void {
     console.log(`🔵 Setting global end reason: ${reason}`)
     this.endReason = reason

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -175,6 +175,10 @@ export class WaitingRoomState extends BaseState {
           // TimeoutWaitingToStart and stops.
           MeetingEndReason.ExitingMeetingBeforeRecord,
           MeetingEndReason.BotNotAccepted,
+          // Passcode failures are deterministic for this join URL; another
+          // browser, IP, or region cannot repair missing/invalid credentials.
+          MeetingEndReason.ZoomPasscodeRequired,
+          MeetingEndReason.ZoomInvalidPasscode,
           // Registration-required webinar: the join URL server-side-redirects to
           // zoom.us/webinar/register/ for every pod/IP — retrying can never help.
           MeetingEndReason.ZoomWebinarRegistrationRequired

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -239,7 +239,7 @@ export class WaitingRoomState extends BaseState {
         console.warn(
           `[Zoom] Preserving confirmed ${resolvedReason} over later ${latestReason ?? "unknown"} failure`
         )
-        GLOBAL.setError(resolvedReason)
+        GLOBAL.replaceError(resolvedReason)
         GLOBAL.setShouldRetry(true)
       }
     }

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -6,6 +6,7 @@ import {
 } from "../../browser/browser-session"
 import { IN_PROCESS_RETRY_MAX } from "../../config/retry-config"
 import { Events } from "../../events"
+import { resolveZoomJoinFailureReason } from "../../meeting/zoom-join-failure"
 import { ScreenRecorderManager } from "../../recording/ScreenRecorder"
 import { HtmlSnapshotService } from "../../services/html-snapshot-service"
 import { GLOBAL } from "../../singleton"
@@ -225,6 +226,19 @@ export class WaitingRoomState extends BaseState {
   private async joinWithInProcessRetry(meetingLink: string): Promise<void> {
     const isZoom = GLOBAL.get().meeting_platform === "zoom"
     const maxInProc = isZoom ? IN_PROCESS_RETRY_MAX : 0
+    let confirmedBotWall: MeetingEndReason.ZoomAnonymousJoinNotAllowed | null = null
+
+    const restoreConfirmedBotWall = (): void => {
+      const latestReason = GLOBAL.getEndReason()
+      const resolvedReason = resolveZoomJoinFailureReason(confirmedBotWall, latestReason)
+      if (resolvedReason === confirmedBotWall && resolvedReason !== latestReason) {
+        console.warn(
+          `[Zoom] Preserving confirmed ${resolvedReason} over later ${latestReason ?? "unknown"} failure`
+        )
+        GLOBAL.setError(resolvedReason)
+        GLOBAL.setShouldRetry(true)
+      }
+    }
 
     for (let attempt = 0; ; attempt++) {
       try {
@@ -273,12 +287,18 @@ export class WaitingRoomState extends BaseState {
         return
       } catch (error) {
         const reason = GLOBAL.getEndReason()
+        if (reason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) {
+          confirmedBotWall = reason
+        }
         // Only the IP-reputation wall is worth an in-process relaunch; every other
         // reason (invalid URL, host denial, passcode, timeout) is not IP-keyed and
         // must fall through to the outer catch → SQS requeue / terminal failure.
         const canInProcessRetry =
           attempt < maxInProc && reason === MeetingEndReason.ZoomAnonymousJoinNotAllowed
-        if (!canInProcessRetry) throw error
+        if (!canInProcessRetry) {
+          restoreConfirmedBotWall()
+          throw error
+        }
 
         console.log(
           `[Zoom] Anti-bot wall (${reason}) — in-process retry ${attempt + 1}/${maxInProc} on a fresh exit IP`
@@ -288,11 +308,16 @@ export class WaitingRoomState extends BaseState {
         GLOBAL.resetErrorState()
         // Recycle browser + proxy onto a new Decodo session id (suffix "x<n>") →
         // the next configured region and a different residential exit IP.
-        await teardownBrowserSession(this.context)
-        await establishBrowserSession(this.context, {
-          sessionSuffix: `x${attempt + 1}`,
-          inProcessAttempt: attempt + 1
-        })
+        try {
+          await teardownBrowserSession(this.context)
+          await establishBrowserSession(this.context, {
+            sessionSuffix: `x${attempt + 1}`,
+            inProcessAttempt: attempt + 1
+          })
+        } catch (relaunchError) {
+          restoreConfirmedBotWall()
+          throw relaunchError
+        }
       }
     }
   }

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -46,6 +46,7 @@ export enum MeetingEndReason {
   // SDK. Maps to the api-server's ZOOM_ANONYMOUS_JOIN_NOT_ALLOWED error code.
   ZoomAnonymousJoinNotAllowed = "zoomAnonymousJoinNotAllowed",
   ZoomPasscodeRequired = "zoomPasscodeRequired",
+  ZoomInvalidPasscode = "zoomInvalidPasscode",
   // The /wc/<id>/join URL server-side-redirected to zoom.us/webinar/register/… :
   // the webinar requires per-registrant registration (name+email → personal tk=
   // link), so an anonymous join can never succeed from any pod/IP. Terminal.
@@ -104,6 +105,8 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "This Zoom meeting rejected the recording bot because it joined anonymously — the host's account blocks anonymous/automated browser joins. We recommend recording it via Zoom RTMS (or the native SDK with a user-authorized credential)."
     case MeetingEndReason.ZoomPasscodeRequired:
       return "Zoom meeting requires a passcode that was not supplied in the meeting URL (?pwd=)."
+    case MeetingEndReason.ZoomInvalidPasscode:
+      return "Zoom rejected the passcode supplied in the meeting URL. Use a join link containing the current passcode."
     case MeetingEndReason.ZoomWebinarRegistrationRequired:
       return "This Zoom webinar requires registration: Zoom redirected the join URL to its registration page, so the bot cannot join anonymously. Register the bot first and use the personalized join link (tk=) from the confirmation, or disable required registration for the webinar."
     case MeetingEndReason.TeamsLoginFailedInvalidCredentials:


### PR DESCRIPTION
## Summary
- Preserve confirmed Zoom anonymous or automated-bot denials when later relaunches only produce generic failures.
- Rotate legacy Decodo sessions across configured regions correctly.
- Detect Zoom passcode forms from raw DOM state because Firefox visibility checks can false-negative.
- Fail fast with centralized zoomPasscodeRequired or zoomInvalidPasscode reasons; both are terminal and do not burn browser, region, or SQS retries.
- Keep visible CAPTCHA or anti-bot walls higher priority than passcode forms.

## Production evidence
A 72-hour production audit found eight never-admitted browser joins previously surfaced as generic timeouts. Retained HTML proved four had an empty required passcode field and four had aria-invalid=true with an Incorrect Password error. No visible smart-CAPTCHA DOM signal existed in those eight cases.

Other joins did show explicit anti-bot evidence. This change preserves that evidence across retry attempts without inventing CAPTCHA classifications.

## Verification
- 3 focused Jest suites passed, 36 tests total
- TypeScript release type-check passed
- git diff --check passed

Coordinated centralized API mapping: Meeting-BaaS/meeting-baas-v2#474.