### PR TITLE
fix(teams): recognise Teams by URL shape

### DIFF
--- a/src/urlParser/teamsUrlParser.test.ts
+++ b/src/urlParser/teamsUrlParser.test.ts
@@ -143,4 +143,49 @@ describe("Teams URL Parser", () => {
       expect(result.password).toBe("")
     })
   })
+
+  // Teams is recognized by URL shape, not by a hostname list: sovereign and
+  // national partner clouds (teams.sovcloud.fr) and the unified Microsoft 365
+  // domain run the same client on their own origin, and every rewrite has to
+  // stay on that origin.
+  describe("Other Teams clouds", () => {
+    test.each([
+      "https://teams.sovcloud.fr/meet/1234567890",
+      "https://teams.cloud.microsoft/meet/1234567890",
+      "https://teams.some-future-cloud.example/meet/1234567890"
+    ])("passes a short join code through unchanged: %s", (url) => {
+      const result = parseMeetingUrlFromJoinInfos(url)
+      expect(result.meetingId).toBe(url)
+    })
+
+    test("rewrites a deep link onto its OWN origin, not teams.microsoft.com", () => {
+      const url =
+        "https://teams.sovcloud.fr/l/meetup-join/19:meeting_123@thread.v2/0?context=%7B%22Tid%22%3A%22abc%22%7D"
+      const result = parseMeetingUrlFromJoinInfos(url)
+
+      expect(result.meetingId.startsWith("https://teams.sovcloud.fr/v2/?meetingjoin=true#/")).toBe(
+        true
+      )
+      expect(result.meetingId).not.toContain("teams.microsoft.com")
+      expect(result.meetingId.endsWith("&anon=true")).toBe(true)
+    })
+
+    test("keeps the passcode from the query string", () => {
+      const result = parseMeetingUrlFromJoinInfos("https://teams.sovcloud.fr/meet/123?p=secret")
+      expect(result.password).toBe("secret")
+    })
+
+    test("accepts a deep link on a host that does not say teams at all", () => {
+      const url = "https://meetings.example.gov/l/meetup-join/19:meeting_9@thread.v2/0"
+      expect(parseMeetingUrlFromJoinInfos(url).meetingId).toBe(url)
+    })
+  })
+
+  describe("SafeLinks-wrapped URLs", () => {
+    test("unwraps the Outlook rewrite before parsing", () => {
+      const inner = "https://teams.sovcloud.fr/meet/1234567890"
+      const wrapped = `https://eur01.safelinks.protection.outlook.com/?url=${encodeURIComponent(inner)}&data=05%7C01`
+      expect(parseMeetingUrlFromJoinInfos(wrapped).meetingId).toBe(inner)
+    })
+  })
 })

--- a/src/urlParser/teamsUrlParser.ts
+++ b/src/urlParser/teamsUrlParser.ts
@@ -7,6 +7,48 @@ interface TeamsUrlComponents {
   password: string
 }
 
