### PR TITLE
fix(diarization): promote corroborated UI evidence when network collapses to one speaker

### DIFF
--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -259,11 +259,16 @@ export class DiarizationTracker {
     }
 
     // Final pass: re-assemble the artifact best-source-per-stretch (repaired
-    // network authoritative; fallbacks fill large holes; boot gap retrofitted
+    // network authoritative unless the full-call UI evidence proves a
+    // one-speaker collapse; fallbacks fill large holes; boot gap retrofitted
     // onto the first identified speaker). See speaker-timeline-assembler.ts.
     const meetingEndRel = Math.max(0, (lastTimestamp - meetingStartTime) / 1000)
-    const { segments: assembled, filledBySource, retrofittedFromSeconds } =
-      assembleSpeakerTimeline(
+    const {
+      segments: assembled,
+      filledBySource,
+      retrofittedFromSeconds,
+      sourceDissonance
+    } = assembleSpeakerTimeline(
       [
         {
           kind: "network" as const,
@@ -279,6 +284,11 @@ export class DiarizationTracker {
       meetingEndRel,
       { botNames }
     )
+    if (sourceDissonance) {
+      console.warn(
+        `[DiarizationTracker] Source dissonance (${sourceDissonance.reason}): promoted ${sourceDissonance.promotedSource} over ${sourceDissonance.demotedSource}; effective speakers network=${sourceDissonance.networkEffectiveSpeakers} ui=${sourceDissonance.uiEffectiveSpeakers}`
+      )
+    }
     for (const [kind, count] of Object.entries(filledBySource)) {
       console.log(
         `[DiarizationTracker] Filled ${count} timeline gap segment(s) from the ${kind} fallback`

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -2,7 +2,8 @@ import type { DiarizationSegment } from "./diarization-tracker"
 import {
   assembleSpeakerTimeline,
   GAP_FILL_MIN_SECONDS,
-  LEADING_RETROFIT_MAX_SECONDS
+  LEADING_RETROFIT_MAX_SECONDS,
+  SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS
 } from "./speaker-timeline-assembler"
 
 function seg(
@@ -26,6 +27,83 @@ describe("assembleSpeakerTimeline", () => {
     )
     expect(segments).toEqual(network)
     expect(filledBySource.ui).toBeUndefined()
+  })
+
+  it("promotes corroborated multi-speaker UI evidence when the network timeline collapsed", () => {
+    // Prod shape: network continuously attributed both people to Stefano, while
+    // the muted UI observer independently saw Stefano and Emanuele taking turns.
+    const network = [seg("Stefano", 0, 1400, 2)]
+    const ui = [seg("Stefano", 0, 640, 2), seg("Emanuele", 640, 1350, 3)]
+    const { segments, filledBySource, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        { kind: "ui", segments: ui }
+      ],
+      1400
+    )
+
+    expect(sourceDissonance).toEqual({
+      reason: "network_single_speaker_ui_multi_speaker",
+      demotedSource: "network",
+      promotedSource: "ui",
+      networkEffectiveSpeakers: 1,
+      uiEffectiveSpeakers: 2
+    })
+    expect(segments).toEqual([...ui, seg("Stefano", 1350, 1400, 2)])
+    expect(filledBySource.network).toBe(1)
+  })
+
+  it("does not promote a transient second UI speaker", () => {
+    const network = [seg("Stefano", 0, 120)]
+    const ui = [
+      seg("Stefano", 0, 100),
+      seg("Emanuele", 100, 100 + SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS - 0.1)
+    ]
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        { kind: "ui", segments: ui }
+      ],
+      120
+    )
+
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual(network)
+  })
+
+  it("does not count the recording bot as multi-speaker UI evidence", () => {
+    const network = [seg("Stefano", 0, 120)]
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        {
+          kind: "ui",
+          segments: [seg("Stefano", 0, 60), seg("MeetingBaaS Notetaker", 60, 120)]
+        }
+      ],
+      120,
+      { botNames: ["MeetingBaaS Notetaker"] }
+    )
+
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual(network)
+  })
+
+  it("requires a shared identity before treating different source names as collapse evidence", () => {
+    const network = [seg("Network Identity", 0, 120)]
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        {
+          kind: "ui",
+          segments: [seg("Alice", 0, 60), seg("Bob", 60, 120)]
+        }
+      ],
+      120
+    )
+
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual(network)
   })
 
   it("fills a mid-call hole from the UI source, clipped to the hole", () => {

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -7,7 +7,9 @@ import { UNKNOWN_SPEAKER } from "./types"
  * interception — authoritative wherever it produced data) > ui (the platform's
  * own active-speaker indicator, shadow-buffered whole-call) > transcription
  * (live transcription-system turns, when one ran). A lower-trust source never
- * overwrites a higher-trust one — it only fills sufficiently large holes.
+ * overwrites a higher-trust one — it only fills sufficiently large holes —
+ * unless the sources provide strong evidence that the network timeline
+ * collapsed to one participant (see detectSourceDissonance).
  */
 
 export type TimelineSourceKind = "network" | "ui" | "transcription"
@@ -29,6 +31,19 @@ export const MIN_SEGMENT_SECONDS = 1
 // masked a real collapse; longer leading gaps are the reconciliation's job
 // (label-only backfill), never the timeline's.
 export const LEADING_RETROFIT_MAX_SECONDS = 20
+// A UI-only identity must own this much unambiguous speaking time before it can
+// count as evidence that a one-speaker network timeline collapsed. This filters
+// transient active-tile mistakes and matches the downstream reconciliation's
+// effective-speaker floor.
+export const SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS = 15
+
+export interface SpeakerSourceDissonance {
+  reason: "network_single_speaker_ui_multi_speaker"
+  demotedSource: "network"
+  promotedSource: "ui"
+  networkEffectiveSpeakers: number
+  uiEffectiveSpeakers: number
+}
 
 /** Positive-length segments, chronological. */
 function normalize(segments: DiarizationSegment[]): DiarizationSegment[] {
@@ -50,6 +65,66 @@ function coverageOf(segments: DiarizationSegment[]): Array<[number, number]> {
     }
   }
   return merged
+}
+
+/** Named, non-bot speaking duration by normalized identity. */
+function speakerDurations(
+  segments: DiarizationSegment[],
+  excludeSpeakers: string[] = []
+): Map<string, number> {
+  const excluded = new Set(
+    [UNKNOWN_SPEAKER, ...excludeSpeakers].map((name) => name.trim().toLowerCase())
+  )
+  const bySpeaker = new Map<string, DiarizationSegment[]>()
+  for (const segment of normalize(segments)) {
+    const key = segment.speaker?.trim().toLowerCase()
+    if (!key || excluded.has(key)) continue
+    const existing = bySpeaker.get(key) ?? []
+    existing.push(segment)
+    bySpeaker.set(key, existing)
+  }
+
+  const durations = new Map<string, number>()
+  for (const [speaker, speakerSegments] of bySpeaker) {
+    const duration = coverageOf(speakerSegments).reduce((sum, [start, end]) => sum + end - start, 0)
+    durations.set(speaker, duration)
+  }
+  return durations
+}
+
+/**
+ * Detect the production failure where the network path continuously attributes
+ * a call to one real participant while the muted UI observer repeatedly sees
+ * two real participants taking turns. The shared identity is important: it
+ * corroborates that both sources describe the same roster rather than two
+ * incompatible naming schemes.
+ */
+function detectSourceDissonance(
+  sources: TimelineSource[],
+  botNames: string[] = []
+): SpeakerSourceDissonance | undefined {
+  const network = sources.find((source) => source.kind === "network")
+  const ui = sources.find((source) => source.kind === "ui")
+  if (!network || !ui) return undefined
+
+  const effectiveNetwork = [...speakerDurations(network.segments, botNames)].filter(
+    ([, seconds]) => seconds >= SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS
+  )
+  const effectiveUi = [...speakerDurations(ui.segments, botNames)].filter(
+    ([, seconds]) => seconds >= SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS
+  )
+  if (effectiveNetwork.length !== 1 || effectiveUi.length < 2) return undefined
+
+  const [networkSpeaker] = effectiveNetwork[0]
+  if (!effectiveUi.some(([uiSpeaker]) => uiSpeaker === networkSpeaker)) return undefined
+
+  return {
+    reason: "network_single_speaker_ui_multi_speaker",
+    demotedSource: "network",
+    promotedSource: "ui",
+    networkEffectiveSpeakers: effectiveNetwork.length,
+    uiEffectiveSpeakers: effectiveUi.length
+  }
 }
 
 /** Holes of at least GAP_FILL_MIN_SECONDS in [0, meetingEnd] left by coverage. */
