### PR TITLE
fix: cap the boot-gap retrofit at the greeting window (300s → 20s)

### DIFF
--- a/src/diarization-tracker.test.ts
+++ b/src/diarization-tracker.test.ts
@@ -285,13 +285,13 @@ describe("DiarizationTracker final re-assembly", () => {
     // closes the previous segment at the new event's time), so the only
     // structural hole a live meeting produces is the leading one: network's
     // first event here lands at 90s, leaving 0→90 uncovered. The muted UI
-    // observer saw Jonny speaking at 40→80 inside that window.
+    // observer saw Jonny speaking at 12→80 inside that window.
     tracker.updateSpeaker(speech("dev-a", "Amr El Shimy", 90), MEETING_START)
 
     await tracker.end(MEETING_START + 100_000, MEETING_START, undefined, undefined, [
       {
         kind: "ui",
-        segments: [{ speaker: "Jonny", user_id: 0, start_time: 40, end_time: 80 }]
+        segments: [{ speaker: "Jonny", user_id: 0, start_time: 12, end_time: 80 }]
       }
     ])
 

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -77,8 +77,8 @@ describe("assembleSpeakerTimeline", () => {
   it("never lets a fallback contribute an Unknown segment", () => {
     const { segments } = assembleSpeakerTimeline(
       [
-        { kind: "network", segments: [seg("Amr", 100, 200)] },
-        { kind: "ui", segments: [seg("Unknown", 0, 90, 0)] }
+        { kind: "network", segments: [seg("Amr", 15, 200)] },
+        { kind: "ui", segments: [seg("Unknown", 0, 12, 0)] }
       ],
       200
     )
@@ -110,7 +110,7 @@ describe("assembleSpeakerTimeline", () => {
       [
         {
           kind: "network",
-          segments: [seg("Unknown", 5, 20, 0), seg("Amr", 30, 100)]
+          segments: [seg("Unknown", 5, 15, 0), seg("Amr", 18, 100)]
         }
       ],
       100
@@ -195,13 +195,13 @@ describe("assembleSpeakerTimeline bot exclusion", () => {
       [
         {
           kind: "network",
-          segments: [seg("MeetingBaaS's Notetaker", 7, 14), seg("Amr", 30, 100)]
+          segments: [seg("MeetingBaaS's Notetaker", 7, 14), seg("Amr", 18, 100)]
         }
       ],
       100,
       { botNames: ["MeetingBaaS's Notetaker"] }
     )
-    expect(retrofittedFromSeconds).toBe(30)
+    expect(retrofittedFromSeconds).toBe(18)
     expect(segments.find((s) => s.speaker === "Amr")?.start_time).toBe(0)
     expect(segments.find((s) => s.speaker === "MeetingBaaS's Notetaker")).toEqual(
       seg("MeetingBaaS's Notetaker", 7, 14)
@@ -216,13 +216,13 @@ describe("assembleSpeakerTimeline multi-name bot exclusion", () => {
       [
         {
           kind: "network",
-          segments: [seg("MeetingBaaS's Notetaker", 7, 14), seg("Amr", 30, 100)]
+          segments: [seg("MeetingBaaS's Notetaker", 7, 14), seg("Amr", 18, 100)]
         }
       ],
       100,
       { botNames: ["Amr's Notetaker", "MeetingBaaS's Notetaker"] }
     )
-    expect(retrofittedFromSeconds).toBe(30)
+    expect(retrofittedFromSeconds).toBe(18)
     expect(segments.find((s) => s.speaker === "Amr")?.start_time).toBe(0)
   })
 })

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -240,3 +240,23 @@ describe("assembleSpeakerTimeline retrofit cap", () => {
     expect(segments[0]).toEqual(seg("Guest", 146.6, 147.6))
   })
 })
+
+describe("assembleSpeakerTimeline retrofit cap boundary", () => {
+  it("retrofits a first segment opening exactly at the cap", () => {
+    const { retrofittedFromSeconds } = assembleSpeakerTimeline(
+      [{ kind: "network", segments: [seg("Opener", LEADING_RETROFIT_MAX_SECONDS, 60)] }],
+      60
+    )
+    expect(retrofittedFromSeconds).toBe(LEADING_RETROFIT_MAX_SECONDS)
+  })
+
+  it("does not retrofit a first segment opening just past the cap", () => {
+    const start = LEADING_RETROFIT_MAX_SECONDS + 0.1
+    const { segments, retrofittedFromSeconds } = assembleSpeakerTimeline(
+      [{ kind: "network", segments: [seg("Opener", start, 60)] }],
+      60
+    )
+    expect(retrofittedFromSeconds).toBeUndefined()
+    expect(segments[0]?.start_time).toBe(start)
+  })
+})

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -90,7 +90,7 @@ describe("assembleSpeakerTimeline", () => {
     // Prod case 8db02fee: first utterance ("Grazie.") at 6.1s, first
     // diarization segment much later — the greeting surfaced as Unknown.
     const { segments } = assembleSpeakerTimeline(
-      [{ kind: "network", segments: [seg("Opener", 144, 300), seg("Guest", 300, 400)] }],
+      [{ kind: "network", segments: [seg("Opener", 14, 300), seg("Guest", 300, 400)] }],
       400
     )
     expect(segments[0]).toEqual(seg("Opener", 0, 300))
@@ -172,10 +172,10 @@ describe("assembleSpeakerTimeline", () => {
 describe("assembleSpeakerTimeline retrofit reporting", () => {
   it("reports the original start the retrofit stretched from", () => {
     const { retrofittedFromSeconds } = assembleSpeakerTimeline(
-      [{ kind: "network", segments: [seg("Opener", 144, 300)] }],
+      [{ kind: "network", segments: [seg("Opener", 14, 300)] }],
       300
     )
-    expect(retrofittedFromSeconds).toBe(144)
+    expect(retrofittedFromSeconds).toBe(14)
   })
 
   it("reports nothing when no retrofit happened", () => {
@@ -224,5 +224,19 @@ describe("assembleSpeakerTimeline multi-name bot exclusion", () => {
     )
     expect(retrofittedFromSeconds).toBe(30)
     expect(segments.find((s) => s.speaker === "Amr")?.start_time).toBe(0)
+  })
+})
+
+
+describe("assembleSpeakerTimeline retrofit cap", () => {
+  it("does not stretch a first segment that opens later than the greeting window", () => {
+    // Prod bot 013722ff: the guest's lone ~1s segment at +146.6s was stretched
+    // to 0s, inflating his talk-time to 147s and masking a collapse downstream.
+    const { segments, retrofittedFromSeconds } = assembleSpeakerTimeline(
+      [{ kind: "network", segments: [seg("Guest", 146.6, 147.6), seg("Host", 147.6, 2400)] }],
+      2400
+    )
+    expect(retrofittedFromSeconds).toBeUndefined()
+    expect(segments[0]).toEqual(seg("Guest", 146.6, 147.6))
   })
 })

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -243,11 +243,12 @@ describe("assembleSpeakerTimeline retrofit cap", () => {
 
 describe("assembleSpeakerTimeline retrofit cap boundary", () => {
   it("retrofits a first segment opening exactly at the cap", () => {
-    const { retrofittedFromSeconds } = assembleSpeakerTimeline(
+    const { segments, retrofittedFromSeconds } = assembleSpeakerTimeline(
       [{ kind: "network", segments: [seg("Opener", LEADING_RETROFIT_MAX_SECONDS, 60)] }],
       60
     )
     expect(retrofittedFromSeconds).toBe(LEADING_RETROFIT_MAX_SECONDS)
+    expect(segments[0]?.start_time).toBe(0)
   })
 
   it("does not retrofit a first segment opening just past the cap", () => {

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -22,9 +22,13 @@ export interface TimelineSource {
 export const GAP_FILL_MIN_SECONDS = 10
 // Minimum length a clipped contribution must keep to be emitted.
 export const MIN_SEGMENT_SECONDS = 1
-// Cap on stretching the first segment back over the boot gap; a first segment
-// later than this means something else broke.
-export const LEADING_RETROFIT_MAX_SECONDS = 300
+// Cap on stretching the first segment back over the boot gap. The gap this
+// exists for is the join greeting (prod: median 3.5s, all observed cases
+// <=21s). A larger stretch inflates a barely-heard participant's talk-time
+// (prod: 1s -> 147s) past the reconciliation's "effective speaker" floor and
+// masked a real collapse; longer leading gaps are the reconciliation's job
+// (label-only backfill), never the timeline's.
+export const LEADING_RETROFIT_MAX_SECONDS = 20
 
 /** Positive-length segments, chronological. */
 function normalize(segments: DiarizationSegment[]): DiarizationSegment[] {


### PR DESCRIPTION
One constant, one regression test.

The retrofit exists for the join greeting — prod distribution: median 3.5s, every observed leading-"Unknown" case ≤21s. With a 300s cap it stretched a guest's lone ~1s segment at +146.6s to 0s on bot `013722ff`, inflating his talk-time to 147s — past the reconciliation's 15s "effective speaker" floor — so a shared-microphone call looked healthy, never reached provider separation, and the guest's **1,198s were labeled as the host**. 5/23 sampled prod bots stretched >30s (max 198s).

Cap → 20s. Leading gaps beyond the greeting become the reconciliation's job (label-only backfill, Meeting-BaaS/meeting-baas-v2#475), which has no timeline side effects.

With this + #467 + #475 in prod, `013722ff` resolves to host + guest by name. Tests: 43 green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYnNopP8vcijmTvpjJJK7W