+/**
+ * Teams is not served from a fixed set of hostnames and never will be again.
+ * Besides the global cloud and personal Teams, meetings arrive on the unified
+ * Microsoft 365 domain (teams.cloud.microsoft) and on the sovereign / national
+ * partner clouds, which run the same web client on their own domain
+ * (teams.sovcloud.fr in France, with more announced across the EU). A hostname
+ * allowlist makes every new one a support ticket, so recognize Teams by URL
+ * SHAPE and use the hostname only as a hint.
+ *
+ * Keep this in step with isTeamsUrl in the API server's utils/meeting-url.ts:
+ * a URL accepted there but rejected here reaches the bot and dies on
+ * "Invalid Teams URL" instead.
+ */
+const TEAMS_PATH_SHAPES = [
+  /^\/l\//, // deep links: /l/meetup-join/, /l/meeting/…
+  /^\/v2\//, // the join format transformTeamsLink rewrites to
+  /^\/meet\//, // short join codes
+  /^\/dl\/launcher\//, // launcher shell
+  /\/light-meetings\/launch/ // personal/free Teams launcher
+]
+
+export function isTeamsUrl(url: URL): boolean {
+  const path = url.pathname.toLowerCase()
+  // The classic web client keeps the deep link in the FRAGMENT
+  // (teams.microsoft.com/_#/l/meetup-join/…), so the signature has to include it.
+  const signature = `${path}${url.hash.toLowerCase()}`
+
+  // Unmistakably Teams on ANY host — this is what makes the next sovereign
+  // cloud work without a code change.
+  if (signature.includes("/l/meetup-join/") || signature.includes("/light-meetings/launch")) {
+    return true
+  }
+
+  // The remaining shapes are generic enough to need a host that names Teams.
+  // The path check is what keeps teams.zoom.us (a Zoom vanity host carrying a
+  // "teams" label) out.
+  const namesTeams = url.hostname.toLowerCase().split(".").includes("teams")
+  return namesTeams && TEAMS_PATH_SHAPES.some((shape) => shape.test(path))
+}
+
+const SAFELINKS_WRAPPER = /^https:\/\/[^/]*safelinks\.protection\.outlook\.com\//i
+
 function convertLightMeetingToStandard(url: URL): string {
   const coords = url.searchParams.get("coords")
   if (!coords) {
@@ -33,7 +75,10 @@ function convertLightMeetingToStandard(url: URL): string {
 
     // Authenticated bots join as the signed-in user; only anonymous bots pass anon=true.
     const anonSuffix = GLOBAL.get().teams_login_config ? "" : "&anon=true"
-    return `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${conversationId}/${messageId}?context=${encodeURIComponent(JSON.stringify(context))}${anonSuffix}`
+    // url.origin, not a hard-coded teams.microsoft.com: a sovereign-cloud link
+    // rewritten onto the global cloud points the bot at a tenant that does not
+    // exist there.
+    return `${url.origin}/v2/?meetingjoin=true#/l/meetup-join/${conversationId}/${messageId}?context=${encodeURIComponent(JSON.stringify(context))}${anonSuffix}`
   } catch (e) {
     console.error("🥕❌ Error converting light meeting URL:", formatError(e))
     GLOBAL.setError(MeetingEndReason.InvalidMeetingUrl)
@@ -64,9 +109,10 @@ function transformTeamsLink(originalLink: string): string {
       return convertLightMeetingToStandard(url)
     }
 
-    // Extract the important parts from the original URL
-    const regex =
-      /https:\/\/teams\.microsoft\.com\/l\/meetup-join\/(.*?)\/(\d+)\?context=(.*?)(?:$|&)/
+    // Extract the important parts from the original URL. Host-agnostic on
+    // purpose: the same deep link is served by every Teams cloud, only the
+    // origin differs.
+    const regex = /\/l\/meetup-join\/(.*?)\/(\d+)\?context=(.*?)(?:$|&)/
     const match = originalLink.match(regex)
 
     if (!match || match.length < 4) {
@@ -75,10 +121,10 @@ function transformTeamsLink(originalLink: string): string {
 
     const [_, threadId, timestamp, context] = match
 
-    // Build the working link format. Authenticated bots join as the signed-in user;
-    // only anonymous bots pass anon=true.
+    // Build the working link format on the URL's OWN origin. Authenticated bots
+    // join as the signed-in user; only anonymous bots pass anon=true.
     const anonSuffix = GLOBAL.get().teams_login_config ? "" : "&anon=true"
-    return `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${threadId}/${timestamp}?context=${context}${anonSuffix}`
+    return `${url.origin}/v2/?meetingjoin=true#/l/meetup-join/${threadId}/${timestamp}?context=${context}${anonSuffix}`
   } catch (error) {
     console.error("Error transforming Teams link:", formatError(error))
     return originalLink
@@ -95,10 +141,15 @@ export function parseMeetingUrlFromJoinInfos(meeting_url: string): TeamsUrlCompo
 
     console.log("Parsing meeting URL:", transformed_meeting_url)
 
-    // Handle Google redirect URLs
+    // Unwrap redirect wrappers: Google's redirect, and Microsoft Defender
+    // SafeLinks, which rewrites every link in an Outlook invite — the wrapper's
+    // hostname is all a host check would ever see.
     if (transformed_meeting_url.startsWith("https://www.google.com/url")) {
       const url = new URL(transformed_meeting_url)
       transformed_meeting_url = url.searchParams.get("q") || transformed_meeting_url
+    } else if (SAFELINKS_WRAPPER.test(transformed_meeting_url)) {
+      const url = new URL(transformed_meeting_url)
+      transformed_meeting_url = url.searchParams.get("url") || transformed_meeting_url
     }
 
     // Decode URL if needed
@@ -108,8 +159,10 @@ export function parseMeetingUrlFromJoinInfos(meeting_url: string): TeamsUrlCompo
 
     const url = new URL(transformed_meeting_url)
 
-    // Handle teams.live.com URLs
-    if (url.hostname.includes("teams.live.com")) {
+    // Personal / free Teams keeps its own branch: its launcher formats
+    // (dl/launcher, light-meetings with a meetingCode) are specific to that
+    // product, not to the hostname.
+    if (url.hostname.endsWith("teams.live.com")) {
       // Handle launcher/deep-link wrapper URLs
       // e.g. teams.live.com/dl/launcher/launcher.html?url=/_#/meet/123?p=abc&anon=true
       if (url.pathname.startsWith("/dl/launcher/")) {
@@ -118,7 +171,7 @@ export function parseMeetingUrlFromJoinInfos(meeting_url: string): TeamsUrlCompo
           const meetMatch = embeddedPath.match(/\/meet\/(\d+)/)
           const pMatch = embeddedPath.match(/[?&]p=([^&]+)/)
           if (meetMatch) {
-            const directUrl = `https://teams.live.com/meet/${meetMatch[1]}${pMatch ? `?p=${pMatch[1]}&anon=true` : "?anon=true"}`
+            const directUrl = `${url.origin}/meet/${meetMatch[1]}${pMatch ? `?p=${pMatch[1]}&anon=true` : "?anon=true"}`
             console.log(`Detected Teams launcher URL, resolved to: ${directUrl}`)
             return {
               meetingId: directUrl,
@@ -140,7 +193,7 @@ export function parseMeetingUrlFromJoinInfos(meeting_url: string): TeamsUrlCompo
             const decoded = JSON.parse(atob(coords))
             if (decoded.meetingCode) {
               const passcode = decoded.passcode || url.searchParams.get("p") || ""
-              const directUrl = `https://teams.live.com/meet/${decoded.meetingCode}${passcode ? `?p=${passcode}&anon=true` : "?anon=true"}`
+              const directUrl = `${url.origin}/meet/${decoded.meetingCode}${passcode ? `?p=${passcode}&anon=true` : "?anon=true"}`
               console.log(`Detected Teams light-meetings launcher URL, resolved to: ${directUrl}`)
               return {
                 meetingId: directUrl,
@@ -166,17 +219,21 @@ export function parseMeetingUrlFromJoinInfos(meeting_url: string): TeamsUrlCompo
       }
     }
 
-    // Handle teams.microsoft.com URLs
-    if (url.hostname.includes("teams.microsoft.com")) {
+    // Every other Teams cloud — the global one, the unified Microsoft 365
+    // domain, and the sovereign / national partner clouds — serves the same web
+    // client, so match on shape instead of on a hostname list. transformTeamsLink
+    // rewrites onto the URL's own origin, so a sovereign link stays on its own
+    // cloud; a URL it does not recognize is returned untouched, which is already
+    // how raw /meet/<code> links are handled.
+    if (isTeamsUrl(url)) {
       console.log(
-        `🥕🥕🥕 Detected teams.microsoft.com URL ${transformed_meeting_url}\n, transforming to more compatible format 🥕🥕🥕`
+        `🥕🥕🥕 Detected Teams URL on ${url.hostname}: ${transformed_meeting_url}\n, transforming to more compatible format 🥕🥕🥕`
       )
-      // Transform the URL to the more compatible format
       const transformedUrl = transformTeamsLink(transformed_meeting_url)
       console.log("Using transformed Teams URL:", transformedUrl)
       return {
         meetingId: transformedUrl,
-        password: ""
+        password: url.searchParams.get("p") || ""
       }
     }
 


### PR DESCRIPTION
## Summary

Pairs with the API-server change: the API can now accept a sovereign-cloud Teams link, and without this the bot would still throw "Invalid Teams URL" on it. Both gates have to agree or the failure just moves.

- `isTeamsUrl` replaces the `teams.microsoft.com` / `teams.live.com` hostname checks: `/l/meetup-join/` and `/light-meetings/launch` are Teams on any host (checked against path *and* fragment), otherwise a host with a `teams` label plus a Teams path shape. The path half is what keeps `teams.zoom.us` out, so the existing rejection cases still reject.
- `transformTeamsLink` and `convertLightMeetingToStandard` now build on `url.origin` instead of a hard-coded `https://teams.microsoft.com/v2/…`. This is the bug behind the hostname one: even with sovcloud detected, the rewrite would have pointed the bot at a tenant that does not exist on the global cloud. No-op for `teams.microsoft.com`. The `teams.live.com` launcher branches got the same treatment.
- The deep-link regex is host-agnostic now — the same link is served by every Teams cloud, only the origin differs.
- Defender SafeLinks is unwrapped alongside the existing Google redirect, since an Outlook-sourced link arrives wrapped and no host check can see through it.
- The passcode is read from `?p=` on all Teams hosts, not just personal Teams. Harmless: `TeamsProvider.getMeetingLink` ignores the password argument.

Worth knowing before merge: this fixes URL handling only. Whether a bot can actually *join* a sovereign cloud is unverified — bot-pod egress to `*.sovcloud.fr`, whether Bleu permits anonymous join, and whether the pre-join DOM matches the selectors in `src/meeting/teams.ts` are all open. One real test link answers all three.

## Testing

- `npx jest src/urlParser/` — 82 pass across the three parser suites. That includes all 24 pre-existing Teams cases unchanged (the v2 rewrites, TACV2, launcher and light-meetings, encoded URLs, Google redirects, and the four invalid-URL rejections) plus 7 new ones: short join codes passed through on three different clouds, a deep link rewritten onto its *own* origin and asserted not to contain `teams.microsoft.com`, a deep link on a host that never says "teams", the passcode case, and a SafeLinks-wrapped link.
- **Not tested:** no live join against any sovereign cloud, and no bot pod run. `tsc --noEmit` was not run separately — ts-jest type-checks both changed files as part of the suite above.

## Release Notes

Teams meetings hosted on sovereign and national clouds (for example `teams.sovcloud.fr`) and on the `teams.cloud.microsoft` domain are no longer rejected as invalid meeting URLs, and links rewritten by Outlook SafeLinks are followed to the real meeting.