@@ -173,11 +248,22 @@ export function assembleSpeakerTimeline(
   segments: DiarizationSegment[]
   filledBySource: Partial<Record<TimelineSourceKind, number>>
   retrofittedFromSeconds?: number
+  sourceDissonance?: SpeakerSourceDissonance
 } {
   let assembled: DiarizationSegment[] = []
   const filledBySource: Partial<Record<TimelineSourceKind, number>> = {}
+  const sourceDissonance = detectSourceDissonance(sources, options?.botNames)
+  const promotedUi = sourceDissonance
+    ? sources.find((source) => source.kind === sourceDissonance.promotedSource)
+    : undefined
+  // On corroborated collapse, let unambiguous UI turns win. Network still fills
+  // any large UI holes, so promoting a sparse UI timeline does not discard the
+  // rest of the call.
+  const orderedSources = promotedUi
+    ? [promotedUi, ...sources.filter((source) => source !== promotedUi)]
+    : sources
 
-  for (const [index, source] of sources.entries()) {
+  for (const [index, source] of orderedSources.entries()) {
     if (index === 0) {
       // Primary source taken as-is, Unknowns included.
       assembled = normalize(source.segments)
@@ -202,6 +288,7 @@ export function assembleSpeakerTimeline(
   return {
     segments: suppressCoveredUnknowns(segments),
     filledBySource,
-    retrofittedFromSeconds
+    retrofittedFromSeconds,
+    sourceDissonance
   }
 }


### PR DESCRIPTION
The divergence-override rule discussed as the natural next step once #317/#319 started collecting whole-call, identity-keyed UI shadow data: when the network path stays healthy-looking but pins an entire call on one participant, and the muted UI observer independently saw two people taking turns, trust the UI.

## The gap this closes

Prod bot `acf4eecf` (root-caused earlier): CSRC picked the single loudest stream and pinned 5,271-vs-31 speaking samples on one of two real, alternating speakers. The timeline was contiguous and *looked* healthy — no gap for a fallback to fill, no retrofit to trigger. The one signal that had the right answer the whole call — Meet's own active-speaker indicator, captured by #317's shadow buffer — had no path to override a confident-looking-but-wrong network timeline. This PR is that path.

## Detection rule

`detectSourceDissonance` in `speaker-timeline-assembler.ts`:
- Network has exactly **one** effective speaker (≥15s, `SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS`, matching the reconciliation-side `EFFECTIVE_SPEAKER_MIN_SECONDS` convention) — a live source didn't die, it collapsed.
- UI independently shows **two or more** effective speakers.
- **Shared identity required**: the network's one speaker's name must also appear among the UI's effective speakers — this is what distinguishes a real collapse from two sources using incompatible naming schemes, and stops a false trigger on an unrelated identity mismatch.
- Recording-bot names are excluded from both sides' counts (same `botNames` mechanism as the rest of the file).

On a match, the UI source is promoted to primary for that call; network still fills any large holes the UI timeline leaves, so a sparse UI signal never discards good network data — it only wins the stretches it corroborates disagreement on.

## Verified before opening

Base (`1cbd64b3`) already contains #319/#323/#324/#322 — confirmed via `merge-base --is-ancestor`, no rebase needed. `npm ci` + `tsc --noEmit` clean; `speaker-timeline-assembler.test.ts` (4 new cases: positive match, transient-speaker rejection, bot-exclusion, no-shared-identity rejection), `diarization-tracker.test.ts`, `speaker-manager.test.ts` — 53/53 pass.

## Known limitation

Bot self-exclusion here inherits the same `botNames`-matching risk class already present elsewhere in this file (e.g. a truncated/SSO-displayed bot name not in the list) — not a regression introduced by this PR, just worth flagging since a missed bot name plus a genuinely single-speaker call is the one way to false-trigger this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYnNopP8vcijmTvpjJJK7W