### PR TITLE
chore(deps): raise npm overrides to clear all open dependency advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4008,9 +4008,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4335,9 +4335,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.38",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+            "version": "2.11.21",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+            "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -4440,9 +4440,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.9",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+            "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
             "dev": true,
             "funding": [
                 {
@@ -4461,11 +4461,11 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
+                "baseline-browser-mapping": "^2.11.20",
+                "caniuse-lite": "^1.0.30001810",
+                "electron-to-chromium": "^1.5.420",
+                "node-releases": "^2.0.54",
+                "update-browserslist-db": "^1.3.2"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -4595,9 +4595,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
                 {
@@ -5296,9 +5296,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.376",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-            "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+            "version": "1.5.422",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+            "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
             "dev": true,
             "license": "ISC",
             "peer": true
@@ -8171,9 +8171,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -8223,9 +8223,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.48",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-            "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -8825,12 +8825,13 @@
             "peer": true
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -9258,14 +9259,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -10175,9 +10176,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
             "dev": true,
             "funding": [
                 {
@@ -10485,9 +10486,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "dev": true,
             "license": "ISC",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@babel/core": "^7.29.7",
         "@smithy/config-resolver": "^4.4.0",
         "body-parser": "^1.20.6",
-        "brace-expansion": "^2.1.2",
+        "brace-expansion": "^2.1.4",
         "diff": "^4.0.4",
         "esbuild": "^0.28.1",
         "fast-xml-parser": "^5.7.0",
@@ -68,12 +68,17 @@
         "ip-address": "^10.3.1",
         "js-yaml": "^4.3.1",
         "lodash": "^4.17.24",
-        "minimatch": "^9.0.5",
+        "minimatch": "^9.0.7",
         "picomatch": "^2.3.2",
-        "postcss": "^8.5.18",
+        "postcss": "^8.5.23",
         "simple-git": "^3.36.0",
         "tar": "^7.5.21",
-        "uuid": "^11.1.1"
+        "uuid": "^11.1.1",
+        "ajv@6": "^6.14.0",
+        "browserslist": "^4.28.7",
+        "nanoid": "^3.3.18",
+        "qs": "^6.16.0",
+        "yaml@1": "^1.10.3"
     },
     "scripts": {
         "dev": "tsx watch src/main.ts",
@@ -112,7 +117,12 @@
     "pnpm": {
         "overrides": {
             "tar@>=7.0.0 <7.5.21": ">=7.5.21 <8",
-            "protobufjs@<7.6.5": ">=7.6.5 <8"
+            "protobufjs@<7.6.5": ">=7.6.5 <8",
+            "ajv@<6.14.0": ">=6.14.0 <7",
+            "browserslist@<=4.28.6": ">=4.28.7 <5",
+            "nanoid@<3.3.18": ">=3.3.18 <4",
+            "qs@<6.16.0": ">=6.16.0 <7",
+            "yaml@>=1.0.0 <1.10.3": ">=1.10.3 <2"
         }
     }
 }


### PR DESCRIPTION
## Summary

Raises the npm overrides until `npm audit` reports zero vulnerabilities. qs was the reported finding; ajv, browserslist, nanoid and yaml were also open and are fixed here too.

Three existing overrides had floors sitting inside an advisory range — postcss `^8.5.18` against an advisory at `<=8.5.22`, minimatch `^9.0.5` against `<9.0.7`, and brace-expansion `^2.1.2` against `<2.1.4`. They resolve clean today only because the highest matching version happens to be patched; the floors are raised so that stays true.

ajv and yaml use npm's version-scoped selector form (`"ajv@6"`, `"yaml@1"`) so a future 8.x ajv or 2.x yaml is not dragged backwards. The inert pnpm.overrides mirror is kept in sync as usual.

### Testing

- `npm audit`: 7 vulnerabilities before, 0 after.
- `tsc --noEmit` passes.
- `jest`: 24 suites, 325 tests, all passing.

### Release notes

None. Dependency resolution only, no source changes.