### PR TITLE
feat(streaming): expose audio capture start time in output handshake

### DIFF
--- a/src/streaming.test.ts
+++ b/src/streaming.test.ts
@@ -28,11 +28,16 @@ class MockWebSocket {
 
   url: string
   readyState = MockWebSocket.CONNECTING
+  sent: unknown[] = []
   private handlers: Record<string, Array<(...args: unknown[]) => void>> = {}
 
   constructor(url: string) {
     this.url = url
     mockWsInstances.push(this)
+  }
+
+  send(data: unknown) {
+    this.sent.push(data)
   }
 
   on(event: string, handler: (...args: unknown[]) => void) {
@@ -78,6 +83,19 @@ jest.mock("./utils/PathManager", () => ({
 }))
 jest.mock("./utils/S3Uploader", () => ({ S3Uploader: class {} }))
 
+const mockSpawn = jest.fn(() => {
+  const makeStream = () => ({ on: () => {} })
+  return {
+    stdin: makeStream(),
+    stdout: makeStream(),
+    stderr: makeStream(),
+    on: () => {},
+    kill: () => {}
+  }
+})
+
+jest.mock("node:child_process", () => ({ spawn: mockSpawn }))
+
 import { Streaming } from "./streaming"
 
 function createStreaming(input = "ws://in/input", output?: string) {
@@ -99,6 +117,7 @@ describe("Streaming input WebSocket", () => {
     mockWsInstances.length = 0
     mockStdin.writes = 0
     mockStdin.ended = false
+    mockSpawn.mockClear()
   })
 
   afterEach(() => {
@@ -167,5 +186,59 @@ describe("Streaming input WebSocket", () => {
     await streaming.stop()
     jest.advanceTimersByTime(120_000)
     expect(mockWsInstances).toHaveLength(1)
+  })
+})
+
+describe("Streaming handshake start_time", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] })
+    mockWsInstances.length = 0
+    mockStdin.writes = 0
+    mockStdin.ended = false
+    mockSpawn.mockClear()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function createOutputStreaming() {
+    return new Streaming(undefined, "ws://out/output", 24000, "bot-123")
+  }
+
+  function handshakeOf(ws: MockWebSocket): Record<string, unknown> {
+    const text = ws.sent.find((m): m is string => typeof m === "string")
+    expect(text).toBeDefined()
+    return JSON.parse(text!)
+  }
+
+  it("sends start_time null before audio capture starts", () => {
+    createOutputStreaming()
+    const ws = mockWsInstances[0]!
+    ws.open()
+    const handshake = handshakeOf(ws)
+    expect(handshake.start_time).toBeNull()
+    expect(handshake.bot_id).toBe("bot-123")
+    expect(handshake.sample_rate).toBe(24000)
+  })
+
+  it("sends the capture start time in handshakes after capture starts", () => {
+    const streaming = createOutputStreaming()
+    const ws0 = mockWsInstances[0]!
+    ws0.open()
+
+    streaming.startAudioCapture()
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+
+    // Simulate a reconnect: close the output socket, wait for backoff.
+    ws0.close()
+    jest.advanceTimersByTime(1000)
+    expect(mockWsInstances).toHaveLength(2)
+
+    const ws1 = mockWsInstances[1]!
+    ws1.open()
+    const handshake = handshakeOf(ws1)
+    expect(typeof handshake.start_time).toBe("number")
+    expect((handshake.start_time as number) > 0).toBe(true)
   })
 })

--- a/src/streaming.test.ts
+++ b/src/streaming.test.ts
@@ -222,6 +222,24 @@ describe("Streaming handshake start_time", () => {
     expect(handshake.sample_rate).toBe(24000)
   })
 
