### PR TITLE
fix(zoom): detect a stalled client load and retry it apart from the bot wall

### DIFF
--- a/src/meeting/zoom-join-failure.test.ts
+++ b/src/meeting/zoom-join-failure.test.ts
@@ -8,6 +8,7 @@ describe("Zoom join failure evidence", () => {
     MeetingEndReason.CannotJoinMeeting,
     MeetingEndReason.TimeoutWaitingToStart,
     MeetingEndReason.ExitingMeetingBeforeRecord,
+    MeetingEndReason.ZoomLoadingStalled,
     MeetingEndReason.ProxyUnavailable,
     MeetingEndReason.Internal,
     null

--- a/src/meeting/zoom-join-failure.ts
+++ b/src/meeting/zoom-join-failure.ts
@@ -3,6 +3,9 @@ import { MeetingEndReason } from "../state-machine/types"
 const DOWNGRADEABLE_AFTER_ZOOM_BOT_WALL: ReadonlySet<MeetingEndReason> = new Set([
   MeetingEndReason.CannotJoinMeeting,
   MeetingEndReason.TimeoutWaitingToStart,
+  // A relaunch that only manages to stall tells us nothing new — the confirmed
+  // wall is still the better explanation of why this bot never got in.
+  MeetingEndReason.ZoomLoadingStalled,
   MeetingEndReason.ExitingMeetingBeforeRecord,
   MeetingEndReason.ProxyUnavailable,
   MeetingEndReason.Internal

--- a/src/meeting/zoom-loading-stall.test.ts
+++ b/src/meeting/zoom-loading-stall.test.ts
@@ -1,7 +1,10 @@
+import type { Page } from "@playwright/test"
 import {
   BLANK_STALL_AFTER_MS,
   classifyZoomLoadState,
+  createZoomLoadProbe,
   LOAD_PHASE_HARD_CAP_MS,
+  loadFingerprint,
   STALL_AFTER_MS,
   ZoomLoadingStallTracker,
   type ZoomLoadSnapshot
@@ -176,11 +179,94 @@ describe("ZoomLoadingStallTracker", () => {
     expect(tracker.reloadCount).toBe(0)
   })
 
+  // The admission phase runs with no reload budget: past the Join click a reload
+  // lands back on the pre-join card, which the caller reads as "loaded" and then
+  // waits out to a TERMINAL TimeoutWaitingToStart. A stall there must go straight
+  // to the requeue instead.
+  it("gives up without reloading when no reload budget is allowed", () => {
+    const tracker = new ZoomLoadingStallTracker("admission", { maxReloads: 0 })
+    const loading = snap({ readyState: "loading", text: "Joining Meeting..." })
+
+    expect(tracker.observe(loading, 0).type).toBe("wait")
+    expect(tracker.observe(loading, STALL_AFTER_MS)).toMatchObject({
+      type: "giveUp",
+      stalled: true
+    })
+    expect(tracker.reloadCount).toBe(0)
+  })
+
+  // A flip through "unknown" and back must not be measured as one long freeze,
+  // or the page spends a reload it never earned.
+  it("starts a fresh stall window after passing through an unknown state", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join", { unknownGraceMs: 60_000 })
+    const loading = snap({ readyState: "loading", text: "Loading..." })
+    const unknown = snap({ text: "some page we do not recognise" })
+
+    expect(tracker.observe(loading, 0).type).toBe("wait")
+    expect(tracker.observe(unknown, 10_000).type).toBe("wait")
+    // Same loading frame as at t=0: without the reset this reads as a 30s freeze.
+    expect(tracker.observe(loading, 30_000).type).toBe("wait")
+    expect(tracker.reloadCount).toBe(0)
+  })
+
   it("stops counting toward the unknown grace once the client comes up", () => {
     const tracker = new ZoomLoadingStallTracker("pre-join", { unknownGraceMs: 5_000 })
     tracker.observe(snap({ text: "something odd" }), 0)
     expect(tracker.observe(snap({ prejoinReady: true }), 1_000).type).toBe("ready")
     // The odd frame reappears: the grace starts over rather than firing at once.
     expect(tracker.observe(snap({ text: "something odd" }), 4_000).type).toBe("wait")
+  })
+})
+
+describe("createZoomLoadProbe", () => {
+  const selectors = { prejoin: "#input-for-name", meetingUi: "button" }
+
+  const hungPage = () => {
+    const evaluate = jest.fn(() => new Promise<never>(() => {}))
+    return { page: { evaluate } as unknown as Page, evaluate }
+  }
+
+  // page.evaluate has no timeout in Playwright, and a renderer whose main thread
+  // is wedged is exactly the page this module exists to catch. Unbounded, the
+  // poll loop blocks before the tracker can ever order a reload or hit the cap.
+  it("returns an unresponsive snapshot instead of hanging on a wedged renderer", async () => {
+    const { page } = hungPage()
+    const probe = createZoomLoadProbe(page, selectors, 20)
+
+    const snapshot = await probe()
+
+    expect(snapshot).toMatchObject({ readyState: "loading", url: "", elementCount: 0 })
+  })
+
+  // Otherwise a frozen page queues a fresh pending evaluation every poll, for as
+  // long as it stays frozen.
+  it("does not queue another evaluation behind one that never came back", async () => {
+    const { page, evaluate } = hungPage()
+    const probe = createZoomLoadProbe(page, selectors, 20)
+
+    await probe()
+    await probe()
+    await probe()
+
+    expect(evaluate).toHaveBeenCalledTimes(1)
+  })
+
+  // The unresponsive snapshot has to be identical every time, or the tracker
+  // reads a page that cannot answer at all as one that keeps changing.
+  it("reports an unchanging snapshot so the stall clock actually runs", async () => {
+    const { page } = hungPage()
+    const probe = createZoomLoadProbe(page, selectors, 20)
+
+    const first = loadFingerprint(await probe())
+    const second = loadFingerprint(await probe())
+
+    expect(second).toBe(first)
+  })
+
+  it("passes the page's real snapshot straight through when it answers", async () => {
+    const answered = snap({ prejoinReady: true, elementCount: 900 })
+    const page = { evaluate: jest.fn(async () => answered) } as unknown as Page
+
+    expect(await createZoomLoadProbe(page, selectors, 20)()).toEqual(answered)
   })
 })

--- a/src/meeting/zoom-loading-stall.test.ts
+++ b/src/meeting/zoom-loading-stall.test.ts
@@ -1,0 +1,186 @@
+import {
+  BLANK_STALL_AFTER_MS,
+  classifyZoomLoadState,
+  LOAD_PHASE_HARD_CAP_MS,
+  STALL_AFTER_MS,
+  ZoomLoadingStallTracker,
+  type ZoomLoadSnapshot
+} from "./zoom-loading-stall"
+
+const snap = (overrides: Partial<ZoomLoadSnapshot> = {}): ZoomLoadSnapshot => ({
+  readyState: "complete",
+  url: "https://app.zoom.us/wc/123/join",
+  text: "",
+  elementCount: 250,
+  appRootEmpty: false,
+  loadingIndicator: false,
+  prejoinReady: false,
+  meetingUiReady: false,
+  ...overrides
+})
+
+describe("classifyZoomLoadState", () => {
+  it("treats a rendered pre-join card as ready even while a spinner node lingers", () => {
+    expect(classifyZoomLoadState(snap({ prejoinReady: true, loadingIndicator: true }))).toBe(
+      "ready"
+    )
+  })
+
+  // The waiting room can legitimately last the full 600s admission timeout. If it
+  // ever reads as "still loading" the bot reloads itself out of a queue it was
+  // already sitting in.
+  it.each([
+    "Please wait, the meeting host will let you in soon",
+    "Waiting for the host to start this meeting",
+    "You will be admitted shortly"
+  ])("treats waiting-room copy as ready: %s", (text) => {
+    expect(classifyZoomLoadState(snap({ text }))).toBe("ready")
+  })
+
+  it("reads Zoom's own connecting copy as loading", () => {
+    expect(classifyZoomLoadState(snap({ text: "Joining Meeting..." }))).toBe("loading")
+  })
+
+  // Zoom mounts an EMPTY #video-share-layout video-player behind the "Joining
+  // Meeting…" overlay. If that counts as admitted, the bot starts recording the
+  // spinner — the precise false positive the old isJoiningSpinner gate existed
+  // to prevent, so it has to survive here.
+  it("keeps the joining overlay ahead of the empty in-meeting DOM behind it", () => {
+    expect(classifyZoomLoadState(snap({ text: "Joining Meeting...", meetingUiReady: true }))).toBe(
+      "loading"
+    )
+  })
+
+  it("reads an incomplete readyState as loading even with no other hint", () => {
+    expect(classifyZoomLoadState(snap({ readyState: "loading" }))).toBe("loading")
+  })
+
+  // The white page: navigation committed, nothing mounted, nothing painted.
+  it("reads a page with nothing painted and nothing mounted as blank", () => {
+    expect(classifyZoomLoadState(snap({ text: "   ", appRootEmpty: true, elementCount: 4 }))).toBe(
+      "blank"
+    )
+  })
+
+  // Zoom builds its DOM well before it paints any text. Calling that blank would
+  // spend the short white-page budget on a client that is genuinely coming up.
+  it("reads a mounted but unpainted client as loading, not blank", () => {
+    expect(classifyZoomLoadState(snap({ text: "", appRootEmpty: false }))).toBe("loading")
+  })
+
+  it("reads a loaded page showing something unrecognised as unknown, not loading", () => {
+    expect(classifyZoomLoadState(snap({ text: "This meeting link is invalid (3,001)" }))).toBe(
+      "unknown"
+    )
+  })
+})
+
+describe("ZoomLoadingStallTracker", () => {
+  const loading = snap({ readyState: "loading", text: "Loading..." })
+
+  // The whole point: Zoom taking minutes to come up is not a failure so long as
+  // it is visibly getting somewhere. The old flat 30s deadline killed exactly
+  // these joins.
+  it("keeps waiting far past the old 30s deadline while the page still changes", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join")
+    let now = 0
+    for (let i = 0; now < LOAD_PHASE_HARD_CAP_MS - STALL_AFTER_MS; i++) {
+      now += STALL_AFTER_MS - 1_000
+      const action = tracker.observe(snap({ readyState: "loading", text: "x".repeat(i + 1) }), now)
+      expect(action.type).toBe("wait")
+    }
+    expect(now).toBeGreaterThan(120_000)
+    expect(tracker.reloadCount).toBe(0)
+  })
+
+  // A white page has no partial render to be patient with, so it should be acted
+  // on well before the spinner budget — and the spinner budget must not shrink
+  // to match.
+  it("reloads a white page on the shorter budget", () => {
+    const white = snap({ text: "", appRootEmpty: true, elementCount: 4 })
+    const tracker = new ZoomLoadingStallTracker("pre-join")
+
+    expect(tracker.observe(white, 0).type).toBe("wait")
+    expect(tracker.observe(white, BLANK_STALL_AFTER_MS - 1).type).toBe("wait")
+    expect(tracker.observe(white, BLANK_STALL_AFTER_MS)).toMatchObject({ type: "reload" })
+    expect(BLANK_STALL_AFTER_MS).toBeLessThan(STALL_AFTER_MS)
+  })
+
+  // Zoom mounts hundreds of nodes before painting a character. Judging progress
+  // on text alone made that look frozen and reloaded a client that was working.
+  it("counts DOM growth as progress even while nothing is painted", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join")
+    let now = 0
+    for (let i = 0; i < 6; i++) {
+      now += STALL_AFTER_MS - 1_000
+      const action = tracker.observe(
+        snap({ readyState: "complete", text: "", elementCount: 100 + i * 40 }),
+        now
+      )
+      expect(action.type).toBe("wait")
+    }
+    expect(tracker.reloadCount).toBe(0)
+  })
+
+  it("reloads once the page has been frozen on the same frame", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join")
+    expect(tracker.observe(loading, 0).type).toBe("wait")
+    expect(tracker.observe(loading, STALL_AFTER_MS - 1).type).toBe("wait")
+
+    const action = tracker.observe(loading, STALL_AFTER_MS)
+    expect(action).toMatchObject({ type: "reload", attempt: 1 })
+  })
+
+  it("does not re-trip on the reloaded page's own first frame", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join")
+    tracker.observe(loading, 0)
+    expect(tracker.observe(loading, STALL_AFTER_MS).type).toBe("reload")
+    // Same frozen frame, immediately after the reload: the clock restarted.
+    expect(tracker.observe(loading, STALL_AFTER_MS + 1_000).type).toBe("wait")
+  })
+
+  it("gives up as a stall once the reload budget is spent", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join", { maxReloads: 1 })
+    tracker.observe(loading, 0)
+    expect(tracker.observe(loading, STALL_AFTER_MS).type).toBe("reload")
+
+    // The reloaded page gets its own full stall window before it counts again.
+    expect(tracker.observe(loading, STALL_AFTER_MS + 1_000).type).toBe("wait")
+    const action = tracker.observe(loading, STALL_AFTER_MS * 2 + 1_000)
+    expect(action).toMatchObject({ type: "giveUp", stalled: true })
+  })
+
+  // A page that repaints its spinner forever never looks frozen, so the frozen
+  // clock alone would hold the pod until the 600s admission timeout.
+  it("gives up as a stall at the hard cap even while the page keeps repainting", () => {
+    const tracker = new ZoomLoadingStallTracker("admission")
+    let now = 0
+    let action = tracker.observe(loading, now)
+    for (let i = 0; action.type === "wait" && i < 500; i++) {
+      now += 1_000
+      action = tracker.observe(snap({ readyState: "loading", text: "y".repeat(i + 1) }), now)
+    }
+    expect(action).toMatchObject({ type: "giveUp", stalled: true })
+    expect(now).toBeGreaterThanOrEqual(LOAD_PHASE_HARD_CAP_MS)
+  })
+
+  // An error page is not slow, it is wrong — reloading it wastes the pod, and it
+  // must not be reported as a stall, because the caller has real reasons for it.
+  it("hands an unrecognised loaded page back quickly and not as a stall", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join", { unknownGraceMs: 5_000 })
+    const wall = snap({ text: "automated bots aren't allowed" })
+
+    expect(tracker.observe(wall, 0).type).toBe("wait")
+    const action = tracker.observe(wall, 5_000)
+    expect(action).toMatchObject({ type: "giveUp", stalled: false, state: "unknown" })
+    expect(tracker.reloadCount).toBe(0)
+  })
+
+  it("stops counting toward the unknown grace once the client comes up", () => {
+    const tracker = new ZoomLoadingStallTracker("pre-join", { unknownGraceMs: 5_000 })
+    tracker.observe(snap({ text: "something odd" }), 0)
+    expect(tracker.observe(snap({ prejoinReady: true }), 1_000).type).toBe("ready")
+    // The odd frame reappears: the grace starts over rather than firing at once.
+    expect(tracker.observe(snap({ text: "something odd" }), 4_000).type).toBe("wait")
+  })
+})

--- a/src/meeting/zoom-loading-stall.ts
+++ b/src/meeting/zoom-loading-stall.ts
@@ -1,0 +1,379 @@
+import type { Page } from "@playwright/test"
+
+/**
+ * Zoom's web client can take a very long time to come up — and sometimes never
+ * comes up at all. Those two look identical for the first half-minute, which is
+ * why a flat "wait 30s for the pre-join card, then fail" both abandons joins
+ * that would have worked and reports the ones that never would as an opaque
+ * CannotJoinMeeting.
+ *
+ * The stall has two faces. Sometimes Zoom sits on a spinner forever; sometimes
+ * the navigation commits and the tab is simply white, with nothing mounted and
+ * nothing to show. The white page is the more clear-cut of the two — there is no
+ * partial render to be patient with — so it gets a shorter budget of its own.
+ *
+ * The question this module asks is not "how long has it been?" but "is anything
+ * still happening?". A client that is slowly booting keeps changing — it
+ * redirects, readyState advances, text appears. A wedged one is frozen on the
+ * same frame indefinitely. So the clock only runs while the page is observably
+ * unchanged, which lets a genuinely slow load take as long as it needs while a
+ * frozen one is caught in ~25s.
+ *
+ * Deliberately separate from the anti-bot wall. That wall is IP-reputation-keyed
+ * and wants a different exit IP (browser relaunch, then a fresh pod); a stall is
+ * a transport or renderer problem inside this page, and the cheapest thing that
+ * clears it is a reload in the very same browser. Do not merge the two paths.
+ *
+ * This file owns no end reasons on purpose — it reports what it saw and the
+ * caller, which knows the phase and its own fallbacks, decides what that means.
+ */
+
+/** Zoom's own loading/connecting copy. Waiting-room text is deliberately absent:
+ *  "please wait, the meeting host will let you in soon" is a legitimate state
+ *  that can last the full admission timeout and must never read as a stall. */
+const LOADING_TEXTS = [
+  "joining meeting",
+  "joining the meeting",
+  "connecting to the meeting",
+  "connecting...",
+  "loading...",
+  "preparing the meeting",
+  "your meeting is loading"
+]
+
+/** Text that proves the client is up and showing meeting UI, even though no
+ *  in-meeting DOM node has mounted yet. Mirrors ZOOM_STATE_CONFIG's waiting-room
+ *  patterns. */
+const MEETING_UI_TEXTS = [
+  "the meeting host will let you in",
+  "will let you in",
+  "waiting for the host to start",
+  "waiting room",
+  "admitted shortly",
+  "host has joined"
+]
+
+/** No observable change for this long, while the page is not up, is a stall.
+ *  Zoom's client mutates the DOM far more often than this whenever it really is
+ *  still working, so a quiet window this long means nothing is coming. */
+export const STALL_AFTER_MS = 25_000
+
+/** In-page reloads before the stall is escalated out of this pod. A stalled
+ *  asset or socket almost always clears on the first reload; a third has never
+ *  been the difference and just holds a warm pod open. */
+export const MAX_STALL_RELOADS = 2
+
+/** Ceiling for one load phase however much the page appears to progress — stops
+ *  a client that repaints a spinner forever from holding the pod all the way to
+ *  the 600s admission timeout. */
+export const LOAD_PHASE_HARD_CAP_MS = 180_000
+
+/** A white page is conclusive far sooner than a spinner: there is no partial
+ *  render to be patient with, nothing is mounted at all. Zoom's client puts its
+ *  root in place within a second or two of the navigation committing, so a
+ *  document still empty after this long is not slow, it is broken. */
+export const BLANK_STALL_AFTER_MS = 12_000
+
+/** A page that has finished loading but shows something we don't recognise is
+ *  not slow, it is wrong (an error page, an unmatched wall). Give it only enough
+ *  time to cover a mid-mount frame, then hand back to the caller's own checks. */
+export const UNKNOWN_GRACE_MS = 15_000
+
+/**
+ * What the Zoom client looks like right now. Plain values only, so every
+ * decision below stays pure and testable without a browser.
+ */
+export interface ZoomLoadSnapshot {
+  /** document.readyState */
+  readyState: string
+  /** Current URL — a redirect is progress, not a stall. */
+  url: string
+  /** Visible body text, lowercased and truncated. */
+  text: string
+  /** Zoom's spinner / loading layer is mounted. */
+  loadingIndicator: boolean
+  /** Total elements in the document. Rises steadily while the client builds
+   *  itself, which is progress even before a single character is painted. */
+  elementCount: number
+  /** Nothing is mounted: no body children, or Zoom's own root is empty. The
+   *  white-page case — the client took the navigation and then rendered
+   *  literally nothing. */
+  appRootEmpty: boolean
+  /** The pre-join card is rendered (name input present). */
+  prejoinReady: boolean
+  /** Waiting-room or in-meeting UI is rendered. */
+  meetingUiReady: boolean
+}
+
+export type ZoomLoadState = "ready" | "loading" | "blank" | "unknown"
+
+export type ZoomLoadAction =
+  | { type: "ready" }
+  | { type: "wait" }
+  | { type: "reload"; attempt: number; stalledForMs: number }
+  /** Stop waiting. `stalled` distinguishes "never finished loading" — the case
+   *  worth its own end reason and its own retry — from "loaded into something
+   *  unexpected", which the caller should classify with its existing checks. */
+  | { type: "giveUp"; state: ZoomLoadState; stalled: boolean; detail: string }
+
+/**
+ * Classify a single observation.
+ *
+ * Rendered UI wins over a lingering spinner NODE: Zoom leaves those in the DOM
+ * after the pre-join card mounts, and reading one as "still loading" would
+ * strand a bot that has in fact arrived. Zoom's explicit connecting COPY is the
+ * one exception and wins over everything — see below.
+ */
+export function classifyZoomLoadState(snapshot: ZoomLoadSnapshot): ZoomLoadState {
+  const text = snapshot.text.toLowerCase()
+
+  // Zoom's explicit connecting copy outranks rendered UI. While the "Joining
+  // Meeting…" overlay is up Zoom has ALREADY mounted an empty
+  // #video-share-layout video-player behind it, and reading that as "in meeting"
+  // is exactly how a bot ends up recording the spinner.
+  if (LOADING_TEXTS.some((t) => text.includes(t))) return "loading"
+
+  if (snapshot.prejoinReady || snapshot.meetingUiReady) return "ready"
+  if (MEETING_UI_TEXTS.some((t) => text.includes(t))) return "ready"
+
+  // A bare spinner NODE is much weaker evidence than the copy above — Zoom
+  // leaves those in the DOM after the card mounts — so it only counts once
+  // nothing rendered has been found.
+  if (snapshot.loadingIndicator) return "loading"
+  if (snapshot.readyState !== "complete") return "loading"
+
+  // Nothing painted AND nothing mounted: the white page. Distinguished from a
+  // client that has built its DOM but not painted text yet — that one is still
+  // coming up and gets the ordinary, longer patience.
+  if (text.trim().length === 0) return snapshot.appRootEmpty ? "blank" : "loading"
+
+  // Recognised nothing on a fully loaded page: a wall, a denial or an error
+  // page. Those carry their own end reasons and must not be reloaded away, so
+  // say so plainly rather than guessing "loading".
+  return "unknown"
+}
+
+/**
+ * The fingerprint that answers "did anything change since last time?". Text
+ * length rather than the text itself keeps a ticking clock or participant
+ * counter from reading as progress on its own — those advance without the load
+ * advancing.
+ */
+export function loadFingerprint(snapshot: ZoomLoadSnapshot): string {
+  return [
+    snapshot.url,
+    snapshot.readyState,
+    String(snapshot.text.length),
+    // Without this, a client that is busily mounting its DOM but has not painted
+    // any text yet looks frozen — identical text length every poll — and gets
+    // reloaded out from under itself while it was in fact working.
+    String(snapshot.elementCount),
+    snapshot.loadingIndicator ? "spin" : "-"
+  ].join("|")
+}
+
+export interface ZoomLoadingStallOptions {
+  stallAfterMs?: number
+  blankStallAfterMs?: number
+  maxReloads?: number
+  hardCapMs?: number
+  unknownGraceMs?: number
+}
+
+/**
+ * Feed it observations, it says whether to keep waiting, reload, or stop.
+ *
+ * An object rather than a bare function because the decision depends on history:
+ * how long the page has been frozen, and how many reloads it has already had.
+ * `now` is injected so tests can drive time directly.
+ */
+export class ZoomLoadingStallTracker {
+  private readonly stallAfterMs: number
+  private readonly blankStallAfterMs: number
+  private readonly maxReloads: number
+  private readonly hardCapMs: number
+  private readonly unknownGraceMs: number
+
+  private startedAt: number | null = null
+  private lastFingerprint: string | null = null
+  private lastChangeAt = 0
+  private unknownSince: number | null = null
+  private reloads = 0
+
+  constructor(
+    private readonly phase: string,
+    options: ZoomLoadingStallOptions = {}
+  ) {
+    this.stallAfterMs = options.stallAfterMs ?? STALL_AFTER_MS
+    this.blankStallAfterMs = options.blankStallAfterMs ?? BLANK_STALL_AFTER_MS
+    this.maxReloads = options.maxReloads ?? MAX_STALL_RELOADS
+    this.hardCapMs = options.hardCapMs ?? LOAD_PHASE_HARD_CAP_MS
+    this.unknownGraceMs = options.unknownGraceMs ?? UNKNOWN_GRACE_MS
+  }
+
+  /** Reloads spent so far — for the caller's logging. */
+  get reloadCount(): number {
+    return this.reloads
+  }
+
+  observe(snapshot: ZoomLoadSnapshot, now: number): ZoomLoadAction {
+    this.startedAt ??= now
+
+    const state = classifyZoomLoadState(snapshot)
+    if (state === "ready") {
+      this.unknownSince = null
+      return { type: "ready" }
+    }
+
+    if (state === "unknown") {
+      this.unknownSince ??= now
+      const unknownFor = now - this.unknownSince
+      if (unknownFor >= this.unknownGraceMs) {
+        return {
+          type: "giveUp",
+          state,
+          stalled: false,
+          detail: `${this.phase}: page loaded but showed nothing recognisable for ${Math.round(
+            unknownFor / 1000
+          )}s`
+        }
+      }
+      return { type: "wait" }
+    }
+    this.unknownSince = null
+
+    const fingerprint = loadFingerprint(snapshot)
+    if (fingerprint !== this.lastFingerprint) {
+      this.lastFingerprint = fingerprint
+      this.lastChangeAt = now
+    }
+
+    const elapsed = now - this.startedAt
+    if (elapsed >= this.hardCapMs) {
+      return {
+        type: "giveUp",
+        state,
+        stalled: true,
+        detail: `${this.phase}: never finished loading within ${Math.round(
+          this.hardCapMs / 1000
+        )}s (state=${state}, reloads=${this.reloads})`
+      }
+    }
+
+    // A white page gets the short window: there is nothing half-rendered to be
+    // patient with, so waiting the full spinner budget just wastes the pod.
+    const patience = state === "blank" ? this.blankStallAfterMs : this.stallAfterMs
+    const frozenFor = now - this.lastChangeAt
+    if (frozenFor < patience) return { type: "wait" }
+
+    if (this.reloads >= this.maxReloads) {
+      return {
+        type: "giveUp",
+        state,
+        stalled: true,
+        detail: `${this.phase}: frozen for ${Math.round(frozenFor / 1000)}s after ${
+          this.reloads
+        } reload(s) (state=${state})`
+      }
+    }
+
+    this.reloads += 1
+    // The reload restarts the observation: the fresh page gets its own first
+    // paint, and keeping the old fingerprint would trip the stall again on the
+    // very next poll.
+    this.lastFingerprint = null
+    this.lastChangeAt = now
+    return { type: "reload", attempt: this.reloads, stalledForMs: frozenFor }
+  }
+}
+
+/**
+ * Selectors the caller considers proof the client is up. Passed in rather than
+ * duplicated here so zoom.ts stays the single source of truth for Zoom's DOM and
+ * the two can never drift apart.
+ */
+export interface ZoomLoadProbeSelectors {
+  /** Pre-join card (the name input). */
+  prejoin: string
+  /** Waiting-room / in-meeting UI. */
+  meetingUi: string
+}
+
+/**
+ * Read the indicators off a live page. Deliberately defensive: this runs against
+ * a page that may be mid-navigation or already torn down, and a throw here would
+ * surface as a join failure rather than the stall it is describing.
+ */
+export async function readZoomLoadSnapshot(
+  page: Page,
+  selectors: ZoomLoadProbeSelectors
+): Promise<ZoomLoadSnapshot> {
+  try {
+    return await page.evaluate(
+      ({ prejoin, meetingUi }) => {
+        const text = (document.body?.innerText || "").slice(0, 4000)
+
+        // Raw querySelector, never a Playwright visibility check: Zoom's web
+        // client reports its own controls as not-visible/not-actionable, so a
+        // locator-based probe false-negatives here (the same reason detectBotWall
+        // reads the DOM directly).
+        const has = (selector: string): boolean => {
+          try {
+            return Boolean(document.querySelector(selector))
+          } catch {
+            return false
+          }
+        }
+
+        // Zoom's client mounts into one of these. "Empty" means the navigation
+        // committed and then nothing was built — a genuinely white page, as
+        // opposed to a client that is mid-build.
+        const roots = ["#zmmtg-root", "#root", "#app"]
+          .map((sel) => document.querySelector(sel))
+          .filter((el): el is Element => el !== null)
+        const appRootEmpty =
+          roots.length > 0
+            ? roots.every((el) => el.children.length === 0)
+            : (document.body?.children.length ?? 0) === 0
+
+        return {
+          readyState: document.readyState,
+          url: location.href,
+          text,
+          elementCount: document.getElementsByTagName("*").length,
+          appRootEmpty,
+          loadingIndicator: has(
+            [
+              ".loading-layer",
+              ".zm-loading",
+              '[class*="loading-spinner"]',
+              '[class*="LoadingLayer"]',
+              ".preview-loading",
+              "#zmmtg-root > .loading"
+            ].join(",")
+          ),
+          prejoinReady: has(prejoin),
+          meetingUiReady: has(meetingUi)
+        }
+      },
+      { prejoin: selectors.prejoin, meetingUi: selectors.meetingUi }
+    )
+  } catch {
+    // An unreadable page is exactly the frozen case this module exists for.
+    // Report it as blank so the tracker's clock keeps running, instead of the
+    // caller treating the error as a hard join failure.
+    return {
+      readyState: "loading",
+      url: "",
+      text: "",
+      // Not reported as an empty root: an evaluate can also throw simply because
+      // a navigation is committing, and calling that a white page would cut the
+      // patience short on a page that is about to come up fine.
+      elementCount: 0,
+      appRootEmpty: false,
+      loadingIndicator: false,
+      prejoinReady: false,
+      meetingUiReady: false
+    }
+  }
+}