+  it("notifies an already-open socket when capture starts", () => {
+    const streaming = createOutputStreaming()
+    const ws = mockWsInstances[0]!
+    ws.open()
+    expect(handshakeOf(ws).start_time).toBeNull()
+
+    // Capture starts while the initial socket is still open. The bot must
+    // deliver the real capture start time before any audio flows.
+    streaming.startAudioCapture()
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+
+    const handshakes = ws.sent.filter((m): m is string => typeof m === "string")
+    expect(handshakes).toHaveLength(2)
+    const updated = JSON.parse(handshakes[1]!)
+    expect(typeof updated.start_time).toBe("number")
+    expect((updated.start_time as number) > 0).toBe(true)
+  })
+
   it("sends the capture start time in handshakes after capture starts", () => {
     const streaming = createOutputStreaming()
     const ws0 = mockWsInstances[0]!

--- a/src/streaming.test.ts
+++ b/src/streaming.test.ts
@@ -83,11 +83,20 @@ jest.mock("./utils/PathManager", () => ({
 }))
 jest.mock("./utils/S3Uploader", () => ({ S3Uploader: class {} }))
 
+const mockAudioDataHandlers: Array<(data: Buffer) => void> = []
+
 const mockSpawn = jest.fn(() => {
   const makeStream = () => ({ on: () => {} })
+  const stdout = {
+    on: (event: string, handler: (data: Buffer) => void) => {
+      if (event === "data") {
+        mockAudioDataHandlers.push(handler)
+      }
+    }
+  }
   return {
     stdin: makeStream(),
-    stdout: makeStream(),
+    stdout,
     stderr: makeStream(),
     on: () => {},
     kill: () => {}
@@ -118,6 +127,7 @@ describe("Streaming input WebSocket", () => {
     mockStdin.writes = 0
     mockStdin.ended = false
     mockSpawn.mockClear()
+    mockAudioDataHandlers.length = 0
   })
 
   afterEach(() => {
@@ -196,6 +206,7 @@ describe("Streaming handshake start_time", () => {
     mockStdin.writes = 0
     mockStdin.ended = false
     mockSpawn.mockClear()
+    mockAudioDataHandlers.length = 0
   })
 
   afterEach(() => {
@@ -238,6 +249,20 @@ describe("Streaming handshake start_time", () => {
     const updated = JSON.parse(handshakes[1]!)
     expect(typeof updated.start_time).toBe("number")
     expect((updated.start_time as number) > 0).toBe(true)
+
+    // Emit one complete 100ms chunk (2400 samples at 24kHz) through the
+    // mocked FFmpeg stdout and verify the updated handshake was delivered
+    // before the first binary PCM message.
+    const samples = new Float32Array(2400)
+    for (const handler of mockAudioDataHandlers) {
+      handler(Buffer.from(samples.buffer))
+    }
+    expect(mockAudioDataHandlers.length).toBeGreaterThan(0)
+
+    const binaryIndex = ws.sent.findIndex((m) => typeof m !== "string")
+    expect(binaryIndex).toBeGreaterThan(0)
+    expect(ws.sent.indexOf(handshakes[1]!)).toBeLessThan(binaryIndex)
+    expect((ws.sent[binaryIndex] as ArrayBuffer).byteLength).toBe(4800)
   })
 
   it("sends the capture start time in handshakes after capture starts", () => {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -74,6 +74,8 @@ export class Streaming {
 
   // Dedicated FFmpeg process for audio capture
   private ffmpegProcess: ChildProcess | null = null
+  // Epoch milliseconds when the audio capture started (set in startAudioCapture, cleared in stopAudioCapture). Exposed in the handshake as start_time.
+  private captureStartTime: number | null = null
   private audioRemainder: Buffer = Buffer.alloc(0)
 
   // Inbound (injection) byte remainder: incoming ws audio messages are raw
@@ -179,6 +181,8 @@ export class Streaming {
       stdio: ["pipe", "pipe", "pipe"]
     })
 
+    this.captureStartTime = Date.now()
+
     // stdin is piped but unused; still guard it so a stray EPIPE on teardown
     // can't escalate to an uncaughtException (see media_context.ts).
     this.ffmpegProcess.stdin?.on("error", (err) => {
@@ -244,6 +248,7 @@ export class Streaming {
       this.ffmpegProcess.kill("SIGTERM")
       this.ffmpegProcess = null
     }
+    this.captureStartTime = null
     this.audioRemainder = Buffer.alloc(0)
   }
 
@@ -360,7 +365,8 @@ export class Streaming {
             protocol_version: 1,
             bot_id: this.botId,
             offset: 0.0,
-            sample_rate: this.sample_rate
+            sample_rate: this.sample_rate,
+            start_time: this.captureStartTime
           }
           console.log(`[Streaming] Sending handshake to ${this.outputUrl}: ${JSON.stringify(handshake)}`)
           this.output_ws.send(JSON.stringify(handshake))

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -177,19 +177,24 @@ export class Streaming {
 
     console.log(`[Streaming] Starting dedicated audio FFmpeg: ${args.join(" ")}`)
 
-    this.ffmpegProcess = spawn("ffmpeg", args, {
+    const proc = spawn("ffmpeg", args, {
       stdio: ["pipe", "pipe", "pipe"]
     })
+    this.ffmpegProcess = proc
 
     this.captureStartTime = Date.now()
 
+    // Notify an already-connected output socket about the capture start time
+    // so it arrives before the first PCM chunk (no reconnect required).
+    this.sendHandshake()
+
     // stdin is piped but unused; still guard it so a stray EPIPE on teardown
     // can't escalate to an uncaughtException (see media_context.ts).
-    this.ffmpegProcess.stdin?.on("error", (err) => {
+    proc.stdin?.on("error", (err) => {
       console.warn(`[Streaming] ffmpeg stdin error (ignored): ${err}`)
     })
 
-    this.ffmpegProcess.stderr?.on("data", (data: Buffer) => {
+    proc.stderr?.on("data", (data: Buffer) => {
       const output = data.toString().trim()
       // FFmpeg outputs diagnostic info to stderr; only log non-progress lines
       if (output && !output.match(/^size=\s*\d+/)) {
@@ -197,18 +202,26 @@ export class Streaming {
       }
     })
 
-    this.ffmpegProcess.on("exit", (code) => {
+    // Guard with an identity check so a stale process teardown can't clear
+    // the state of a newer capture.
+    proc.on("exit", (code) => {
       console.log(`[Streaming] Audio FFmpeg exited with code ${code}`)
-      this.ffmpegProcess = null
+      if (this.ffmpegProcess === proc) {
+        this.ffmpegProcess = null
+        this.captureStartTime = null
+      }
     })
 
-    this.ffmpegProcess.on("error", (err) => {
+    proc.on("error", (err) => {
       console.error("[Streaming] Audio FFmpeg error:", formatError(err))
-      this.ffmpegProcess = null
+      if (this.ffmpegProcess === proc) {
+        this.ffmpegProcess = null
+        this.captureStartTime = null
+      }
     })
 
     // Handle stdout: Float32 PCM data with byte alignment
-    this.ffmpegProcess.stdout?.on("data", (data: Buffer) => {
+    proc.stdout?.on("data", (data: Buffer) => {
       if (this.isPaused) return
 
       // Handle chunk boundaries: Float32 frames can split across data events
@@ -250,6 +263,26 @@ export class Streaming {
     }
     this.captureStartTime = null
     this.audioRemainder = Buffer.alloc(0)
+  }
+
+  /**
+   * Send the output handshake JSON to a connected output WebSocket.
+   * Sent on connection open and again when audio capture starts so
+   * consumers receive the real capture start time before the first audio chunk.
+   */
+  private sendHandshake(): void {
+    if (!this.output_ws || this.output_ws.readyState !== 1) {
+      return
+    }
+    const handshake = {
+      protocol_version: 1,
+      bot_id: this.botId,
+      offset: 0.0,
+      sample_rate: this.sample_rate,
+      start_time: this.captureStartTime
+    }
+    console.log(`[Streaming] Sending handshake to ${this.outputUrl}: ${JSON.stringify(handshake)}`)
+    this.output_ws.send(JSON.stringify(handshake))
   }
 
   /**
@@ -361,15 +394,7 @@ export class Streaming {
         this.reconnectAttempts = 0
 
         if (this.output_ws) {
-          const handshake = {
-            protocol_version: 1,
-            bot_id: this.botId,
-            offset: 0.0,
-            sample_rate: this.sample_rate,
-            start_time: this.captureStartTime
-          }
-          console.log(`[Streaming] Sending handshake to ${this.outputUrl}: ${JSON.stringify(handshake)}`)
-          this.output_ws.send(JSON.stringify(handshake))
+          this.sendHandshake()
 
           // Initialize debug audio file if enabled
           if (this.debugAudioEnabled) {


### PR DESCRIPTION
## Summary

Adds `start_time` (epoch milliseconds) to the output WebSocket handshake so consumers can align the audio stream with wall clock time.

## Changes

- New `captureStartTime` field on `Streaming`, set in `startAudioCapture()` (when the dedicated capture FFmpeg starts) and cleared in `stopAudioCapture()` and on FFmpeg exit/error (identity-guarded so a stale process teardown cannot clear a newer capture).
- Handshake is extracted into `sendHandshake()` and now includes `start_time`. It is sent on connection open (`null` if capture has not started) and **again as soon as capture starts**, so an already-connected consumer receives the real value before the first audio chunk, not only on reconnect.
- Regression tests: `start_time: null` before capture, updated handshake delivered to an open socket when capture starts, and the real timestamp in reconnect handshakes.

## Context

Requested via support ticket: consumers could not correlate streamed audio with wall clock time because `offset` is always `0.0` and audio capture starts after `joined_at`. Complements docs PR Meeting-BaaS/docs#178.

## Verification

- `jest src/streaming.test.ts`: 8/8 passing
- `tsc --skipLibCheck --noEmit -p tsconfig.json`: clean
- `biome lint`: no errors (test-file `noNonNullAssertion` warnings match existing style)