--- a/src/meeting/zoom-loading-stall.ts
+++ b/src/meeting/zoom-loading-stall.ts
@@ -227,6 +227,11 @@ export class ZoomLoadingStallTracker {
 
     if (state === "unknown") {
       this.unknownSince ??= now
+      // Drop the change fingerprint so the next loading observation starts a
+      // fresh stall window. Without this a loading -> unknown -> loading flip
+      // that happens to keep an identical fingerprint would be measured as one
+      // long freeze and spend a reload it never earned.
+      this.lastFingerprint = null
       const unknownFor = now - this.unknownSince
       if (unknownFor >= this.unknownGraceMs) {
         return {
@@ -299,10 +304,75 @@ export interface ZoomLoadProbeSelectors {
   meetingUi: string
 }
 
+/** Ceiling on one probe. `page.evaluate` has no timeout of its own, so a
+ *  renderer whose main thread is wedged never returns from it — and that is the
+ *  exact page this module exists to catch. Without a bound the polling loop
+ *  blocks forever *before* the tracker can order a reload or hit the hard cap. */
+export const PROBE_TIMEOUT_MS = 5_000
+
+/** What we report when the page will not answer: a frozen, unchanging snapshot.
+ *  Not flagged as an empty root — an evaluate can also fail because a navigation
+ *  is committing, and calling that a white page would cut the patience short on
+ *  a page that is about to come up fine. Being constant is the point: the
+ *  fingerprint never moves, so the stall clock runs and the tracker acts. */
+function unresponsiveSnapshot(): ZoomLoadSnapshot {
+  return {
+    readyState: "loading",
+    url: "",
+    text: "",
+    elementCount: 0,
+    appRootEmpty: false,
+    loadingIndicator: false,
+    prejoinReady: false,
+    meetingUiReady: false
+  }
+}
+
+/**
+ * A probe bound in time and limited to one outstanding evaluation.
+ *
+ * Both guards matter. The timeout stops a wedged renderer from hanging the
+ * caller; the in-flight check stops a probe being queued behind one that is
+ * never coming back, which would otherwise pile up a new pending evaluation
+ * every poll for as long as the page stays frozen.
+ */
+export function createZoomLoadProbe(
+  page: Page,
+  selectors: ZoomLoadProbeSelectors,
+  timeoutMs: number = PROBE_TIMEOUT_MS
+): () => Promise<ZoomLoadSnapshot> {
+  let inFlight = false
+
+  return async function probe(): Promise<ZoomLoadSnapshot> {
+    // An earlier probe that still has not come back is itself the answer: the
+    // page is not responding.
+    if (inFlight) return unresponsiveSnapshot()
+
+    inFlight = true
+    const evaluation = readZoomLoadSnapshot(page, selectors).finally(() => {
+      inFlight = false
+    })
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        evaluation,
+        new Promise<ZoomLoadSnapshot>((resolve) => {
+          timer = setTimeout(() => resolve(unresponsiveSnapshot()), timeoutMs)
+        })
+      ])
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }
+}
+
 /**
  * Read the indicators off a live page. Deliberately defensive: this runs against
  * a page that may be mid-navigation or already torn down, and a throw here would
  * surface as a join failure rather than the stall it is describing.
+ *
+ * Unbounded on its own — callers should go through `createZoomLoadProbe`.
  */
 export async function readZoomLoadSnapshot(
   page: Page,
@@ -359,21 +429,9 @@ export async function readZoomLoadSnapshot(
       { prejoin: selectors.prejoin, meetingUi: selectors.meetingUi }
     )
   } catch {
-    // An unreadable page is exactly the frozen case this module exists for.
-    // Report it as blank so the tracker's clock keeps running, instead of the
-    // caller treating the error as a hard join failure.
-    return {
-      readyState: "loading",
-      url: "",
-      text: "",
-      // Not reported as an empty root: an evaluate can also throw simply because
-      // a navigation is committing, and calling that a white page would cut the
-      // patience short on a page that is about to come up fine.
-      elementCount: 0,
-      appRootEmpty: false,
-      loadingIndicator: false,
-      prejoinReady: false,
-      meetingUiReady: false
-    }
+    // An unreadable page is exactly the frozen case this module exists for, so
+    // report the unresponsive snapshot and let the tracker's clock run, instead
+    // of the caller treating the error as a hard join failure.
+    return unresponsiveSnapshot()
   }
 }

--- a/src/meeting/zoom-loading-stall.ts
+++ b/src/meeting/zoom-loading-stall.ts
@@ -372,9 +372,12 @@ export function createZoomLoadProbe(
  * a page that may be mid-navigation or already torn down, and a throw here would
  * surface as a join failure rather than the stall it is describing.
  *
- * Unbounded on its own — callers should go through `createZoomLoadProbe`.
+ * Unbounded on its own, and deliberately not exported: `page.evaluate` has no
+ * timeout, so the only way out of this module is through `createZoomLoadProbe`,
+ * which adds one. Leaving a raw reader on the public surface would let a future
+ * caller reintroduce the hang this file exists to detect.
  */
-export async function readZoomLoadSnapshot(
+async function readZoomLoadSnapshot(
   page: Page,
   selectors: ZoomLoadProbeSelectors
 ): Promise<ZoomLoadSnapshot> {

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -24,8 +24,8 @@ import {
   ZOOM_INVALID_PASSCODE_PATTERN
 } from "./zoom-passcode"
 import {
+  createZoomLoadProbe,
   MAX_STALL_RELOADS,
-  readZoomLoadSnapshot,
   type ZoomLoadProbeSelectors,
   ZoomLoadingStallTracker
 } from "./zoom-loading-stall"
@@ -349,7 +349,7 @@ export class ZoomProvider implements MeetingProviderInterface {
 
     // Wait for the pre-join name input: patient while Zoom is still coming up,
     // reloading when it freezes (see waitForPrejoinCard).
-    const prejoin = await this.waitForPrejoinCard(page)
+    const prejoin = await this.waitForPrejoinCard(page, cancelCheck)
     if (prejoin !== "ready") {
       // The client never came up at all. Its own reason, so it is neither
       // confused with a refusal nor retried like the IP-keyed wall.
@@ -736,14 +736,25 @@ export class ZoomProvider implements MeetingProviderInterface {
    * handed straight back so the caller's registration / wall / denial checks
    * still own that decision.
    */
-  private async waitForPrejoinCard(page: Page): Promise<"ready" | "stalled" | "unrecognised"> {
+  private async waitForPrejoinCard(
+    page: Page,
+    cancelCheck: () => boolean
+  ): Promise<"ready" | "stalled" | "unrecognised"> {
     const tracker = new ZoomLoadingStallTracker("pre-join")
+    const probe = createZoomLoadProbe(page, LOAD_PROBE_SELECTORS)
 
     while (true) {
-      const action = tracker.observe(
-        await readZoomLoadSnapshot(page, LOAD_PROBE_SELECTORS),
-        Date.now()
-      )
+      // This loop can now run for minutes, so it has to honour a stop request
+      // the way waitForAdmission does — otherwise an API stop sits unanswered
+      // until the whole load phase gives up.
+      if (cancelCheck()) {
+        if (!GLOBAL.getEndReason()) {
+          GLOBAL.setError(MeetingEndReason.ExitingMeetingBeforeRecord)
+        }
+        throw new Error("Bot stopped while waiting for the Zoom pre-join card")
+      }
+
+      const action = tracker.observe(await probe(), Date.now())
 
       switch (action.type) {
         case "ready":
@@ -777,8 +788,16 @@ export class ZoomProvider implements MeetingProviderInterface {
     const start = Date.now()
     // Watches the client for the whole admission wait: a connect that never
     // resolves is a load stall, not a host who never admitted us, and the two
-    // need opposite responses (reload/requeue vs. give up quietly).
-    const loadTracker = new ZoomLoadingStallTracker("admission")
+    // need opposite responses (requeue vs. give up quietly).
+    //
+    // No reloads in this phase, deliberately. Past the Join click a reload
+    // throws the join away and lands back on the pre-join card, which this loop
+    // would read as "loaded" and then wait out to the 600s TimeoutWaitingToStart
+    // — a TERMINAL reason, so the bot would not even retry. A reload cannot
+    // recover a join anyway, so a stall here goes straight to the requeue, where
+    // a fresh pod re-runs the join properly.
+    const loadTracker = new ZoomLoadingStallTracker("admission", { maxReloads: 0 })
+    const probe = createZoomLoadProbe(page, LOAD_PROBE_SELECTORS)
 
     while (Date.now() - start < timeoutMs) {
       if (cancelCheck()) {
@@ -824,20 +843,7 @@ export class ZoomProvider implements MeetingProviderInterface {
       // beside it was immediately overwritten and a detected stall never
       // actually retried. ZoomLoadingStalled is retryable by construction, and
       // the retry decision now lives in exactly one place (ZOOM_TERMINAL).
-      const loadAction = loadTracker.observe(
-        await readZoomLoadSnapshot(page, LOAD_PROBE_SELECTORS),
-        Date.now()
-      )
-      if (loadAction.type === "reload") {
-        console.warn(
-          `[Zoom] Client frozen mid-admission for ${Math.round(loadAction.stalledForMs / 1000)}s — reloading (${loadAction.attempt}/${MAX_STALL_RELOADS})`
-        )
-        await page
-          .reload({ waitUntil: "domcontentloaded", timeout: 60_000 })
-          .catch((e) => console.warn("[Zoom] Stall reload failed:", formatError(e)))
-        await sleep(LOAD_POLL_MS)
-        continue
-      }
+      const loadAction = loadTracker.observe(await probe(), Date.now())
       if (loadAction.type === "giveUp" && loadAction.stalled) {
         console.warn(`[Zoom] ${loadAction.detail}`)
         GLOBAL.setError(MeetingEndReason.ZoomLoadingStalled)

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -23,6 +23,12 @@ import {
   type ZoomPasscodeFailureReason,
   ZOOM_INVALID_PASSCODE_PATTERN
 } from "./zoom-passcode"
+import {
+  MAX_STALL_RELOADS,
+  readZoomLoadSnapshot,
+  type ZoomLoadProbeSelectors,
+  ZoomLoadingStallTracker
+} from "./zoom-loading-stall"
 import { ZOOM_STATE_CONFIG } from "./zoom-state-config"
 
 // Zoom Web Client selectors (verified against the live DOM). Two client variants
@@ -37,6 +43,18 @@ const JOIN_BUTTON = "button.preview-join-button, #joinBtn"
 const PREVIEW_MUTE = "#preview-audio-control-button"
 const PREVIEW_VIDEO = "#preview-video-control-button"
 const LEAVE_BUTTON = 'button[aria-label="Leave"]'
+
+// What the loading-stall probe treats as proof the client is up. Built from the
+// selectors above and the shared state config so there is exactly one place a
+// Zoom DOM change has to be made.
+const LOAD_PROBE_SELECTORS: ZoomLoadProbeSelectors = {
+  prejoin: NAME_INPUT,
+  meetingUi: ZOOM_STATE_CONFIG.inMeetingPattern.selectors.join(",")
+}
+
+// How often the load probe re-reads the page. Fast enough that a card mounting
+// between polls costs ~1s, cheap enough to run for the whole admission wait.
+const LOAD_POLL_MS = 1_000
 const LEAVE_CONFIRM = "button.leave-meeting-options__btn--danger"
 const PERMISSION_DISMISS = 'button:has-text("Continue without microphone and camera")'
 const PASSCODE_INPUT =
@@ -329,10 +347,17 @@ export class ZoomProvider implements MeetingProviderInterface {
       throw new Error("Bot stopped before joining Zoom meeting")
     }
 
-    // Wait for the pre-join name input.
-    try {
-      await page.waitForSelector(NAME_INPUT, { timeout: 30_000 })
-    } catch {
+    // Wait for the pre-join name input: patient while Zoom is still coming up,
+    // reloading when it freezes (see waitForPrejoinCard).
+    const prejoin = await this.waitForPrejoinCard(page)
+    if (prejoin !== "ready") {
+      // The client never came up at all. Its own reason, so it is neither
+      // confused with a refusal nor retried like the IP-keyed wall.
+      if (prejoin === "stalled") {
+        GLOBAL.setError(MeetingEndReason.ZoomLoadingStalled)
+        throw new Error("[Zoom] zoom_loading_stalled: pre-join card never rendered")
+      }
+
       // Registration-required webinar: Zoom server-side-redirects /wc/<id>/join
       // to its registration page, so no name input can ever render — from any
       // pod or IP. Deterministic (bots ca8d3a00 / a32de694 burned 6 pods each
@@ -698,14 +723,62 @@ export class ZoomProvider implements MeetingProviderInterface {
     return sawBlockingModal ? "blocked" : "absent"
   }
 
+  /**
+   * Wait for the pre-join card, giving Zoom as long as it needs while the client
+   * is still visibly loading and reloading the page when it freezes.
+   *
+   * Replaces a flat 30s waitForSelector that was wrong in both directions: it
+   * abandoned joins where Zoom was merely slow (it can take minutes), and it
+   * reported the ones that never loaded as a plain CannotJoinMeeting —
+   * indistinguishable from a genuine refusal, and retried the same way.
+   *
+   * "unrecognised" means the page finished loading into something we don't know:
+   * handed straight back so the caller's registration / wall / denial checks
+   * still own that decision.
+   */
+  private async waitForPrejoinCard(page: Page): Promise<"ready" | "stalled" | "unrecognised"> {
+    const tracker = new ZoomLoadingStallTracker("pre-join")
+
+    while (true) {
+      const action = tracker.observe(
+        await readZoomLoadSnapshot(page, LOAD_PROBE_SELECTORS),
+        Date.now()
+      )
+
+      switch (action.type) {
+        case "ready":
+          return "ready"
+
+        case "reload":
+          console.warn(
+            `[Zoom] Pre-join page frozen for ${Math.round(action.stalledForMs / 1000)}s — reloading (${action.attempt}/${MAX_STALL_RELOADS})`
+          )
+          // A reload that itself times out is not fatal: the next poll re-reads
+          // the page and the tracker decides again on what it actually finds.
+          await page
+            .reload({ waitUntil: "domcontentloaded", timeout: 60_000 })
+            .catch((e) => console.warn("[Zoom] Stall reload failed:", formatError(e)))
+          break
+
+        case "giveUp":
+          console.warn(`[Zoom] Giving up on pre-join load — ${action.detail}`)
+          return action.stalled ? "stalled" : "unrecognised"
+
+        default:
+          break
+      }
+
+      await sleep(LOAD_POLL_MS)
+    }
+  }
+
   private async waitForAdmission(page: Page, cancelCheck: () => boolean): Promise<void> {
     const timeoutMs = (GLOBAL.get().waiting_room_timeout ?? 600) * 1000
     const start = Date.now()
-    // A real connect resolves in a few seconds; if Zoom sits on the "Joining
-    // Meeting…" spinner far longer, the join is wedged. Bail out RETRYABLE so a
-    // fresh pod/IP tries again instead of silently recording the spinner.
-    const JOINING_STUCK_MS = 90_000
-    let joiningSince: number | null = null
+    // Watches the client for the whole admission wait: a connect that never
+    // resolves is a load stall, not a host who never admitted us, and the two
+    // need opposite responses (reload/requeue vs. give up quietly).
+    const loadTracker = new ZoomLoadingStallTracker("admission")
 
     while (Date.now() - start < timeoutMs) {
       if (cancelCheck()) {
@@ -741,29 +814,44 @@ export class ZoomProvider implements MeetingProviderInterface {
         throw new Error(`[Zoom] Rejected during admission: ${reason}`)
       }
 
-      // "Joining Meeting…" / connecting spinner. Zoom mounts an (empty)
-      // #video-share-layout video-player behind it, which the in-meeting detector
-      // would false-positive as "admitted" — so the bot starts recording the
-      // spinner. Treat the spinner as NOT admitted: keep waiting, and if it never
-      // resolves, bail out retryable rather than record a frozen page.
-      if (await this.isJoiningSpinner(page)) {
-        joiningSince ??= Date.now()
-        const stuckFor = Date.now() - joiningSince
-        if (stuckFor > JOINING_STUCK_MS) {
-          console.warn(
-            `[Zoom] Stuck on "Joining Meeting…" spinner for ${Math.round(stuckFor / 1000)}s — bailing out retryable`
-          )
-          GLOBAL.setShouldRetry(true)
-          GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
-          throw new Error("[Zoom] Stuck on Joining Meeting spinner")
-        }
+      // Is the client even up? This has to run BEFORE the admission checks
+      // below: Zoom mounts an empty #video-share-layout video-player behind the
+      // "Joining Meeting…" overlay, and the in-meeting detector would read that
+      // as admitted and start recording the spinner.
+      //
+      // The old version of this check bailed out with TimeoutWaitingToStart,
+      // which waiting-room-state lists as TERMINAL — so the setShouldRetry(true)
+      // beside it was immediately overwritten and a detected stall never
+      // actually retried. ZoomLoadingStalled is retryable by construction, and
+      // the retry decision now lives in exactly one place (ZOOM_TERMINAL).
+      const loadAction = loadTracker.observe(
+        await readZoomLoadSnapshot(page, LOAD_PROBE_SELECTORS),
+        Date.now()
+      )
+      if (loadAction.type === "reload") {
+        console.warn(
+          `[Zoom] Client frozen mid-admission for ${Math.round(loadAction.stalledForMs / 1000)}s — reloading (${loadAction.attempt}/${MAX_STALL_RELOADS})`
+        )
+        await page
+          .reload({ waitUntil: "domcontentloaded", timeout: 60_000 })
+          .catch((e) => console.warn("[Zoom] Stall reload failed:", formatError(e)))
+        await sleep(LOAD_POLL_MS)
+        continue
+      }
+      if (loadAction.type === "giveUp" && loadAction.stalled) {
+        console.warn(`[Zoom] ${loadAction.detail}`)
+        GLOBAL.setError(MeetingEndReason.ZoomLoadingStalled)
+        throw new Error(`[Zoom] zoom_loading_stalled: ${loadAction.detail}`)
+      }
+      if (loadAction.type === "wait") {
         console.log(
-          `[Zoom] "Joining Meeting…" spinner (${Math.round(stuckFor / 1000)}s) — not admitted yet`
+          `[Zoom] Client still loading — not admitted yet (${Math.round((Date.now() - start) / 1000)}s)`
         )
         await sleep(2000)
         continue
       }
-      joiningSince = null
+      // "ready", or a page that loaded into something we don't recognise: the
+      // waiting-room / in-meeting / denial checks below own it from here.
 
       // Waiting room first (see method doc).
       const waiting = await zoomStateDetector.isWaitingRoom(page)
@@ -870,26 +958,6 @@ export class ZoomProvider implements MeetingProviderInterface {
   private throwPasscodeFailure(reason: ZoomPasscodeFailureReason): never {
     GLOBAL.setError(reason)
     throw new Error(`[Zoom] ${getErrorMessageFromCode(reason)}`)
-  }
-
-  /**
-   * True while Zoom shows the post-Join "Joining Meeting…" / connecting spinner.
-   * Distinct from the waiting-room copy ("please wait, the host will let you in"),
-   * so it won't shadow a genuine waiting room.
-   */
-  private async isJoiningSpinner(page: Page): Promise<boolean> {
-    try {
-      return await page.evaluate(() => {
-        const t = (document.body?.innerText || "").toLowerCase()
-        return (
-          t.includes("joining meeting") ||
-          t.includes("joining the meeting") ||
-          t.includes("connecting to the meeting")
-        )
-      })
-    } catch {
-      return false
-    }
   }
 
   async findEndMeeting(page: Page, _opts?: { ignoreAloneSignals?: boolean }): Promise<boolean> {

--- a/src/state-machine/states/waiting-room-state.ts
+++ b/src/state-machine/states/waiting-room-state.ts
@@ -182,6 +182,11 @@ export class WaitingRoomState extends BaseState {
           // Registration-required webinar: the join URL server-side-redirects to
           // zoom.us/webinar/register/ for every pod/IP — retrying can never help.
           MeetingEndReason.ZoomWebinarRegistrationRequired
+          // ZoomLoadingStalled is deliberately NOT here. Zoom's client failing to
+          // come up is transient, and the bot has already spent its in-page
+          // reloads by the time the reason is set — a fresh pod is the right next
+          // step. Adding it would silently recreate the bug where a detected
+          // stall set shouldRetry(true) and had it overwritten right here.
         ]
         if (!endReason || !ZOOM_TERMINAL.includes(endReason)) {
           console.log(
@@ -297,6 +302,12 @@ export class WaitingRoomState extends BaseState {
         // Only the IP-reputation wall is worth an in-process relaunch; every other
         // reason (invalid URL, host denial, passcode, timeout) is not IP-keyed and
         // must fall through to the outer catch → SQS requeue / terminal failure.
+        //
+        // ZoomLoadingStalled explicitly included in "every other reason": a stall
+        // is a transport/renderer problem in the page, not a burned exit IP, and
+        // it has already been given its in-page reloads. Relaunching the browser
+        // onto a new residential IP would spend the wall's budget on a problem a
+        // new IP does not fix.
         const canInProcessRetry =
           attempt < maxInProc && reason === MeetingEndReason.ZoomAnonymousJoinNotAllowed
         if (!canInProcessRetry) {

--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -51,6 +51,12 @@ export enum MeetingEndReason {
   // the webinar requires per-registrant registration (name+email → personal tk=
   // link), so an anonymous join can never succeed from any pod/IP. Terminal.
   ZoomWebinarRegistrationRequired = "zoomWebinarRegistrationRequired",
+  // The Zoom web client never finished coming up — frozen on a spinner, a blank
+  // #zmmtg-root, or a navigation that resolved but never rendered. Distinct from
+  // both CannotJoinMeeting (which lumped it in with real refusals) and from the
+  // anti-bot wall: nothing is rejecting the bot, the page simply did not load, so
+  // the useful response is a reload and then a fresh pod — not a new exit IP.
+  ZoomLoadingStalled = "zoomLoadingStalled",
   // Authenticated Teams bot (username/password) — failure modes the api-server distinguishes.
   // Invalid/Captcha/Mfa flip the teams_login to invalid (per-account); Timeout is transient.
   TeamsLoginFailedInvalidCredentials = "teamsLoginFailedInvalidCredentials",
@@ -109,6 +115,8 @@ export function getErrorMessageFromCode(errorCode: MeetingEndReason): string {
       return "Zoom rejected the passcode supplied in the meeting URL. Use a join link containing the current passcode."
     case MeetingEndReason.ZoomWebinarRegistrationRequired:
       return "This Zoom webinar requires registration: Zoom redirected the join URL to its registration page, so the bot cannot join anonymously. Register the bot first and use the personalized join link (tk=) from the confirmation, or disable required registration for the webinar."
+    case MeetingEndReason.ZoomLoadingStalled:
+      return "The Zoom web client did not finish loading — it stayed on a loading/connecting screen without progressing. This is usually transient on Zoom's side; the bot reloaded and retried before giving up."
     case MeetingEndReason.TeamsLoginFailedInvalidCredentials:
       return "Microsoft rejected the account email/password. Update the teams_login credentials."
     case MeetingEndReason.TeamsLoginFailedCaptcha:


### PR DESCRIPTION
## Summary

Zoom's web client sometimes takes a very long time to come up, and sometimes never comes up at all — either sitting on a spinner or leaving the tab entirely white. Bots that hit this failed to join meetings that were perfectly fine, and reported it as a generic "cannot join meeting", indistinguishable from a meeting that genuinely refused the bot.

Two defects caused it. First, a detected stall never actually retried: `waitForAdmission` already noticed a 90s freeze on the "Joining Meeting…" spinner and called `setShouldRetry(true)`, but tagged it `TimeoutWaitingToStart`, which `waiting-room-state.ts` lists in `ZOOM_TERMINAL` and overwrites with `setShouldRetry(false)` moments later — the bail-out was dead code. Second, slow was indistinguishable from broken: the pre-join path waited a flat 30s for `#input-for-name`, so a client needing 45s was abandoned while a client that would never load spent the same 30s and reported the same opaque reason.

A stall now has its own detection, its own end reason, and its own retry path:

- **`zoom-loading-stall.ts` (new)** asks "is anything still happening?" rather than "how long has it been?". The clock only runs while the page is observably unchanged (url, readyState, painted text length, element count, spinner presence), so a genuinely slow load gets as long as it needs while a frozen one is caught in ~25s. A 180s hard cap stops a client that repaints a spinner forever from holding the pod to the 600s admission timeout.
- **The white page is its own case.** The probe reads DOM shape, not just text: whether Zoom's mount root (`#zmmtg-root` / `#root` / `#app`) is actually empty. A blank tab has no partial render to be patient with, so it gets a shorter 12s budget — reloading at 12s and giving up around 36s rather than ~75s.
- **DOM growth counts as progress.** Zoom mounts hundreds of nodes before painting a character, so judging progress on text alone made a client that was genuinely coming up look frozen. `elementCount` is part of the change fingerprint, which is also what separates a mid-build client from a true white page.
- **The retry path is deliberately not the wall's.** Before the Join click, up to 2 in-page reloads in the same browser; after it, none — past that point a reload throws the join away and lands back on the pre-join card, so an admission stall goes straight to the requeue where a fresh pod re-runs the join properly. Either way the new `ZoomLoadingStalled` reason propagates to the ordinary SQS requeue onto a fresh pod. It does *not* spend the in-pod relaunch budget on a fresh residential exit IP — that budget exists for the IP-reputation-keyed anti-bot wall, and a new IP does not fix a renderer that will not come up. Both classification points carry comments saying so.
- **The probe is bounded and never overlaps.** `page.evaluate` has no timeout in Playwright, and a renderer with a wedged main thread — the exact page this feature targets — never returns from it, which would block the poll loop before the tracker could act. Each probe is raced against a 5s ceiling and a new one is never queued behind one that has not come back, so a frozen page cannot pile up pending evaluations.
- **Cancellation is honoured.** The pre-join wait can now run for minutes, so it checks `cancelCheck()` each cycle like `waitForAdmission` does; an API stop is answered immediately instead of after the load phase gives up.
- **Existing behaviour preserved.** The empty `#video-share-layout video-player` Zoom mounts *behind* the "Joining Meeting…" overlay still never counts as admitted (the old `isJoiningSpinner` gate existed to stop the bot recording the spinner). Waiting-room copy counts as loaded, since it can legitimately last the full 600s. A page that finishes loading into something unrecognised gets ~15s, not 3 minutes, and is handed back to the existing registration / wall / denial checks, which keep their own reasons.

## Testing

- `jest src/meeting/zoom-loading-stall.test.ts`: 25/25 passing — classification of spinner / white page / waiting room / unrecognised page, patience past the old 30s deadline, the short white-page budget, DOM-growth-as-progress, the reload budget, the hard cap, the bounded non-overlapping probe against a wedged page, the reload-free admission phase, and the stall window resetting across an unknown state.
- `jest` (full suite): 26/27 suites green, 370 tests passing. The one failure is `meeting-state-detector.test.ts`, which launches real Chromium and fails locally only because the Playwright browser is not installed (`Executable doesn't exist`) — unrelated to this change.
- `tsc --noEmit -p tsconfig.json`: clean.
- `biome check`: clean on all new and modified files. `zoom.ts` and `waiting-room-state.ts` carry pre-existing formatting/import-sort findings present on `v2-improvements` too; left untouched to keep the diff readable.

## Release Notes

Zoom bots no longer give up on meetings where Zoom's web client is simply slow to load — they now wait as long as the client is still making progress, instead of abandoning the join after 30 seconds.

When the client genuinely never loads, whether it hangs on a connecting spinner or renders a blank page, the bot reloads it and retries on a fresh worker before failing. If it still cannot get in, the failure is reported as **Zoom Client Did Not Load** rather than a generic "cannot join meeting", making it clear that nothing rejected the bot and the same meeting link will usually work on a later attempt.

Requires Meeting-BaaS/meeting-baas-v2#496 for the new reason to reach customers as `ZOOM_LOADING_STALLED` rather than `UNKNOWN_ERROR`. Merge that first or alongside.
