### PR TITLE
fix(diarization): recover speaker separation when a source collapses, and scope rosters to the joined meeting

### DIFF
--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -25,9 +25,7 @@ const LAUNCH_TIMEOUT_MS = 60_000
 // so ~750ms is plenty; pkill -9 below is instant, keeping the fast retry fast.
 const BROWSER_CLOSE_TIMEOUT_MS = 750
 
-// Exit ASN the previous browser session in THIS pod left through. Only read on a
-// Zoom in-process retry, whose entire purpose is to escape an IP-keyed wall — a
-// relaunch that lands on the same network has bought nothing.
+// Exit ASN of this pod's previous Zoom session, to spot a retry on the same network.
 let lastZoomExitAsn: number | null = null
 
 /**
@@ -96,13 +94,7 @@ export async function establishBrowserSession(
       )
       if (proxyUrl) session.proxyUrl = proxyUrl
 
-      // Every selected region refused us. Decodo answers 407 for regions a plan
-      // does not entitle, so a team pinned to a narrow region set can walk its
-      // whole list ("region X exit unreachable" → "all selected regions
-      // unreachable") and end up joining direct — from the pod's datacenter IP,
-      // the single strongest bot signal on both Meet and Zoom. An unpinned
-      // residential exit is strictly better than no exit, so spend one more
-      // start without the geo pin before conceding the proxy.
+      // Every pinned region refused us; an unpinned residential exit beats a datacenter IP.
       if (!session.proxyUrl) {
         console.warn(
           `[BrowserSession] pinned residential exit unavailable for ${platform} — retrying without a geo pin`
@@ -231,11 +223,7 @@ export async function establishBrowserSession(
     }
   }
 
-  // A Zoom in-pod relaunch exists to escape an IP-keyed wall, so it is worth
-  // nothing unless the exit actually moved. Decodo always hands back a new
-  // session label; on a narrow pinned pool it can hand back the same network
-  // every time. Meet verifies this already (burned-ASN loop above) — Zoom
-  // assumed it. Verify, and re-roll onto the next candidate region if not.
+  // A Zoom in-pod retry only helps if the exit network changed; re-roll the region if not.
   if (session.proxyUrl && platform === "zoom" && (opts.inProcessAttempt ?? 0) > 0) {
     const ASN_ROTATIONS = 2
     for (let rot = 1; rot <= ASN_ROTATIONS; rot++) {
@@ -251,8 +239,7 @@ export async function establishBrowserSession(
         { countryOffset: countryOffset + rot }
       )
       if (!rotated) {
-        // The rotation tore the old proxy down without replacing it — don't
-        // launch against a dead proxy URL; the guard below decides what next.
+        // The old proxy is gone; let the guard below decide.
         session.proxyUrl = undefined
         break
       }
@@ -271,10 +258,7 @@ export async function establishBrowserSession(
   // clear session.proxyUrl on a failed rotation — not just the initial proxy
   // start. The LAST retry still falls back to a live/direct exit as the
   // final resort rather than never joining.
-  // Zoom is included because its browser-join wall blocks datacenter IPs
-  // outright: measured over 14 days of prod, attempts that fell through to a
-  // proxy-less join were walled 93% of the time. The cap is platform-aware
-  // (getMaxRetryCount), so Meet keeps exactly the budget it had.
+  // Zoom walls 93% of proxy-less joins (14 days of prod).
   if (
     (platform === "meet" || platform === "zoom") &&
     !session.proxyUrl &&

--- a/src/browser/browser-session.ts
+++ b/src/browser/browser-session.ts
@@ -11,7 +11,7 @@ import {
 } from "../proxy/toggle-proxy"
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
-import { IN_PROCESS_RETRY_MAX, MAX_RETRY_COUNT } from "../config/retry-config"
+import { getMaxRetryCount, IN_PROCESS_RETRY_MAX, MAX_RETRY_COUNT } from "../config/retry-config"
 import { formatError } from "../utils/Logger"
 import { openBrowser } from "./browser"
 
@@ -24,6 +24,11 @@ const LAUNCH_TIMEOUT_MS = 60_000
 // would trip the crash handler). It's a local transport, not a network round-trip,
 // so ~750ms is plenty; pkill -9 below is instant, keeping the fast retry fast.
 const BROWSER_CLOSE_TIMEOUT_MS = 750
+
+// Exit ASN the previous browser session in THIS pod left through. Only read on a
+// Zoom in-process retry, whose entire purpose is to escape an IP-keyed wall — a
+// relaunch that lands on the same network has bought nothing.
+let lastZoomExitAsn: number | null = null
 
 /**
  * Force-reap any Firefox/stealthfox processes still alive after context.close().
@@ -90,6 +95,26 @@ export async function establishBrowserSession(
         { countryOffset }
       )
       if (proxyUrl) session.proxyUrl = proxyUrl
+
+      // Every selected region refused us. Decodo answers 407 for regions a plan
+      // does not entitle, so a team pinned to a narrow region set can walk its
+      // whole list ("region X exit unreachable" → "all selected regions
+      // unreachable") and end up joining direct — from the pod's datacenter IP,
+      // the single strongest bot signal on both Meet and Zoom. An unpinned
+      // residential exit is strictly better than no exit, so spend one more
+      // start without the geo pin before conceding the proxy.
+      if (!session.proxyUrl) {
+        console.warn(
+          `[BrowserSession] pinned residential exit unavailable for ${platform} — retrying without a geo pin`
+        )
+        const unpinned = await startToggleProxy(
+          GLOBAL.get().bot_uuid,
+          retryCount,
+          `${opts.sessionSuffix ?? ""}nopin`,
+          { skipGeoPin: true }
+        )
+        if (unpinned) session.proxyUrl = unpinned
+      }
 
       // Burned-ASN avoidance (Meet only). startToggleProxy already probed the
       // exit IP + ASN. If we landed on a network Google is currently flagging,
@@ -206,7 +231,37 @@ export async function establishBrowserSession(
     }
   }
 
-  // Meet, no proxy, retries remain → requeue instead of joining direct.
+  // A Zoom in-pod relaunch exists to escape an IP-keyed wall, so it is worth
+  // nothing unless the exit actually moved. Decodo always hands back a new
+  // session label; on a narrow pinned pool it can hand back the same network
+  // every time. Meet verifies this already (burned-ASN loop above) — Zoom
+  // assumed it. Verify, and re-roll onto the next candidate region if not.
+  if (session.proxyUrl && platform === "zoom" && (opts.inProcessAttempt ?? 0) > 0) {
+    const ASN_ROTATIONS = 2
+    for (let rot = 1; rot <= ASN_ROTATIONS; rot++) {
+      const asn = getExitAsn()
+      if (asn === null || asn !== lastZoomExitAsn) break
+      console.warn(
+        `[BrowserSession] Zoom in-pod retry landed on the same exit ASN ${asn} — rotating (${rot}/${ASN_ROTATIONS})`
+      )
+      const rotated = await startToggleProxy(
+        GLOBAL.get().bot_uuid,
+        retryCount,
+        `${opts.sessionSuffix ?? ""}a${rot}`,
+        { countryOffset: countryOffset + rot }
+      )
+      if (!rotated) {
+        // The rotation tore the old proxy down without replacing it — don't
+        // launch against a dead proxy URL; the guard below decides what next.
+        session.proxyUrl = undefined
+        break
+      }
+      session.proxyUrl = rotated
+    }
+  }
+  if (platform === "zoom") lastZoomExitAsn = getExitAsn()
+
+  // Meet/Zoom, no proxy, retries remain → requeue instead of joining direct.
   // A proxyless Meet join comes from the pod's datacenter IP and flags ~94%
   // (measured in prod during the 2026-08-10 Decodo capacity burst: 523
   // upstream_unreachable joins → 491 flagged) — it burns the team's
@@ -216,14 +271,22 @@ export async function establishBrowserSession(
   // clear session.proxyUrl on a failed rotation — not just the initial proxy
   // start. The LAST retry still falls back to a live/direct exit as the
   // final resort rather than never joining.
-  if (platform === "meet" && !session.proxyUrl && retryCount < MAX_RETRY_COUNT) {
+  // Zoom is included because its browser-join wall blocks datacenter IPs
+  // outright: measured over 14 days of prod, attempts that fell through to a
+  // proxy-less join were walled 93% of the time. The cap is platform-aware
+  // (getMaxRetryCount), so Meet keeps exactly the budget it had.
+  if (
+    (platform === "meet" || platform === "zoom") &&
+    !session.proxyUrl &&
+    retryCount < getMaxRetryCount()
+  ) {
     console.warn(
-      "[BrowserSession] Meet proxy unavailable — requeueing instead of a direct (datacenter-IP) join"
+      `[BrowserSession] ${platform} proxy unavailable — requeueing instead of a direct (datacenter-IP) join`
     )
     GLOBAL.setError(MeetingEndReason.ProxyUnavailable)
     GLOBAL.setShouldRetry(true)
     throw new Error(
-      "Residential proxy unavailable for Meet join — requeueing to retry when the pool has capacity"
+      `Residential proxy unavailable for ${platform} join — requeueing to retry when the pool has capacity`
     )
   }
 

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -79,6 +79,14 @@ export const envVars = cleanEnv(process.env, {
   // meet/teams later is a one-value change. Only takes effect when
   // STEALTHFOX_BINARY_PATH is set, so local/dev without the binary is unaffected.
   STEALTHFOX_PLATFORMS: str({ default: "zoom" }),
+  // Which platforms disguise a bot-sounding display name by swapping one letter
+  // of each offending token for a Cyrillic look-alike — comma-separated
+  // ("zoom", "zoom,meet", "all"). Empty (the default) leaves every name exactly
+  // as the customer typed it. Deploy-level, so it can be A/B'd from a configmap
+  // against the phase= field on the Zoom wall log line: a wall with
+  // phase=pre_name fired before the name was ever typed, and no naming change
+  // can move it.
+  HOMOGLYPH_NAME_PLATFORMS: str({ default: "" }),
   // Absolute path to the stealthfox Firefox binary. Baked into the Docker image
   // at /opt/stealthfox/<tag>/firefox by scripts/fetch-stealthfox.sh. Empty =
   // stealthfox disabled (falls back to CloakBrowser).

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -79,13 +79,7 @@ export const envVars = cleanEnv(process.env, {
   // meet/teams later is a one-value change. Only takes effect when
   // STEALTHFOX_BINARY_PATH is set, so local/dev without the binary is unaffected.
   STEALTHFOX_PLATFORMS: str({ default: "zoom" }),
-  // Which platforms disguise a bot-sounding display name by swapping one letter
-  // of each offending token for a Cyrillic look-alike — comma-separated
-  // ("zoom", "zoom,meet", "all"). Empty (the default) leaves every name exactly
-  // as the customer typed it. Deploy-level, so it can be A/B'd from a configmap
-  // against the phase= field on the Zoom wall log line: a wall with
-  // phase=pre_name fired before the name was ever typed, and no naming change
-  // can move it.
+  // Comma-separated platforms ("zoom", "all") that disguise bot-like names; empty = off.
   HOMOGLYPH_NAME_PLATFORMS: str({ default: "" }),
   // Absolute path to the stealthfox Firefox binary. Baked into the Docker image
   // at /opt/stealthfox/<tag>/firefox by scripts/fetch-stealthfox.sh. Empty =

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -284,8 +284,7 @@ export class DiarizationTracker {
       { botNames }
     )
     if (sourceDissonance) {
-      // Loud on purpose: it means an interceptor regressed and was silently
-      // wrong for a whole call. Counts and ratios only — names are PII.
+      // An interceptor was wrong for the whole call. Counts only: names are PII.
       console.error(
         `[DiarizationTracker] ⚠️ Source dissonance (${sourceDissonance.reason}): promoted ${sourceDissonance.promotedSource} over ${sourceDissonance.demotedSource}; ` +
           `effective speakers ${sourceDissonance.demotedSource}=${sourceDissonance.primaryEffectiveSpeakers} ${sourceDissonance.promotedSource}=${sourceDissonance.challengerEffectiveSpeakers}, ` +

--- a/src/diarization-tracker.ts
+++ b/src/diarization-tracker.ts
@@ -262,8 +262,12 @@ export class DiarizationTracker {
     // network authoritative; fallbacks fill large holes; boot gap retrofitted
     // onto the first identified speaker). See speaker-timeline-assembler.ts.
     const meetingEndRel = Math.max(0, (lastTimestamp - meetingStartTime) / 1000)
-    const { segments: assembled, filledBySource, retrofittedFromSeconds } =
-      assembleSpeakerTimeline(
+    const {
+      segments: assembled,
+      filledBySource,
+      retrofittedFromSeconds,
+      sourceDissonance
+    } = assembleSpeakerTimeline(
       [
         {
           kind: "network" as const,
@@ -279,6 +283,15 @@ export class DiarizationTracker {
       meetingEndRel,
       { botNames }
     )
+    if (sourceDissonance) {
+      // Loud on purpose: it means an interceptor regressed and was silently
+      // wrong for a whole call. Counts and ratios only — names are PII.
+      console.error(
+        `[DiarizationTracker] ⚠️ Source dissonance (${sourceDissonance.reason}): promoted ${sourceDissonance.promotedSource} over ${sourceDissonance.demotedSource}; ` +
+          `effective speakers ${sourceDissonance.demotedSource}=${sourceDissonance.primaryEffectiveSpeakers} ${sourceDissonance.promotedSource}=${sourceDissonance.challengerEffectiveSpeakers}, ` +
+          `dominance=${sourceDissonance.primaryDominance}, other-speaker seconds ${sourceDissonance.primaryOtherSeconds} -> ${sourceDissonance.challengerOtherSeconds}`
+      )
+    }
     for (const [kind, count] of Object.entries(filledBySource)) {
       console.log(
         `[DiarizationTracker] Filled ${count} timeline gap segment(s) from the ${kind} fallback`

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import {
   uploadLogsToS3,
   uploadScreenshotsToS3
 } from "./utils/Logger"
+import { isBotLikeName, skeletonizeBotName } from "./utils/bot-name-disguise"
 import { BotMessageSchema } from "./utils/meeting-params-schema"
 import { PathManager } from "./utils/PathManager"
 import { getMaxRetryCount } from "./config/retry-config"
@@ -24,10 +25,6 @@ import {
   requeueToSQS,
   shouldAttemptRetry
 } from "./utils/retry-handler"
-
-// Bot-like display-name tokens; log-only hint when a Zoom join is rejected.
-const BOT_LIKE_NAME_RE =
-  /note ?taker|recorder|recording|transcri|\bbots?\b|\bai\b|assistant|\bnotes?\b/i
 
 /**
  * SIGTERM does not always mean "the cluster is taking this pod away".
@@ -203,7 +200,10 @@ async function handleFailedRecording(): Promise<void> {
   if (
     (endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed ||
       endReason === MeetingEndReason.BotNotAccepted) &&
-    BOT_LIKE_NAME_RE.test(botName)
+    // Skeletonise first: with HOMOGLYPH_NAME_PLATFORMS on, the name reaching
+    // here already has a Cyrillic letter in the very token we are looking for,
+    // and a raw match would silently stop firing exactly when it matters most.
+    isBotLikeName(skeletonizeBotName(botName))
   ) {
     console.warn(
       `[Hint] Bot display name "${botName}" contains a bot-indicating keyword; some Zoom hosts auto-reject such names — a more human name may get admitted.`

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,21 +26,8 @@ import {
   shouldAttemptRetry
 } from "./utils/retry-handler"
 
-/**
- * SIGTERM does not always mean "the cluster is taking this pod away".
- *
- * The supervisor that launched this process (apps/sqs-consumer) also runs a
- * watchdog that SIGTERMs a bot which has outlived its recording window — a floor
- * of REDIS_SESSION_EXPIRATION_SEC, five hours by default. That is the OPPOSITE
- * of an eviction: the bot is wedged, the meeting it was sent to ended hours ago,
- * and requeuing relaunches it into a dead meeting. Measured in prod, this
- * produced relaunches of the same bot_uuid at exactly 18000s and 36000s after
- * the first, each burning a pod, a video-device slot and a proxy session.
- *
- * The supervisor drops a sentinel file before it kills, and names it in
- * WATCHDOG_KILL_SENTINEL. Absent env var or absent file → an eviction, and the
- * requeue below is correct. Present → salvage the artifacts, never requeue.
- */
+// sqs-consumer's watchdog drops WATCHDOG_KILL_SENTINEL before SIGTERMing a bot that
+// outlived its recording window; requeuing it would relaunch into a dead meeting.
 function killedByWatchdog(): boolean {
   const sentinel = process.env["WATCHDOG_KILL_SENTINEL"]
   if (!sentinel) return false
@@ -200,9 +187,7 @@ async function handleFailedRecording(): Promise<void> {
   if (
     (endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed ||
       endReason === MeetingEndReason.BotNotAccepted) &&
-    // Skeletonise first: with HOMOGLYPH_NAME_PLATFORMS on, the name reaching
-    // here already has a Cyrillic letter in the very token we are looking for,
-    // and a raw match would silently stop firing exactly when it matters most.
+    // Undo the homoglyph disguise before matching.
     isBotLikeName(skeletonizeBotName(botName))
   ) {
     console.warn(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { exit } from "node:process"
 import { ZodError } from "zod"
 import { Api } from "./api/methods"
@@ -28,6 +29,31 @@ import {
 const BOT_LIKE_NAME_RE =
   /note ?taker|recorder|recording|transcri|\bbots?\b|\bai\b|assistant|\bnotes?\b/i
 
+/**
+ * SIGTERM does not always mean "the cluster is taking this pod away".
+ *
+ * The supervisor that launched this process (apps/sqs-consumer) also runs a
+ * watchdog that SIGTERMs a bot which has outlived its recording window — a floor
+ * of REDIS_SESSION_EXPIRATION_SEC, five hours by default. That is the OPPOSITE
+ * of an eviction: the bot is wedged, the meeting it was sent to ended hours ago,
+ * and requeuing relaunches it into a dead meeting. Measured in prod, this
+ * produced relaunches of the same bot_uuid at exactly 18000s and 36000s after
+ * the first, each burning a pod, a video-device slot and a proxy session.
+ *
+ * The supervisor drops a sentinel file before it kills, and names it in
+ * WATCHDOG_KILL_SENTINEL. Absent env var or absent file → an eviction, and the
+ * requeue below is correct. Present → salvage the artifacts, never requeue.
+ */
+function killedByWatchdog(): boolean {
+  const sentinel = process.env["WATCHDOG_KILL_SENTINEL"]
+  if (!sentinel) return false
+  try {
+    return existsSync(sentinel)
+  } catch {
+    return false
+  }
+}
+
 // On SIGTERM (k8s eviction), requeue the meeting to a fresh pod so it isn't lost.
 // The shared GLOBAL.claimRecovery() token is taken ONLY right before a requeue, so
 // at most one requeue happens; a non-requeuing path must never take it (that would
@@ -39,7 +65,15 @@ process.on("SIGTERM", async () => {
     console.log("[SIGTERM] Recovery already owned by a requeuing handler — standing down")
     return
   }
-  console.error("[SIGTERM] Pod termination received — requeuing so the meeting isn't lost")
+  const watchdogKill = killedByWatchdog()
+  if (watchdogKill) {
+    console.error(
+      "[SIGTERM] Watchdog kill — this bot outlived its recording window; salvaging artifacts, NOT requeuing"
+    )
+    GLOBAL.setShouldRetry(false)
+  } else {
+    console.error("[SIGTERM] Pod termination received — requeuing so the meeting isn't lost")
+  }
   try {
     if (!GLOBAL.isServerless()) await uploadLogsToS3()
   } catch (e) {
@@ -49,6 +83,8 @@ process.on("SIGTERM", async () => {
     if (GLOBAL.hasRecordingFinalized()) {
       // Merged recording exists — preserve for S3/EFS salvage, don't requeue (no claim).
       console.log("[SIGTERM] Recording finalized — preserving artifacts (not requeuing)")
+    } else if (watchdogKill) {
+      console.log("[SIGTERM] Watchdog kill — artifacts preserved, requeue deliberately skipped")
     } else if (!GLOBAL.isServerless()) {
       GLOBAL.setShouldRetry(true)
       if (shouldAttemptRetry(GLOBAL.getRetryCount())) {

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -437,6 +437,10 @@ export function browserInterceptionLogic(schema: any[]) {
     // join. Proven-foreign only — a device id whose space cannot be parsed still
     // merges exactly as before, so this can never starve a roster.
     let ownSpace: string | null = null
+    // True once ownSpace came from the bot's OWN device record. A majority pin is
+    // a guess made before that record arrives; this one cannot be wrong, so it
+    // supersedes the guess and is never reconsidered.
+    let ownSpaceIsAuthoritative = false
     let foreignSpaceUsers = 0
 
     function spaceOf(deviceId: unknown): string | null {
@@ -445,22 +449,59 @@ export function browserInterceptionLogic(schema: any[]) {
       return match ? match[1] : null
     }
 
+    function isSelfRecord(user: any): boolean {
+      return user?.isCurrentUserString === "true" || user?.isCurrentUserString === "1"
+    }
+
     function updateUsers(userManager: any, users: any[]) {
       const rostered = users.filter((u) => u?.deviceId)
 
-      if (!ownSpace) {
-        // The space most of this first roster belongs to. A majority rather than
-        // the first entry, so one stray record cannot pin the wrong conference.
-        const counts = new Map<string, number>()
+      if (!ownSpaceIsAuthoritative) {
+        let selfSpace: string | null = null
         for (const user of rostered) {
+          if (!isSelfRecord(user)) continue
           const space = spaceOf(user.deviceId)
-          if (space) counts.set(space, (counts.get(space) ?? 0) + 1)
+          if (space) {
+            selfSpace = space
+            break
+          }
         }
-        let best = 0
-        for (const [space, count] of counts) {
-          if (count > best) {
-            best = count
-            ownSpace = space
+
+        if (selfSpace) {
+          if (ownSpace && ownSpace !== selfSpace) {
+            // The provisional pin named the wrong conference. Users admitted
+            // under it are already in the map, so re-pinning alone would leave
+            // the foreign ones merged — drop them as we correct the pin.
+            let purged = 0
+            for (const deviceId of [...userManager.allUsersMap.keys()]) {
+              const space = spaceOf(deviceId)
+              if (space && space !== selfSpace) {
+                userManager.allUsersMap.delete(deviceId)
+                purged++
+              }
+            }
+            console.warn(
+              `[NetworkInterceptor] 🔒 re-pinned the conference from the bot's own device (dropped ${purged} user(s) admitted under the provisional pin)`
+            )
+          }
+          ownSpace = selfSpace
+          ownSpaceIsAuthoritative = true
+        } else if (!ownSpace) {
+          // No self record yet. Fall back to the space most of this roster
+          // belongs to — a majority rather than the first entry, so one stray
+          // record cannot pin the wrong conference — and let the self record
+          // correct it if this guess turns out wrong.
+          const counts = new Map<string, number>()
+          for (const user of rostered) {
+            const space = spaceOf(user.deviceId)
+            if (space) counts.set(space, (counts.get(space) ?? 0) + 1)
+          }
+          let best = 0
+          for (const [space, count] of counts) {
+            if (count > best) {
+              best = count
+              ownSpace = space
+            }
           }
         }
       }

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -427,12 +427,55 @@ export function browserInterceptionLogic(schema: any[]) {
         })
     }
 
+    // ===== CONFERENCE SCOPE =====
+    // Every Meet device id is `spaces/<space>/devices/<n>`, so a roster payload
+    // states which conference it describes. The bot's tab is only ever in one, and
+    // the fetch hook that feeds updateUsers matches broadly (any URL containing
+    // "meet/"), so pin the space the first roster establishes and refuse users from
+    // any other one. This is the Meet counterpart of the Teams roster scoping: a
+    // signed-in bot must never merge a participant from a conference it did not
+    // join. Proven-foreign only — a device id whose space cannot be parsed still
+    // merges exactly as before, so this can never starve a roster.
+    let ownSpace: string | null = null
+    let foreignSpaceUsers = 0
+
+    function spaceOf(deviceId: unknown): string | null {
+      if (typeof deviceId !== "string") return null
+      const match = deviceId.match(/^spaces\/([^/]+)\//)
+      return match ? match[1] : null
+    }
+
     function updateUsers(userManager: any, users: any[]) {
-      users
-        .filter((u) => u?.deviceId)
-        .forEach((user) => {
-          userManager.allUsersMap.set(user.deviceId, user)
-        })
+      const rostered = users.filter((u) => u?.deviceId)
+
+      if (!ownSpace) {
+        // The space most of this first roster belongs to. A majority rather than
+        // the first entry, so one stray record cannot pin the wrong conference.
+        const counts = new Map<string, number>()
+        for (const user of rostered) {
+          const space = spaceOf(user.deviceId)
+          if (space) counts.set(space, (counts.get(space) ?? 0) + 1)
+        }
+        let best = 0
+        for (const [space, count] of counts) {
+          if (count > best) {
+            best = count
+            ownSpace = space
+          }
+        }
+      }
+
+      for (const user of rostered) {
+        const space = spaceOf(user.deviceId)
+        if (ownSpace && space && space !== ownSpace) {
+          foreignSpaceUsers++
+          console.warn(
+            `[NetworkInterceptor] 🔒 dropped a user from another conference (${foreignSpaceUsers} so far)`
+          )
+          continue
+        }
+        userManager.allUsersMap.set(user.deviceId, user)
+      }
     }
 
     function getAllUsers(userManager: any) {

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -428,18 +428,9 @@ export function browserInterceptionLogic(schema: any[]) {
     }
 
     // ===== CONFERENCE SCOPE =====
-    // Every Meet device id is `spaces/<space>/devices/<n>`, so a roster payload
-    // states which conference it describes. The bot's tab is only ever in one, and
-    // the fetch hook that feeds updateUsers matches broadly (any URL containing
-    // "meet/"), so pin the space the first roster establishes and refuse users from
-    // any other one. This is the Meet counterpart of the Teams roster scoping: a
-    // signed-in bot must never merge a participant from a conference it did not
-    // join. Proven-foreign only — a device id whose space cannot be parsed still
-    // merges exactly as before, so this can never starve a roster.
+    // Device ids are `spaces/<space>/devices/<n>`: pin our space, drop users from any other.
     let ownSpace: string | null = null
-    // True once ownSpace came from the bot's OWN device record. A majority pin is
-    // a guess made before that record arrives; this one cannot be wrong, so it
-    // supersedes the guess and is never reconsidered.
+    // Set once ownSpace comes from the bot's own device record, not a majority guess.
     let ownSpaceIsAuthoritative = false
     let foreignSpaceUsers = 0
 
@@ -469,9 +460,7 @@ export function browserInterceptionLogic(schema: any[]) {
 
         if (selfSpace) {
           if (ownSpace && ownSpace !== selfSpace) {
-            // The provisional pin named the wrong conference. Users admitted
-            // under it are already in the map, so re-pinning alone would leave
-            // the foreign ones merged — drop them as we correct the pin.
+            // The provisional pin was wrong; purge users admitted under it.
             let purged = 0
             for (const deviceId of [...userManager.allUsersMap.keys()]) {
               const space = spaceOf(deviceId)
@@ -487,10 +476,7 @@ export function browserInterceptionLogic(schema: any[]) {
           ownSpace = selfSpace
           ownSpaceIsAuthoritative = true
         } else if (!ownSpace) {
-          // No self record yet. Fall back to the space most of this roster
-          // belongs to — a majority rather than the first entry, so one stray
-          // record cannot pin the wrong conference — and let the self record
-          // correct it if this guess turns out wrong.
+          // No self record yet: provisionally pin the majority space.
           const counts = new Map<string, number>()
           for (const user of rostered) {
             const space = spaceOf(user.deviceId)
@@ -711,18 +697,8 @@ export function browserInterceptionLogic(schema: any[]) {
       return audioData.some((v) => Math.abs(v) > 0.001)
     }
 
-    // Find users with audio levels from contributing sources.
-    //
-    // Ranks every AUDIBLE source, including ones whose SSRC has no device
-    // mapping yet. Filtering unresolved sources out before the sort silently
-    // handed the turn to the loudest source we happened to be able to name:
-    // a participant whose SSRC never resolved was invisible, so the other
-    // participant won every sample — over an open mic that clears the level
-    // threshold all call, that is one speaker for the whole meeting, broadcast
-    // once (the callers dedupe on change) and never corrected. Prod: a 30
-    // minute Meet with three roster entries came back 100% attributed to one
-    // person. Callers must therefore handle `user` being null — see
-    // speakingDeviceOf.
+    // Rank every audible source, including unresolved SSRCs (`user` null), so an
+    // unnameable speaker can't hand every turn to the nameable one.
     function getUsersWithAudio(contributingSources: any[], userManager: any): any[] {
       return contributingSources
         .map((source) => ({
@@ -735,11 +711,7 @@ export function browserInterceptionLogic(schema: any[]) {
         .sort((a, b) => b.audioLevel - a.audioLevel)
     }
 
-    // Device id to attribute an audio entry to. An unresolved SSRC keeps its
-    // own identity (the SSRC itself, matching how the dcrpc path keys speakers
-    // it cannot name) so turn boundaries survive as "Unknown" instead of being
-    // merged into whoever happened to be nameable. Finalize treats an Unknown
-    // stretch as a hole and lets the UI observer name it.
+    // An unresolved SSRC is keyed by the SSRC itself, surfacing as its own "Unknown".
     function speakingDeviceOf(entry: any): string | null {
       if (!entry) return null
       return entry.user ? entry.user.deviceId : String(entry.ssrc)
@@ -818,10 +790,7 @@ export function browserInterceptionLogic(schema: any[]) {
       const filteredUsers = filterActiveUsers(allUsers)
       const users = buildUserStateList(filteredUsers, speakingDeviceId, audioLevel)
 
-      // The speaker is audible but not in the roster (an SSRC no collections
-      // record mapped, or a user filterActiveUsers dropped). Emit it as its own
-      // Unknown participant rather than sending an all-silent update that would
-      // leave the previous speaker holding the turn. Mirrors broadcastDcrpcSpeakers.
+      // Audible but not rostered: emit as Unknown so the last speaker doesn't keep the turn.
       if (speakingDeviceId && !users.some((u: any) => u.deviceId === speakingDeviceId)) {
         users.push({
           deviceId: speakingDeviceId,

--- a/src/meeting/meet/network-interception/browser-bundle.ts
+++ b/src/meeting/meet/network-interception/browser-bundle.ts
@@ -670,7 +670,18 @@ export function browserInterceptionLogic(schema: any[]) {
       return audioData.some((v) => Math.abs(v) > 0.001)
     }
 
-    // Find users with audio levels from contributing sources
+    // Find users with audio levels from contributing sources.
+    //
+    // Ranks every AUDIBLE source, including ones whose SSRC has no device
+    // mapping yet. Filtering unresolved sources out before the sort silently
+    // handed the turn to the loudest source we happened to be able to name:
+    // a participant whose SSRC never resolved was invisible, so the other
+    // participant won every sample — over an open mic that clears the level
+    // threshold all call, that is one speaker for the whole meeting, broadcast
+    // once (the callers dedupe on change) and never corrected. Prod: a 30
+    // minute Meet with three roster entries came back 100% attributed to one
+    // person. Callers must therefore handle `user` being null — see
+    // speakingDeviceOf.
     function getUsersWithAudio(contributingSources: any[], userManager: any): any[] {
       return contributingSources
         .map((source) => ({
@@ -679,8 +690,18 @@ export function browserInterceptionLogic(schema: any[]) {
           timestamp: source.timestamp,
           user: getUserByStreamId(userManager, source.source.toString())
         }))
-        .filter((x) => x.user && x.audioLevel > 0.05)
+        .filter((x) => x.audioLevel > 0.05)
         .sort((a, b) => b.audioLevel - a.audioLevel)
+    }
+
+    // Device id to attribute an audio entry to. An unresolved SSRC keeps its
+    // own identity (the SSRC itself, matching how the dcrpc path keys speakers
+    // it cannot name) so turn boundaries survive as "Unknown" instead of being
+    // merged into whoever happened to be nameable. Finalize treats an Unknown
+    // stretch as a hole and lets the UI observer name it.
+    function speakingDeviceOf(entry: any): string | null {
+      if (!entry) return null
+      return entry.user ? entry.user.deviceId : String(entry.ssrc)
     }
 
     // Build user state list with speaking status
@@ -755,6 +776,22 @@ export function browserInterceptionLogic(schema: any[]) {
       const allUsers = getAllUsers(userManager)
       const filteredUsers = filterActiveUsers(allUsers)
       const users = buildUserStateList(filteredUsers, speakingDeviceId, audioLevel)
+
+      // The speaker is audible but not in the roster (an SSRC no collections
+      // record mapped, or a user filterActiveUsers dropped). Emit it as its own
+      // Unknown participant rather than sending an all-silent update that would
+      // leave the previous speaker holding the turn. Mirrors broadcastDcrpcSpeakers.
+      if (speakingDeviceId && !users.some((u: any) => u.deviceId === speakingDeviceId)) {
+        users.push({
+          deviceId: speakingDeviceId,
+          name: "Unknown",
+          isCurrentUser: false,
+          isSpeaking: true,
+          status: 1,
+          isHost: false,
+          audioLevel
+        })
+      }
 
       // Calls the Node-side callback exposed via Playwright"s exposeFunction (see network-interception/index.ts)
       // This crosses the browser/Node boundary → triggers NetworkSpeakerLogger.handleNetworkPayload
@@ -972,8 +1009,8 @@ export function browserInterceptionLogic(schema: any[]) {
                     // DEBUG: Log speaker detection only when speaker changes (reduces noise significantly)
                     // The speaker change log below will handle the important state changes
 
-                    if (loudestSpeaker?.user) {
-                      const currentSpeakerId = loudestSpeaker.user.deviceId
+                    const currentSpeakerId = speakingDeviceOf(loudestSpeaker)
+                    if (currentSpeakerId) {
                       // Only broadcast if speaker changed
                       if (currentSpeakerId !== lastBroadcastedSpeakerId) {
                         console.error(
@@ -1317,8 +1354,8 @@ export function browserInterceptionLogic(schema: any[]) {
 
         const usersWithAudioLevels = getUsersWithAudio(freshSources, userManager)
         const loudestSpeaker = usersWithAudioLevels[0]
-        if (loudestSpeaker?.user) {
-          const currentSpeakerId = loudestSpeaker.user.deviceId
+        const currentSpeakerId = speakingDeviceOf(loudestSpeaker)
+        if (currentSpeakerId) {
           if (currentSpeakerId !== lastBroadcastedSpeakerId) {
             console.error(
               `[NetworkInterceptor] 🎤 Speaker changed (csrc sample): ${lastBroadcastedSpeakerId || "none"} → ${currentSpeakerId} (audioLevel: ${loudestSpeaker.audioLevel})`

--- a/src/meeting/teams.ts
+++ b/src/meeting/teams.ts
@@ -420,7 +420,7 @@ export class TeamsProvider implements MeetingProviderInterface {
 
     try {
       const { setupTeamsNetworkInterceptionScripts } = await import("./teams/network-interception")
-      const success = await setupTeamsNetworkInterceptionScripts(page)
+      const success = await setupTeamsNetworkInterceptionScripts(page, link)
       if (!success) {
         console.warn("[Teams] ⚠️ Failed to setup network interception scripts")
       }

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -12,13 +12,7 @@
 import type { RosterScopeResolver, TeamsInterceptorScope } from "./meeting-scope"
 import type { SpeakerSetResolver, SpeakerTimelineRung } from "./speaker-timeline"
 
-/**
- * @param resolveSpeakingSet - Passed in, not imported: this is stringified into the page.
- * @param resolveRosterScope - Likewise. Keeps the roster-scoping decision in one
- *   tested place (meeting-scope.ts) instead of a second copy inlined here.
- * @param meetingScope - Which conversation this bot joined, and whether it signed in.
- *   Serialized in by the injector for the same reason.
- */
+/** Arguments are passed in, not imported: this function is stringified into the page. */
 export function teamsBrowserInterceptionLogic(
   resolveSpeakingSet: SpeakerSetResolver,
   resolveRosterScope: RosterScopeResolver,
@@ -194,30 +188,18 @@ export function teamsBrowserInterceptionLogic(
       captionsEnabled: false,
       // Caption interval overruling a live dsh — 0 on single-signal sessions.
       rungCaptionOverDsh: 0,
-      // Roster scoping. rosterScopeRejected > 0 means this session was offered a
-      // roster belonging to another meeting — the concurrent-signed-in-session
-      // leak. unplaceable counts payloads carrying no conversation id (what strict
-      // mode would additionally drop); unknown counts payloads seen before this
-      // bot's own conversation could be identified at all.
+      // Roster scoping; rosterScopeRejected > 0 means another meeting's roster was offered.
       ownConversationKnown: false,
       rosterScopeRejected: 0,
       rosterScopeAggregate: 0,
       rosterScopeUnplaceable: 0,
       rosterScopeUnknown: 0,
-      // True if strict scoping was backed off to keep a signed-in session's roster
-      // from starving — the signal that this meeting's roster traffic is unscoped.
       rosterScopeStrictRelaxed: false
     }
     const diag = (window as any).__teamsNetDiag
 
     // ===== MEETING SCOPE =====
-    // Only merge roster payloads that belong to the meeting this bot joined.
-    // An anonymous bot's page only ever knows one meeting, so this is a no-op for
-    // it. A signed-in bot's page is a full Teams client for the M365 account and
-    // also fetches state for OTHER calls that account is in — which is how
-    // concurrent sessions on one teams_login mixed their rosters. The decision
-    // itself lives in meeting-scope.ts and is passed in (this function is
-    // stringified into the page and cannot import at runtime).
+    // Merge only roster payloads for the meeting this bot joined (see meeting-scope.ts).
     const scope: TeamsInterceptorScope = meetingScope || {
       conversationId: null,
       isAuthenticated: false
@@ -225,35 +207,12 @@ export function teamsBrowserInterceptionLogic(
     let ownConversation: string | null = scope.conversationId
     diag.ownConversationKnown = Boolean(ownConversation)
 
-    // Signed-in bots require positive proof that a roster payload belongs to this
-    // meeting. The one risk in that is a session whose roster traffic carries no
-    // conversation id anywhere, which would leave the bot knowing nobody — so this
-    // self-corrects instead of hiding behind config: if strict scoping has dropped
-    // unplaceable payloads and the roster is STILL empty, it stops being strict.
-    // A relaxed session is back to dropping only proven-foreign payloads, which is
-    // strictly better than the pre-fix behaviour it falls back to.
+    // Signed-in bots scope strictly, but relax if that leaves the roster empty.
     const STRICT_ESCAPE_AFTER = 5
     let strict = scope.isAuthenticated
     let droppedWhileEmpty = 0
 
-    /**
-     * Latch the joined conversation off the live call, for join URLs that carry no
-     * thread id (short /meet/<code> links resolve it only after joining). Stored raw
-     * — resolveRosterScope extracts the id.
-     */
-    /**
-     * Whether `raw` actually names a conversation.
-     *
-     * getActiveCall() can expose a call GUID (`call.id`) before any thread id is
-     * available. Latching that would pin a value resolveRosterScope reads as
-     * "own-unknown" — which accepts EVERYTHING — for the rest of the meeting,
-     * and learnOwnConversation's own `if (ownConversation) return` guard means
-     * no later threadId could ever replace it. The diagnostic would report the
-     * scope as known while the scoping did nothing.
-     *
-     * Probing the injected resolver keeps the id grammar in the one tested
-     * place (meeting-scope.ts) rather than re-inlining the regex here.
-     */
+    // A bare call GUID names no conversation; latching one would switch scoping off.
     function namesAConversation(raw: string): boolean {
       return (
         resolveRosterScope({
@@ -264,6 +223,7 @@ export function teamsBrowserInterceptionLogic(
       )
     }
 
+    // Latch the conversation from the live call when the join URL had none.
     function learnOwnConversation(): void {
       if (ownConversation) return
       try {
@@ -289,9 +249,7 @@ export function teamsBrowserInterceptionLogic(
         isAuthenticated: scope.isAuthenticated,
         strict
       })
-      // Both strict-only rejections feed the same starvation escape hatch: a
-      // roster that is still empty after repeated drops means strict scoping is
-      // rejecting the only payloads this session carries participants on.
+      // Strict-only rejections count toward the starvation escape.
       const countTowardStrictEscape = () => {
         if (verdict.accept || participantsByDeviceId.size > 0) return
         droppedWhileEmpty++
@@ -449,8 +407,7 @@ export function teamsBrowserInterceptionLogic(
     function handleRosterUpdate(eventDataObject: any): void {
       try {
         const decodedBody = decodeWebSocketBody(eventDataObject.body)
-        // The trouter socket is per-USER, not per-call: an account in two meetings
-        // receives roster deltas for both over this one socket.
+        // The trouter socket is per user, so it carries other meetings' deltas too.
         if (!isInMeetingScope(eventDataObject?.url, JSON.stringify(decodedBody))) {
           debug("🔒 rejected out-of-scope roster frame", eventDataObject?.url)
           return

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -234,19 +234,43 @@ export function teamsBrowserInterceptionLogic(
     // strictly better than the pre-fix behaviour it falls back to.
     const STRICT_ESCAPE_AFTER = 5
     let strict = scope.isAuthenticated
-    let unplaceableWhileEmpty = 0
+    let droppedWhileEmpty = 0
 
     /**
      * Latch the joined conversation off the live call, for join URLs that carry no
      * thread id (short /meet/<code> links resolve it only after joining). Stored raw
      * — resolveRosterScope extracts the id.
      */
+    /**
+     * Whether `raw` actually names a conversation.
+     *
+     * getActiveCall() can expose a call GUID (`call.id`) before any thread id is
+     * available. Latching that would pin a value resolveRosterScope reads as
+     * "own-unknown" — which accepts EVERYTHING — for the rest of the meeting,
+     * and learnOwnConversation's own `if (ownConversation) return` guard means
+     * no later threadId could ever replace it. The diagnostic would report the
+     * scope as known while the scoping did nothing.
+     *
+     * Probing the injected resolver keeps the id grammar in the one tested
+     * place (meeting-scope.ts) rather than re-inlining the regex here.
+     */
+    function namesAConversation(raw: string): boolean {
+      return (
+        resolveRosterScope({
+          own: raw,
+          isAuthenticated: false,
+          strict: false
+        }).reason !== "own-unknown"
+      )
+    }
+
     function learnOwnConversation(): void {
       if (ownConversation) return
       try {
         const call = getActiveCall()
         const raw = call?.threadId || call?.conversationId || call?.threadKey || call?.id
         if (typeof raw !== "string" || !raw) return
+        if (!namesAConversation(raw)) return
         ownConversation = raw
         diag.ownConversationKnown = true
         debug("🔒 meeting scope learned from active call", raw)
@@ -265,20 +289,28 @@ export function teamsBrowserInterceptionLogic(
         isAuthenticated: scope.isAuthenticated,
         strict
       })
-      if (verdict.reason === "own-unknown") diag.rosterScopeUnknown++
-      else if (verdict.reason === "aggregate") diag.rosterScopeAggregate++
-      else if (verdict.reason === "unplaceable") {
-        diag.rosterScopeUnplaceable++
-        if (!verdict.accept && participantsByDeviceId.size === 0) {
-          unplaceableWhileEmpty++
-          if (unplaceableWhileEmpty >= STRICT_ESCAPE_AFTER) {
-            strict = false
-            diag.rosterScopeStrictRelaxed = true
-            console.warn(
-              `${LOG} ⚠️ roster still empty after dropping ${unplaceableWhileEmpty} unscoped payloads — relaxing to proven-foreign-only`
-            )
-          }
+      // Both strict-only rejections feed the same starvation escape hatch: a
+      // roster that is still empty after repeated drops means strict scoping is
+      // rejecting the only payloads this session carries participants on.
+      const countTowardStrictEscape = () => {
+        if (verdict.accept || participantsByDeviceId.size > 0) return
+        droppedWhileEmpty++
+        if (droppedWhileEmpty >= STRICT_ESCAPE_AFTER) {
+          strict = false
+          diag.rosterScopeStrictRelaxed = true
+          console.warn(
+            `${LOG} ⚠️ roster still empty after dropping ${droppedWhileEmpty} strictly-scoped payloads — relaxing to proven-foreign-only`
+          )
         }
+      }
+
+      if (verdict.reason === "own-unknown") diag.rosterScopeUnknown++
+      else if (verdict.reason === "aggregate") {
+        diag.rosterScopeAggregate++
+        countTowardStrictEscape()
+      } else if (verdict.reason === "unplaceable") {
+        diag.rosterScopeUnplaceable++
+        countTowardStrictEscape()
       }
       if (!verdict.accept) diag.rosterScopeRejected++
       return verdict.accept

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -9,10 +9,21 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: browser-side bundle over untyped Teams/WebRTC internals. */
 
 // Type-only: erased, so the stringified bundle stays self-contained.
+import type { RosterScopeResolver, TeamsInterceptorScope } from "./meeting-scope"
 import type { SpeakerSetResolver, SpeakerTimelineRung } from "./speaker-timeline"
 
-/** @param resolveSpeakingSet - Passed in, not imported: this is stringified into the page. */
-export function teamsBrowserInterceptionLogic(resolveSpeakingSet: SpeakerSetResolver) {
+/**
+ * @param resolveSpeakingSet - Passed in, not imported: this is stringified into the page.
+ * @param resolveRosterScope - Likewise. Keeps the roster-scoping decision in one
+ *   tested place (meeting-scope.ts) instead of a second copy inlined here.
+ * @param meetingScope - Which conversation this bot joined, and whether it signed in.
+ *   Serialized in by the injector for the same reason.
+ */
+export function teamsBrowserInterceptionLogic(
+  resolveSpeakingSet: SpeakerSetResolver,
+  resolveRosterScope: RosterScopeResolver,
+  meetingScope: TeamsInterceptorScope
+) {
   try {
     if ((window as any).__teamsNetworkInterceptorInitialized === true) {
       console.warn("[Teams NetworkInterceptor] ⚠️ Already initialized, skipping duplicate")
@@ -182,9 +193,96 @@ export function teamsBrowserInterceptionLogic(resolveSpeakingSet: SpeakerSetReso
       captionUnmatched: 0,
       captionsEnabled: false,
       // Caption interval overruling a live dsh — 0 on single-signal sessions.
-      rungCaptionOverDsh: 0
+      rungCaptionOverDsh: 0,
+      // Roster scoping. rosterScopeRejected > 0 means this session was offered a
+      // roster belonging to another meeting — the concurrent-signed-in-session
+      // leak. unplaceable counts payloads carrying no conversation id (what strict
+      // mode would additionally drop); unknown counts payloads seen before this
+      // bot's own conversation could be identified at all.
+      ownConversationKnown: false,
+      rosterScopeRejected: 0,
+      rosterScopeAggregate: 0,
+      rosterScopeUnplaceable: 0,
+      rosterScopeUnknown: 0,
+      // True if strict scoping was backed off to keep a signed-in session's roster
+      // from starving — the signal that this meeting's roster traffic is unscoped.
+      rosterScopeStrictRelaxed: false
     }
     const diag = (window as any).__teamsNetDiag
+
+    // ===== MEETING SCOPE =====
+    // Only merge roster payloads that belong to the meeting this bot joined.
+    // An anonymous bot's page only ever knows one meeting, so this is a no-op for
+    // it. A signed-in bot's page is a full Teams client for the M365 account and
+    // also fetches state for OTHER calls that account is in — which is how
+    // concurrent sessions on one teams_login mixed their rosters. The decision
+    // itself lives in meeting-scope.ts and is passed in (this function is
+    // stringified into the page and cannot import at runtime).
+    const scope: TeamsInterceptorScope = meetingScope || {
+      conversationId: null,
+      isAuthenticated: false
+    }
+    let ownConversation: string | null = scope.conversationId
+    diag.ownConversationKnown = Boolean(ownConversation)
+
+    // Signed-in bots require positive proof that a roster payload belongs to this
+    // meeting. The one risk in that is a session whose roster traffic carries no
+    // conversation id anywhere, which would leave the bot knowing nobody — so this
+    // self-corrects instead of hiding behind config: if strict scoping has dropped
+    // unplaceable payloads and the roster is STILL empty, it stops being strict.
+    // A relaxed session is back to dropping only proven-foreign payloads, which is
+    // strictly better than the pre-fix behaviour it falls back to.
+    const STRICT_ESCAPE_AFTER = 5
+    let strict = scope.isAuthenticated
+    let unplaceableWhileEmpty = 0
+
+    /**
+     * Latch the joined conversation off the live call, for join URLs that carry no
+     * thread id (short /meet/<code> links resolve it only after joining). Stored raw
+     * — resolveRosterScope extracts the id.
+     */
+    function learnOwnConversation(): void {
+      if (ownConversation) return
+      try {
+        const call = getActiveCall()
+        const raw = call?.threadId || call?.conversationId || call?.threadKey || call?.id
+        if (typeof raw !== "string" || !raw) return
+        ownConversation = raw
+        diag.ownConversationKnown = true
+        debug("🔒 meeting scope learned from active call", raw)
+      } catch {
+        // Teams internals unavailable — stay permissive.
+      }
+    }
+
+    /** Whether a roster payload may be merged into this bot's participant map. */
+    function isInMeetingScope(url: string | undefined, body: string | undefined): boolean {
+      learnOwnConversation()
+      const verdict = resolveRosterScope({
+        own: ownConversation,
+        url,
+        body,
+        isAuthenticated: scope.isAuthenticated,
+        strict
+      })
+      if (verdict.reason === "own-unknown") diag.rosterScopeUnknown++
+      else if (verdict.reason === "aggregate") diag.rosterScopeAggregate++
+      else if (verdict.reason === "unplaceable") {
+        diag.rosterScopeUnplaceable++
+        if (!verdict.accept && participantsByDeviceId.size === 0) {
+          unplaceableWhileEmpty++
+          if (unplaceableWhileEmpty >= STRICT_ESCAPE_AFTER) {
+            strict = false
+            diag.rosterScopeStrictRelaxed = true
+            console.warn(
+              `${LOG} ⚠️ roster still empty after dropping ${unplaceableWhileEmpty} unscoped payloads — relaxing to proven-foreign-only`
+            )
+          }
+        }
+      }
+      if (!verdict.accept) diag.rosterScopeRejected++
+      return verdict.accept
+    }
 
     // ===== TEAMS INTERNAL CALLING SDK (best-effort) =====
 
@@ -319,6 +417,12 @@ export function teamsBrowserInterceptionLogic(resolveSpeakingSet: SpeakerSetReso
     function handleRosterUpdate(eventDataObject: any): void {
       try {
         const decodedBody = decodeWebSocketBody(eventDataObject.body)
+        // The trouter socket is per-USER, not per-call: an account in two meetings
+        // receives roster deltas for both over this one socket.
+        if (!isInMeetingScope(eventDataObject?.url, JSON.stringify(decodedBody))) {
+          debug("🔒 rejected out-of-scope roster frame", eventDataObject?.url)
+          return
+        }
         const rawParticipants = Object.values<any>(decodedBody.participants || {})
         applyParticipants(rawParticipants)
       } catch (error) {
@@ -347,6 +451,10 @@ export function teamsBrowserInterceptionLogic(resolveSpeakingSet: SpeakerSetReso
     function tryHttpRoster(url: string, text: string): void {
       try {
         if (!text || text.indexOf("displayName") === -1) return
+        if (!isInMeetingScope(url, text)) {
+          debug("🔒 rejected out-of-scope roster payload", url)
+          return
+        }
         const body = JSON.parse(text)
         // The HTTP snapshot nests the roster as { roster: { participants: {mri: {...}} } };
         // other endpoints use top-level participants / value. Handle all as object-or-array.

--- a/src/meeting/teams/network-interception/index.ts
+++ b/src/meeting/teams/network-interception/index.ts
@@ -22,11 +22,7 @@ declare global {
   }
 }
 
-/**
- * The meeting this bot is joining, for roster scoping. `joinUrl` is the link the
- * bot is about to navigate to — deep links carry the conversation id, everything
- * else is resolved in-page from the live call.
- */
+/** Roster scope for the meeting at `joinUrl`; links without a thread id resolve in-page. */
 export function buildTeamsInterceptorScope(joinUrl: string): TeamsInterceptorScope {
   return {
     ...deriveMeetingScope(joinUrl),

--- a/src/meeting/teams/network-interception/index.ts
+++ b/src/meeting/teams/network-interception/index.ts
@@ -3,10 +3,13 @@
 
 import path from "node:path"
 import type { Page } from "@playwright/test"
+import { GLOBAL } from "../../../singleton"
 import { teamsBrowserInterceptionLogic } from "./browser-bundle"
+import { deriveMeetingScope, resolveRosterScope, type TeamsInterceptorScope } from "./meeting-scope"
 import { resolveSpeakingSet } from "./speaker-timeline"
 
 export type { NetworkPayload, NetworkUser } from "./types"
+
 import type { NetworkPayload } from "./types"
 
 declare global {
@@ -20,10 +23,25 @@ declare global {
 }
 
 /**
+ * The meeting this bot is joining, for roster scoping. `joinUrl` is the link the
+ * bot is about to navigate to — deep links carry the conversation id, everything
+ * else is resolved in-page from the live call.
+ */
+export function buildTeamsInterceptorScope(joinUrl: string): TeamsInterceptorScope {
+  return {
+    ...deriveMeetingScope(joinUrl),
+    isAuthenticated: Boolean(GLOBAL.get().teams_login_config)
+  }
+}
+
+/**
  * Inject interception scripts; must run BEFORE page.goto() (addInitScript only
  * applies to later navigations). Reuses the shared Meet libs bundle for pako.
  */
-export async function setupTeamsNetworkInterceptionScripts(page: Page): Promise<boolean> {
+export async function setupTeamsNetworkInterceptionScripts(
+  page: Page,
+  joinUrl: string
+): Promise<boolean> {
   try {
     const bundlePath = path.resolve(
       __dirname,
@@ -36,6 +54,11 @@ export async function setupTeamsNetworkInterceptionScripts(page: Page): Promise<
     return false
   }
 
+  const scope = buildTeamsInterceptorScope(joinUrl)
+  console.log(
+    `[Teams NetworkInterceptor] Roster scope: conversation=${scope.conversationId ?? "unresolved (will latch in-page)"} authenticated=${scope.isAuthenticated}`
+  )
+
   const script = `
         (function() {
             try {
@@ -44,7 +67,7 @@ export async function setupTeamsNetworkInterceptionScripts(page: Page): Promise<
                     console.error("[Teams NetworkInterceptor] pako dependency not loaded");
                 }
                 // As source: the stringified bundle cannot import it.
-                (${teamsBrowserInterceptionLogic.toString()})(${resolveSpeakingSet.toString()});
+                (${teamsBrowserInterceptionLogic.toString()})(${resolveSpeakingSet.toString()}, ${resolveRosterScope.toString()}, ${JSON.stringify(scope)});
             } catch (e) {
                 console.error("[Teams NetworkInterceptor] Initialization error:", e);
             }

--- a/src/meeting/teams/network-interception/meeting-scope.test.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.test.ts
@@ -1,0 +1,181 @@
+import { deriveMeetingScope, findConversationIds, resolveRosterScope } from "./meeting-scope"
+
+const OURS = "19:meeting_ndc4mjy5ndqtnwe2os00@thread.v2"
+const THEIRS = "19:meeting_zjjkzwrmnzytytc2os00@thread.v2"
+
+describe("findConversationIds", () => {
+  it("finds a raw conversation id in a URL path", () => {
+    expect(
+      findConversationIds(`https://teams.microsoft.com/api/csa/conversations/${OURS}/roster`)
+    ).toEqual([OURS])
+  })
+
+  it("finds a percent-encoded id", () => {
+    const encoded = encodeURIComponent(OURS)
+    expect(encoded).not.toBe(OURS)
+    expect(findConversationIds(`https://teams.microsoft.com/api/v1?threadId=${encoded}`)).toEqual([
+      OURS
+    ])
+  })
+
+  it("finds ids inside a JSON body", () => {
+    const body = JSON.stringify({ roster: { conversationId: OURS, participants: {} } })
+    expect(findConversationIds(body)).toEqual([OURS])
+  })
+
+  it("is case-insensitive and de-duplicates", () => {
+    const text = `${OURS} ${OURS.toUpperCase()}`
+    expect(findConversationIds(text)).toEqual([OURS])
+  })
+
+  it("returns every distinct id from an account-scoped aggregate", () => {
+    const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
+    expect(findConversationIds(body).sort()).toEqual([OURS, THEIRS].sort())
+  })
+
+  it("matches the other thread suffixes Teams uses", () => {
+    expect(findConversationIds("19:abc123@thread.tacv2")).toEqual(["19:abc123@thread.tacv2"])
+    expect(findConversationIds("19:abc123@thread.skype")).toEqual(["19:abc123@thread.skype"])
+  })
+
+  it("returns nothing for payloads with no conversation id", () => {
+    expect(findConversationIds("")).toEqual([])
+    expect(findConversationIds('{"participants":{"8:orgid:abc":{"displayName":"A"}}}')).toEqual([])
+  })
+
+  it("does not mistake a user MRI for a conversation id", () => {
+    expect(findConversationIds("8:orgid:2b9f0e5c-1111-2222-3333-444455556666")).toEqual([])
+  })
+
+  it("survives malformed percent-encoding", () => {
+    expect(findConversationIds(`%E0%A4%A ${OURS}`)).toEqual([OURS])
+  })
+})
+
+describe("deriveMeetingScope", () => {
+  it("reads the conversation off a meetup-join deep link", () => {
+    const url = `https://teams.microsoft.com/v2/?meetingjoin=true#/l/meetup-join/${OURS}/0?context=%7B%22Tid%22%3A%22t%22%7D`
+    expect(deriveMeetingScope(url).conversationId).toBe(OURS)
+  })
+
+  it("reads the conversation off an encoded deep link", () => {
+    const url = `https://teams.microsoft.com/l/meetup-join/${encodeURIComponent(OURS)}/0`
+    expect(deriveMeetingScope(url).conversationId).toBe(OURS)
+  })
+
+  it("yields null for a short /meet/ join code, to be latched in-page", () => {
+    expect(
+      deriveMeetingScope("https://teams.microsoft.com/meet/357286674199395?p=abc").conversationId
+    ).toBeNull()
+  })
+
+  it("yields null rather than guessing when a link names several conversations", () => {
+    expect(
+      deriveMeetingScope(`https://x/l/meetup-join/${OURS}/0?prev=${THEIRS}`).conversationId
+    ).toBeNull()
+  })
+
+  it("tolerates an empty or missing URL", () => {
+    expect(deriveMeetingScope("").conversationId).toBeNull()
+    expect(deriveMeetingScope(undefined as unknown as string).conversationId).toBeNull()
+  })
+})
+
+describe("resolveRosterScope", () => {
+  // How the interceptor actually calls this: anonymous bots never scope strictly,
+  // signed-in bots do until they self-relax to keep a roster from starving.
+  const anon = { isAuthenticated: false, strict: false }
+  const signedIn = { isAuthenticated: true, strict: true }
+  const signedInRelaxed = { isAuthenticated: true, strict: false }
+
+  it("accepts a payload scoped to our own conversation", () => {
+    expect(
+      resolveRosterScope({ own: OURS, url: `/csa/conversations/${OURS}/roster`, ...signedIn })
+    ).toEqual({ accept: true, reason: "match" })
+  })
+
+  it("rejects a payload scoped to another conversation — the concurrent-session leak", () => {
+    expect(
+      resolveRosterScope({ own: OURS, url: `/csa/conversations/${THEIRS}/roster`, ...signedIn })
+    ).toEqual({ accept: false, reason: "foreign" })
+  })
+
+  it("rejects a foreign payload identified only by its body", () => {
+    const body = JSON.stringify({ roster: { conversationId: THEIRS, participants: {} } })
+    expect(resolveRosterScope({ own: OURS, url: "/api/v2/state", body, ...signedIn }).accept).toBe(
+      false
+    )
+  })
+
+  it("rejects an account-scoped aggregate for a signed-in bot", () => {
+    const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
+    expect(resolveRosterScope({ own: OURS, body, ...signedIn })).toEqual({
+      accept: false,
+      reason: "aggregate"
+    })
+  })
+
+  it("keeps anonymous behaviour unchanged for that same aggregate", () => {
+    // An anonymous bot's page never sees another meeting, so nothing is taken away
+    // from the path that had no incident.
+    const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
+    expect(resolveRosterScope({ own: OURS, body, ...anon })).toEqual({
+      accept: true,
+      reason: "match"
+    })
+  })
+
+  it("drops a payload it cannot place when signed in — nothing merges without proof", () => {
+    const body = '{"participants":{"8:orgid:abc":{"displayName":"A"}}}'
+    expect(resolveRosterScope({ own: OURS, url: "/api/roster", body, ...signedIn })).toEqual({
+      accept: false,
+      reason: "unplaceable"
+    })
+  })
+
+  it("keeps an unplaceable payload once a starved session has relaxed", () => {
+    const body = '{"participants":{"8:orgid:abc":{"displayName":"A"}}}'
+    expect(resolveRosterScope({ own: OURS, body, ...signedInRelaxed })).toEqual({
+      accept: true,
+      reason: "unplaceable"
+    })
+  })
+
+  it("never drops an unplaceable payload for an anonymous bot", () => {
+    const body = '{"participants":{"8:orgid:abc":{"displayName":"A"}}}'
+    expect(
+      resolveRosterScope({ own: OURS, body, isAuthenticated: false, strict: true }).accept
+    ).toBe(true)
+  })
+
+  it("accepts everything until our own conversation is identified", () => {
+    expect(
+      resolveRosterScope({ own: null, url: `/conversations/${THEIRS}/roster`, ...signedIn })
+    ).toEqual({ accept: true, reason: "own-unknown" })
+  })
+
+  it("extracts our conversation from a raw call threadId", () => {
+    expect(
+      resolveRosterScope({ own: `thread:${OURS};ctx=1`, url: `/x/${THEIRS}`, ...signedIn }).accept
+    ).toBe(false)
+    expect(
+      resolveRosterScope({ own: `thread:${OURS};ctx=1`, url: `/x/${OURS}`, ...signedIn }).accept
+    ).toBe(true)
+  })
+
+  it("matches regardless of case and encoding", () => {
+    expect(
+      resolveRosterScope({ own: OURS.toUpperCase(), url: encodeURIComponent(OURS), ...signedIn })
+    ).toEqual({ accept: true, reason: "match" })
+  })
+
+  it("is self-contained, so it survives being stringified into the page", () => {
+    // The injector ships this function as source text; a closure over any
+    // module-level binding would throw a ReferenceError in the browser.
+    // biome-ignore lint/security/noGlobalEval: asserting the stringify contract
+    const rebuilt = eval(`(${resolveRosterScope.toString()})`) as typeof resolveRosterScope
+    expect(
+      rebuilt({ own: OURS, url: `/c/${THEIRS}`, isAuthenticated: true, strict: false })
+    ).toEqual({ accept: false, reason: "foreign" })
+  })
+})

--- a/src/meeting/teams/network-interception/meeting-scope.test.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.test.ts
@@ -82,8 +82,6 @@ describe("deriveMeetingScope", () => {
 })
 
 describe("resolveRosterScope", () => {
-  // How the interceptor actually calls this: anonymous bots never scope strictly,
-  // signed-in bots do until they self-relax to keep a roster from starving.
   const anon = { isAuthenticated: false, strict: false }
   const signedIn = { isAuthenticated: true, strict: true }
   const signedInRelaxed = { isAuthenticated: true, strict: false }
@@ -116,10 +114,6 @@ describe("resolveRosterScope", () => {
   })
 
   it("accepts the aggregate once strict scoping has relaxed", () => {
-    // The escape hatch exists because "our participants also arrive on a
-    // call-scoped payload" is an observation, not a guarantee. A session that
-    // only ever delivers aggregates would otherwise starve to an empty roster
-    // with no way back.
     const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
     expect(resolveRosterScope({ own: OURS, body, ...signedInRelaxed })).toEqual({
       accept: true,
@@ -128,16 +122,12 @@ describe("resolveRosterScope", () => {
   })
 
   it("still rejects a proven-foreign payload after relaxing", () => {
-    // Relaxing must not reopen the leak: an aggregate at least proves it
-    // contains our conversation, a purely foreign payload does not.
     expect(
       resolveRosterScope({ own: OURS, url: `/csa/conversations/${THEIRS}/roster`, ...signedInRelaxed })
     ).toEqual({ accept: false, reason: "foreign" })
   })
 
   it("keeps anonymous behaviour unchanged for that same aggregate", () => {
-    // An anonymous bot's page never sees another meeting, so nothing is taken away
-    // from the path that had no incident.
     const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
     expect(resolveRosterScope({ own: OURS, body, ...anon })).toEqual({
       accept: true,
@@ -190,8 +180,6 @@ describe("resolveRosterScope", () => {
   })
 
   it("is self-contained, so it survives being stringified into the page", () => {
-    // The injector ships this function as source text; a closure over any
-    // module-level binding would throw a ReferenceError in the browser.
     // biome-ignore lint/security/noGlobalEval: asserting the stringify contract
     const rebuilt = eval(`(${resolveRosterScope.toString()})`) as typeof resolveRosterScope
     expect(

--- a/src/meeting/teams/network-interception/meeting-scope.test.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.test.ts
@@ -115,6 +115,26 @@ describe("resolveRosterScope", () => {
     })
   })
 
+  it("accepts the aggregate once strict scoping has relaxed", () => {
+    // The escape hatch exists because "our participants also arrive on a
+    // call-scoped payload" is an observation, not a guarantee. A session that
+    // only ever delivers aggregates would otherwise starve to an empty roster
+    // with no way back.
+    const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
+    expect(resolveRosterScope({ own: OURS, body, ...signedInRelaxed })).toEqual({
+      accept: true,
+      reason: "match"
+    })
+  })
+
+  it("still rejects a proven-foreign payload after relaxing", () => {
+    // Relaxing must not reopen the leak: an aggregate at least proves it
+    // contains our conversation, a purely foreign payload does not.
+    expect(
+      resolveRosterScope({ own: OURS, url: `/csa/conversations/${THEIRS}/roster`, ...signedInRelaxed })
+    ).toEqual({ accept: false, reason: "foreign" })
+  })
+
   it("keeps anonymous behaviour unchanged for that same aggregate", () => {
     // An anonymous bot's page never sees another meeting, so nothing is taken away
     // from the path that had no incident.

--- a/src/meeting/teams/network-interception/meeting-scope.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.ts
@@ -1,0 +1,190 @@
+// Meeting scope for the Teams roster interceptor.
+//
+// An ANONYMOUS bot's browser only ever knows the one meeting it joined, so the
+// interceptor could merge any roster-shaped payload it saw and stay correct.
+// A SIGNED-IN bot's browser is a full Teams client for the M365 account, and it
+// fetches state scoped to the ACCOUNT — including other calls that account is in
+// when several bots run concurrently on the same teams_login. Merging those mixed
+// foreign participants into this bot's roster, and (via the per-call mediaStream
+// sourceId map, whose ids are only unique within one call) occasionally pinned a
+// foreign display name onto this bot's OWN audio.
+//
+// Scoping needs exactly one fact: which conversation this bot actually joined.
+
+/**
+ * Teams conversation (thread) ids: `19:meeting_<...>@thread.v2` for scheduled
+ * meetings, `19:<...>@thread.tacv2` / `@thread.skype` for the other call shapes.
+ *
+ * Built per call — a shared /g/ regex carries `lastIndex` between calls and would
+ * silently skip matches.
+ */
+function conversationRe(): RegExp {
+  return /19:[^@"'\\/\s]+@thread\.[a-z0-9]+/gi
+}
+
+export interface TeamsMeetingScope {
+  /**
+   * The joined conversation, lowercased for comparison. Null when the join URL
+   * carries no thread id — short `/meet/<code>` links and the personal-Teams
+   * launcher resolve the conversation only after the client joins, so the browser
+   * side latches it from the live call instead.
+   */
+  conversationId: string | null
+}
+
+/**
+ * Every Teams conversation id in `text`, lowercased and de-duplicated.
+ *
+ * Searches the raw text and, separately, its percent-decoded form: ids travel
+ * URL-encoded in query strings (`19%3Ameeting_...%40thread.v2`) and raw in paths
+ * and JSON bodies.
+ */
+export function findConversationIds(text: string): string[] {
+  if (!text) return []
+
+  const candidates = [text]
+  try {
+    const decoded = decodeURIComponent(text)
+    if (decoded !== text) candidates.push(decoded)
+  } catch {
+    // Malformed percent-encoding — the raw pass still applies.
+  }
+
+  const found = new Set<string>()
+  for (const candidate of candidates) {
+    const matches = candidate.match(conversationRe())
+    if (matches) {
+      for (const match of matches) found.add(match.toLowerCase())
+    }
+  }
+  return [...found]
+}
+
+/**
+ * The conversation this bot was sent to join, read off the join URL.
+ *
+ * Deep links (`/l/meetup-join/<threadId>/<messageId>`) carry it directly — that
+ * covers scheduled meetings, which is where concurrent signed-in sessions on one
+ * account actually happen. Anything else returns null and is resolved in-page.
+ */
+export function deriveMeetingScope(joinUrl: string): TeamsMeetingScope {
+  const ids = findConversationIds(joinUrl ?? "")
+  // A join URL names exactly one conversation; if a link ever carried more than
+  // one, guessing which is the meeting would be worse than staying permissive.
+  return { conversationId: ids.length === 1 ? ids[0] : null }
+}
+
+/**
+ * What the browser-side bundle receives. Serialized into the injected script, so
+ * it must stay JSON-safe.
+ */
+export interface TeamsInterceptorScope extends TeamsMeetingScope {
+  /**
+   * True when the bot signed into an M365 account (`teams_login_config` present).
+   * Signed-in bots are the only ones whose page can see another meeting's roster,
+   * and they scope strictly: see `resolveRosterScope`.
+   */
+  isAuthenticated: boolean
+}
+
+export type RosterScopeReason =
+  /** This bot's own conversation isn't identified yet — nothing to compare against. */
+  | "own-unknown"
+  /** The payload names our conversation and only ours. */
+  | "match"
+  /** The payload names conversations, none of them ours. */
+  | "foreign"
+  /** Names ours AND others: an account-scoped aggregate, not one call's roster. */
+  | "aggregate"
+  /** Names no conversation at all. */
+  | "unplaceable"
+
+export interface RosterScopeVerdict {
+  accept: boolean
+  reason: RosterScopeReason
+}
+
+/** Signature the browser bundle receives; see resolveRosterScope. */
+export type RosterScopeResolver = (input: {
+  own: string | null
+  url?: string
+  body?: string
+  isAuthenticated: boolean
+  strict: boolean
+}) => RosterScopeVerdict
+
+/**
+ * Decide whether a roster payload belongs to the meeting this bot joined.
+ *
+ * SELF-CONTAINED: this is stringified into the page alongside the interceptor
+ * bundle (same mechanism as `resolveSpeakingSet`), so it must not reference
+ * anything outside its own body — no imports, no module-level constants.
+ *
+ * An ANONYMOUS bot keeps its pre-existing behaviour exactly: its page only ever
+ * knows the one meeting it joined, so only proven-foreign payloads are dropped and
+ * nothing is taken away from the path that never had an incident.
+ *
+ * A SIGNED-IN bot scopes strictly — a payload merges only if it proves it belongs
+ * to this meeting. That is what actually closes the leak, since a foreign payload
+ * carrying no conversation id would otherwise still merge. The caller relaxes
+ * `strict` on its own if strict scoping ever turns out to starve a real roster.
+ *
+ * @param own - The joined conversation, or any raw string containing it (a live
+ *   call's threadId). Null/unrecognized means "not yet identified".
+ */
+export function resolveRosterScope(input: {
+  own: string | null
+  url?: string
+  body?: string
+  isAuthenticated: boolean
+  strict: boolean
+}): RosterScopeVerdict {
+  const CONVERSATION = /19:[^@"'\\/\s]+@thread\.[a-z0-9]+/gi
+
+  const idsIn = (text: string | null | undefined): string[] => {
+    if (!text) return []
+    const candidates = [text]
+    try {
+      const decoded = decodeURIComponent(text)
+      if (decoded !== text) candidates.push(decoded)
+    } catch {
+      // Malformed percent-encoding — the raw pass still applies.
+    }
+    const found: string[] = []
+    for (const candidate of candidates) {
+      const matches = candidate.match(CONVERSATION)
+      if (!matches) continue
+      for (const match of matches) {
+        const lower = match.toLowerCase()
+        if (found.indexOf(lower) === -1) found.push(lower)
+      }
+    }
+    return found
+  }
+
+  const ownIds = idsIn(input.own)
+  if (ownIds.length !== 1) return { accept: true, reason: "own-unknown" }
+  const ownId = ownIds[0]
+
+  const seen: string[] = []
+  for (const source of [input.url, input.body]) {
+    for (const id of idsIn(source)) {
+      if (seen.indexOf(id) === -1) seen.push(id)
+    }
+  }
+
+  if (seen.length === 0) {
+    const strictDrop = input.strict && input.isAuthenticated
+    return { accept: !strictDrop, reason: "unplaceable" }
+  }
+
+  if (seen.indexOf(ownId) === -1) return { accept: false, reason: "foreign" }
+
+  if (seen.length > 1 && input.isAuthenticated) {
+    // Our own participants still arrive on the call-scoped snapshot and the
+    // socket deltas, so dropping the aggregate costs nothing it carried.
+    return { accept: false, reason: "aggregate" }
+  }
+
+  return { accept: true, reason: "match" }
+}

--- a/src/meeting/teams/network-interception/meeting-scope.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.ts
@@ -180,9 +180,17 @@ export function resolveRosterScope(input: {
 
   if (seen.indexOf(ownId) === -1) return { accept: false, reason: "foreign" }
 
-  if (seen.length > 1 && input.isAuthenticated) {
+  if (seen.length > 1 && input.isAuthenticated && input.strict) {
     // Our own participants still arrive on the call-scoped snapshot and the
     // socket deltas, so dropping the aggregate costs nothing it carried.
+    //
+    // Gated on `strict` for the same reason the unplaceable drop is: that
+    // premise is an observation, not a guarantee. If a session ever delivers
+    // its roster ONLY on aggregate payloads, rejecting them unconditionally
+    // would starve the roster to empty with no way back — precisely the
+    // degraded outcome this scoping exists to prevent. The caller counts
+    // aggregate rejections toward the same starvation escape hatch, so a
+    // session like that relaxes instead of reporting no participants.
     return { accept: false, reason: "aggregate" }
   }
 

--- a/src/meeting/teams/network-interception/meeting-scope.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.ts
@@ -1,44 +1,17 @@
-// Meeting scope for the Teams roster interceptor.
-//
-// An ANONYMOUS bot's browser only ever knows the one meeting it joined, so the
-// interceptor could merge any roster-shaped payload it saw and stay correct.
-// A SIGNED-IN bot's browser is a full Teams client for the M365 account, and it
-// fetches state scoped to the ACCOUNT — including other calls that account is in
-// when several bots run concurrently on the same teams_login. Merging those mixed
-// foreign participants into this bot's roster, and (via the per-call mediaStream
-// sourceId map, whose ids are only unique within one call) occasionally pinned a
-// foreign display name onto this bot's OWN audio.
-//
-// Scoping needs exactly one fact: which conversation this bot actually joined.
+// A signed-in bot's page also sees the account's other calls, so the Teams roster
+// interceptor merges only rosters from the conversation this bot joined.
 
-/**
- * Teams conversation (thread) ids: `19:meeting_<...>@thread.v2` for scheduled
- * meetings, `19:<...>@thread.tacv2` / `@thread.skype` for the other call shapes.
- *
- * Built per call — a shared /g/ regex carries `lastIndex` between calls and would
- * silently skip matches.
- */
+// Teams thread ids. Built per call: a shared /g/ regex carries lastIndex between calls.
 function conversationRe(): RegExp {
   return /19:[^@"'\\/\s]+@thread\.[a-z0-9]+/gi
 }
 
 export interface TeamsMeetingScope {
-  /**
-   * The joined conversation, lowercased for comparison. Null when the join URL
-   * carries no thread id — short `/meet/<code>` links and the personal-Teams
-   * launcher resolve the conversation only after the client joins, so the browser
-   * side latches it from the live call instead.
-   */
+  /** Lowercased; null when the join URL has no thread id (latched in-page instead). */
   conversationId: string | null
 }
 
-/**
- * Every Teams conversation id in `text`, lowercased and de-duplicated.
- *
- * Searches the raw text and, separately, its percent-decoded form: ids travel
- * URL-encoded in query strings (`19%3Ameeting_...%40thread.v2`) and raw in paths
- * and JSON bodies.
- */
+/** Every conversation id in `text`, raw or percent-encoded, lowercased and de-duplicated. */
 export function findConversationIds(text: string): string[] {
   if (!text) return []
 
@@ -60,43 +33,26 @@ export function findConversationIds(text: string): string[] {
   return [...found]
 }
 
-/**
- * The conversation this bot was sent to join, read off the join URL.
- *
- * Deep links (`/l/meetup-join/<threadId>/<messageId>`) carry it directly — that
- * covers scheduled meetings, which is where concurrent signed-in sessions on one
- * account actually happen. Anything else returns null and is resolved in-page.
- */
+/** The conversation a meetup-join deep link names; null (resolved in-page) otherwise. */
 export function deriveMeetingScope(joinUrl: string): TeamsMeetingScope {
   const ids = findConversationIds(joinUrl ?? "")
-  // A join URL names exactly one conversation; if a link ever carried more than
-  // one, guessing which is the meeting would be worse than staying permissive.
+  // Don't guess between several ids.
   return { conversationId: ids.length === 1 ? ids[0] : null }
 }
 
-/**
- * What the browser-side bundle receives. Serialized into the injected script, so
- * it must stay JSON-safe.
- */
+/** Serialized into the page, so it must stay JSON-safe. */
 export interface TeamsInterceptorScope extends TeamsMeetingScope {
-  /**
-   * True when the bot signed into an M365 account (`teams_login_config` present).
-   * Signed-in bots are the only ones whose page can see another meeting's roster,
-   * and they scope strictly: see `resolveRosterScope`.
-   */
+  /** Signed in via `teams_login_config`; only these pages can see other meetings. */
   isAuthenticated: boolean
 }
 
 export type RosterScopeReason =
   /** This bot's own conversation isn't identified yet — nothing to compare against. */
   | "own-unknown"
-  /** The payload names our conversation and only ours. */
   | "match"
-  /** The payload names conversations, none of them ours. */
   | "foreign"
   /** Names ours AND others: an account-scoped aggregate, not one call's roster. */
   | "aggregate"
-  /** Names no conversation at all. */
   | "unplaceable"
 
 export interface RosterScopeVerdict {
@@ -104,7 +60,6 @@ export interface RosterScopeVerdict {
   reason: RosterScopeReason
 }
 
-/** Signature the browser bundle receives; see resolveRosterScope. */
 export type RosterScopeResolver = (input: {
   own: string | null
   url?: string
@@ -114,23 +69,9 @@ export type RosterScopeResolver = (input: {
 }) => RosterScopeVerdict
 
 /**
- * Decide whether a roster payload belongs to the meeting this bot joined.
- *
- * SELF-CONTAINED: this is stringified into the page alongside the interceptor
- * bundle (same mechanism as `resolveSpeakingSet`), so it must not reference
- * anything outside its own body — no imports, no module-level constants.
- *
- * An ANONYMOUS bot keeps its pre-existing behaviour exactly: its page only ever
- * knows the one meeting it joined, so only proven-foreign payloads are dropped and
- * nothing is taken away from the path that never had an incident.
- *
- * A SIGNED-IN bot scopes strictly — a payload merges only if it proves it belongs
- * to this meeting. That is what actually closes the leak, since a foreign payload
- * carrying no conversation id would otherwise still merge. The caller relaxes
- * `strict` on its own if strict scoping ever turns out to starve a real roster.
- *
- * @param own - The joined conversation, or any raw string containing it (a live
- *   call's threadId). Null/unrecognized means "not yet identified".
+ * Whether a roster payload belongs to the joined meeting. Anonymous bots drop only
+ * proven-foreign payloads; strict signed-in bots also drop unplaceable ones.
+ * Self-contained: it is stringified into the page, so no outside references.
  */
 export function resolveRosterScope(input: {
   own: string | null
@@ -181,16 +122,7 @@ export function resolveRosterScope(input: {
   if (seen.indexOf(ownId) === -1) return { accept: false, reason: "foreign" }
 
   if (seen.length > 1 && input.isAuthenticated && input.strict) {
-    // Our own participants still arrive on the call-scoped snapshot and the
-    // socket deltas, so dropping the aggregate costs nothing it carried.
-    //
-    // Gated on `strict` for the same reason the unplaceable drop is: that
-    // premise is an observation, not a guarantee. If a session ever delivers
-    // its roster ONLY on aggregate payloads, rejecting them unconditionally
-    // would starve the roster to empty with no way back — precisely the
-    // degraded outcome this scoping exists to prevent. The caller counts
-    // aggregate rejections toward the same starvation escape hatch, so a
-    // session like that relaxes instead of reporting no participants.
+    // Our participants also arrive call-scoped; `strict` lets a starved session relax.
     return { accept: false, reason: "aggregate" }
   }
 

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -2,7 +2,7 @@ import type { BrowserContext, Page } from "@playwright/test"
 import { envVars } from "../config/env-vars"
 import { captureFingerprint } from "../browser/fingerprint-probe"
 import { listenPage } from "../browser/page-logger"
-import { setZoomJoinHost } from "../proxy/toggle-proxy"
+import { getProxyTelemetry, setZoomJoinHost } from "../proxy/toggle-proxy"
 import { HtmlSnapshotService } from "../services/html-snapshot-service"
 import { GLOBAL } from "../singleton"
 import { getErrorMessageFromCode, MeetingEndReason } from "../state-machine/types"
@@ -43,6 +43,16 @@ const JOIN_BUTTON = "button.preview-join-button, #joinBtn"
 const PREVIEW_MUTE = "#preview-audio-control-button"
 const PREVIEW_VIDEO = "#preview-video-control-button"
 const LEAVE_BUTTON = 'button[aria-label="Leave"]'
+
+// Which of Zoom's anti-bot walls fired. The end reason collapses all four into
+// zoomAnonymousJoinNotAllowed, which cannot answer the one question that decides
+// what to fix: a wall that fires BEFORE the display name is typed is pure IP /
+// fingerprint reputation and no naming change can touch it.
+type ZoomWallPhase =
+  | "pre_name" // rendered on the pre-join page, before any name was entered
+  | "no_name_input" // the name field never appeared at all
+  | "post_name" // appeared only after the name was typed, before Join
+  | "admission" // streamed in after the Join click, during the admission wait
 
 // What the loading-stall probe treats as proof the client is up. Built from the
 // selectors above and the shared state config so there is exactly one place a
@@ -373,10 +383,7 @@ export class ZoomProvider implements MeetingProviderInterface {
       }
       // The wall can render here instead of a name field — check before failing.
       const wall = await this.detectBotWall(page)
-      if (wall) {
-        GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
-        throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
-      }
+      if (wall) this.failBotWall("no_name_input", wall)
       GLOBAL.setError(MeetingEndReason.CannotJoinMeeting)
       throw new Error("[Zoom] Pre-join name input never appeared")
     }
@@ -384,10 +391,7 @@ export class ZoomProvider implements MeetingProviderInterface {
     // A visible CAPTCHA takes priority over a coexisting passcode field: it is
     // IP-reputation-driven and may clear on a regional retry.
     const initialWall = await this.detectBotWall(page)
-    if (initialWall) {
-      GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
-      throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${initialWall}`)
-    }
+    if (initialWall) this.failBotWall("pre_name", initialWall)
 
     // Zoom can render its passcode form while Firefox reports the input as not
     // visible/actionable. Read raw DOM state instead of using isVisible(), then
@@ -419,10 +423,7 @@ export class ZoomProvider implements MeetingProviderInterface {
     // classic client, or the sign-in / anti-bot wall). These cannot be cleared
     // by automation — fail fast rather than holding the browser.
     const wall = await this.detectBotWall(page)
-    if (wall) {
-      GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
-      throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
-    }
+    if (wall) this.failBotWall("post_name", wall)
 
     // Wait for Join to enable (React enables within ~1-2s of valid name).
     const joinEnabled = await page
@@ -814,10 +815,7 @@ export class ZoomProvider implements MeetingProviderInterface {
       // exit IP (see main.ts handleFailedRecording), since the wall is
       // IP-reputation-driven rather than deterministic for this meeting.
       const wall = await this.detectBotWall(page)
-      if (wall) {
-        GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
-        throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
-      }
+      if (wall) this.failBotWall("admission", wall)
 
       // Missing/invalid passcodes leave the browser on the pre-join form. Check
       // every poll because Zoom can show the rejection only after Join input.
@@ -864,6 +862,17 @@ export class ZoomProvider implements MeetingProviderInterface {
       if (!waiting.matched) {
         const inMeeting = await zoomStateDetector.isInMeeting(page)
         if (inMeeting.matched) {
+          {
+            // The wall lines above are useless without a denominator: a network
+            // that is never used cannot be told from one that never fails. Emit
+            // the same exit identity on a clean admission.
+            const t = getProxyTelemetry()
+            console.log(
+              `[Zoom] ✅ admitted proxy=${t.enabled ? "on" : "off"} ` +
+                `exit_cc=${t.exit_country ?? "none"} exit_asn=${t.exit_asn ?? "none"} ` +
+                `session=${t.session_id ?? "none"} sqs_retry=${GLOBAL.getRetryCount()}`
+            )
+          }
           console.log("[Zoom] Admitted — Leave button visible")
           return
         }
@@ -875,6 +884,27 @@ export class ZoomProvider implements MeetingProviderInterface {
 
     GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
     throw new Error(`[Zoom] Not admitted within ${timeoutMs}ms`)
+  }
+
+  /**
+   * Single exit for every Zoom anti-bot wall.
+   *
+   * Zoom, unlike Meet, reports no structured detection signal anywhere, so the
+   * only record of WHY a bot was walled is this line. It carries the exit
+   * identity that was in force (country + ASN, never the IP — that is redacted
+   * downstream) and which wall fired, which is what makes a per-network flag
+   * rate computable from logs alone.
+   */
+  private failBotWall(phase: ZoomWallPhase, wall: string): never {
+    const t = getProxyTelemetry()
+    console.error(
+      `[Zoom] 🚨 bot wall phase=${phase} wall="${wall}" ` +
+        `proxy=${t.enabled ? "on" : "off"} exit_cc=${t.exit_country ?? "none"} ` +
+        `exit_asn=${t.exit_asn ?? "none"} session=${t.session_id ?? "none"} ` +
+        `proxy_off_reason=${t.disabled_reason ?? "none"} sqs_retry=${GLOBAL.getRetryCount()}`
+    )
+    GLOBAL.setError(MeetingEndReason.ZoomAnonymousJoinNotAllowed)
+    throw new Error(`[Zoom] zoom_anonymous_join_not_allowed: ${wall}`)
   }
 
   private async detectBotWall(page: Page): Promise<string | null> {

--- a/src/meeting/zoom.ts
+++ b/src/meeting/zoom.ts
@@ -44,15 +44,8 @@ const PREVIEW_MUTE = "#preview-audio-control-button"
 const PREVIEW_VIDEO = "#preview-video-control-button"
 const LEAVE_BUTTON = 'button[aria-label="Leave"]'
 
-// Which of Zoom's anti-bot walls fired. The end reason collapses all four into
-// zoomAnonymousJoinNotAllowed, which cannot answer the one question that decides
-// what to fix: a wall that fires BEFORE the display name is typed is pure IP /
-// fingerprint reputation and no naming change can touch it.
-type ZoomWallPhase =
-  | "pre_name" // rendered on the pre-join page, before any name was entered
-  | "no_name_input" // the name field never appeared at all
-  | "post_name" // appeared only after the name was typed, before Join
-  | "admission" // streamed in after the Join click, during the admission wait
+// Which Zoom anti-bot wall fired; a pre_name wall is IP/fingerprint, not the name.
+type ZoomWallPhase = "pre_name" | "no_name_input" | "post_name" | "admission"
 
 // What the loading-stall probe treats as proof the client is up. Built from the
 // selectors above and the shared state config so there is exactly one place a
@@ -863,9 +856,7 @@ export class ZoomProvider implements MeetingProviderInterface {
         const inMeeting = await zoomStateDetector.isInMeeting(page)
         if (inMeeting.matched) {
           {
-            // The wall lines above are useless without a denominator: a network
-            // that is never used cannot be told from one that never fails. Emit
-            // the same exit identity on a clean admission.
+            // Denominator for the wall log lines: the exit identity on a clean admission.
             const t = getProxyTelemetry()
             console.log(
               `[Zoom] ✅ admitted proxy=${t.enabled ? "on" : "off"} ` +
@@ -886,15 +877,7 @@ export class ZoomProvider implements MeetingProviderInterface {
     throw new Error(`[Zoom] Not admitted within ${timeoutMs}ms`)
   }
 
-  /**
-   * Single exit for every Zoom anti-bot wall.
-   *
-   * Zoom, unlike Meet, reports no structured detection signal anywhere, so the
-   * only record of WHY a bot was walled is this line. It carries the exit
-   * identity that was in force (country + ASN, never the IP — that is redacted
-   * downstream) and which wall fired, which is what makes a per-network flag
-   * rate computable from logs alone.
-   */
+  /** Single exit for every Zoom anti-bot wall; logs the phase and exit network (never the IP). */
   private failBotWall(phase: ZoomWallPhase, wall: string): never {
     const t = getProxyTelemetry()
     console.error(

--- a/src/meeting/zoom/network-interception/browser-bundle.ts
+++ b/src/meeting/zoom/network-interception/browser-bundle.ts
@@ -36,15 +36,7 @@ export function zoomBrowserInterceptionLogic() {
     ;(window as any).__zoomNetworkInterceptorStopped = false
 
     // ===== STEALTH: native-toString masking =====
-    // This bundle runs via addInitScript, so it is in place before Zoom's own
-    // client boots — which is exactly when Zoom decides whether we are a bot.
-    // Everything it replaces (WebSocket, Worker, RTCPeerConnection) is a global
-    // a page can interrogate for free: Function.prototype.toString.call(WebSocket)
-    // on a wrapper returns its JS source instead of "[native code]", and the
-    // wrapper's own .name/.length differ from the native constructor's. Route
-    // toString through a Proxy that reports a native signature for our wrappers
-    // (keyed in a WeakMap) and is transparent for everything else. Ported from
-    // the Meet bundle, which has carried this since its own detection work.
+    // Our wrapped globals must report "[native code]" to Function.prototype.toString.
     const __nativeStr = new WeakMap<any, string>()
     try {
       const __origToString = Function.prototype.toString
@@ -60,9 +52,7 @@ export function zoomBrowserInterceptionLogic() {
       /* environment forbids patching — masking is simply absent */
     }
 
-    // Make a wrapper indistinguishable from the constructor it replaces: same
-    // reported source, same .name, same .length. Reading them off the original
-    // rather than hardcoding keeps it correct across engines.
+    // Copy the original's native signature, .name and .length onto a wrapper.
     const __disguise = (wrapper: any, original: any): any => {
       try {
         __nativeStr.set(wrapper, `function ${original.name}() { [native code] }`)
@@ -75,11 +65,7 @@ export function zoomBrowserInterceptionLogic() {
     }
 
     // ===== STEALTH: cloak our injected window globals =====
-    // No real browser has a __zoomSpeakerQueue. A detector that enumerates window
-    // finds every one of these on the first frame. Redefining them as
-    // non-enumerable keeps them reachable by name (nothing breaks) and removes
-    // them from Object.keys / for-in. Re-run deferred as well, because the
-    // exposeFunction bridges below are installed out of band by Playwright.
+    // Non-enumerable; re-run later because Playwright installs its bridges out of band.
     const __CLOAK_NAMES = [
       "__zoomNetworkInterceptorMain",
       "__zoomNetworkInterceptorInitialized",

--- a/src/meeting/zoom/network-interception/browser-bundle.ts
+++ b/src/meeting/zoom/network-interception/browser-bundle.ts
@@ -35,6 +35,84 @@ export function zoomBrowserInterceptionLogic() {
     ;(window as any).__zoomNetworkInterceptorInitialized = true
     ;(window as any).__zoomNetworkInterceptorStopped = false
 
+    // ===== STEALTH: native-toString masking =====
+    // This bundle runs via addInitScript, so it is in place before Zoom's own
+    // client boots — which is exactly when Zoom decides whether we are a bot.
+    // Everything it replaces (WebSocket, Worker, RTCPeerConnection) is a global
+    // a page can interrogate for free: Function.prototype.toString.call(WebSocket)
+    // on a wrapper returns its JS source instead of "[native code]", and the
+    // wrapper's own .name/.length differ from the native constructor's. Route
+    // toString through a Proxy that reports a native signature for our wrappers
+    // (keyed in a WeakMap) and is transparent for everything else. Ported from
+    // the Meet bundle, which has carried this since its own detection work.
+    const __nativeStr = new WeakMap<any, string>()
+    try {
+      const __origToString = Function.prototype.toString
+      const __tsProxy = new Proxy(__origToString, {
+        apply(target, thisArg: any, args: any[]) {
+          const masked = thisArg == null ? undefined : __nativeStr.get(thisArg)
+          if (masked) return masked
+          return Reflect.apply(target, thisArg, args)
+        }
+      })
+      ;(Function.prototype as any).toString = __tsProxy
+    } catch (_e) {
+      /* environment forbids patching — masking is simply absent */
+    }
+
+    // Make a wrapper indistinguishable from the constructor it replaces: same
+    // reported source, same .name, same .length. Reading them off the original
+    // rather than hardcoding keeps it correct across engines.
+    const __disguise = (wrapper: any, original: any): any => {
+      try {
+        __nativeStr.set(wrapper, `function ${original.name}() { [native code] }`)
+        Object.defineProperty(wrapper, "name", { value: original.name, configurable: true })
+        Object.defineProperty(wrapper, "length", { value: original.length, configurable: true })
+      } catch (_e) {
+        /* frozen or non-configurable — skip */
+      }
+      return wrapper
+    }
+
+    // ===== STEALTH: cloak our injected window globals =====
+    // No real browser has a __zoomSpeakerQueue. A detector that enumerates window
+    // finds every one of these on the first frame. Redefining them as
+    // non-enumerable keeps them reachable by name (nothing breaks) and removes
+    // them from Object.keys / for-in. Re-run deferred as well, because the
+    // exposeFunction bridges below are installed out of band by Playwright.
+    const __CLOAK_NAMES = [
+      "__zoomNetworkInterceptorMain",
+      "__zoomNetworkInterceptorInitialized",
+      "__zoomNetworkInterceptorStopped",
+      "__zoomSpeakerQueue",
+      "__zoomStopNetworkInterception",
+      "__zoomNetDiag",
+      "zoomSpeakersChanged",
+      "zoomSpeakerForensics",
+      "zoomCleanerLog",
+      "zoomChatMessage",
+      "zoomChatCleanup",
+      "zoomObserverCleanup",
+      "zoomHtmlCleanerInterval"
+    ]
+    const __cloak = () => {
+      for (const n of __CLOAK_NAMES) {
+        try {
+          if (Object.prototype.hasOwnProperty.call(window, n)) {
+            const v = (window as any)[n]
+            Object.defineProperty(window, n, {
+              value: v,
+              enumerable: false,
+              configurable: true,
+              writable: true
+            })
+          }
+        } catch (_e) {
+          /* already non-configurable — skip */
+        }
+      }
+    }
+
     // "[NetworkInterceptor]" prefix so page-logger surfaces warn/error by
     // default (no LOG_LEVEL=debug needed); "[Zoom]" distinguishes from Meet/Teams.
     const LOG = "[NetworkInterceptor][Zoom]"
@@ -761,6 +839,7 @@ export function zoomBrowserInterceptionLogic() {
       ProxiedWebSocket.OPEN = OriginalWebSocket.OPEN
       ProxiedWebSocket.CLOSING = OriginalWebSocket.CLOSING
       ProxiedWebSocket.CLOSED = OriginalWebSocket.CLOSED
+      __disguise(ProxiedWebSocket, OriginalWebSocket)
       ;(window as any).WebSocket = ProxiedWebSocket
     }
 
@@ -783,6 +862,7 @@ export function zoomBrowserInterceptionLogic() {
           return worker
         } as any
         ProxiedWorker.prototype = OriginalWorker.prototype
+        __disguise(ProxiedWorker, OriginalWorker)
         ;(window as any).Worker = ProxiedWorker
       }
     }
@@ -825,11 +905,17 @@ export function zoomBrowserInterceptionLogic() {
           ProxiedRTCPeerConnection.generateCertificate = (...a: any[]) =>
             OriginalRTCPeerConnection.generateCertificate(...a)
         }
+        __disguise(ProxiedRTCPeerConnection, OriginalRTCPeerConnection)
         ;(window as any).RTCPeerConnection = ProxiedRTCPeerConnection
       }
     }
 
     const pollInterval = setInterval(pollReceivers, 100)
+    __cloak()
+    setTimeout(__cloak, 0)
+    setTimeout(__cloak, 1000)
+    setTimeout(__cloak, 4000)
+
     ;(window as any).__zoomStopNetworkInterception = () => {
       ;(window as any).__zoomNetworkInterceptorStopped = true
       try {

--- a/src/singleton-identity.test.ts
+++ b/src/singleton-identity.test.ts
@@ -1,0 +1,74 @@
+import { GLOBAL } from "./singleton"
+import type { Participant } from "./types"
+import { UNKNOWN_SPEAKER } from "./types"
+
+/**
+ * Regression cover for the collapse that made a multi-speaker meeting report one
+ * speaker: the registries deduped on name, and "Unknown" is the placeholder every
+ * interceptor shares before a roster resolves.
+ */
+describe("participant/speaker identity registry", () => {
+  const p = (over: Partial<Participant>): Participant => ({
+    name: UNKNOWN_SPEAKER,
+    id: null,
+    isNetworkDetected: true,
+    ...over
+  })
+
+  beforeEach(() => {
+    // The registries are append-only for the life of a bot; reset between cases.
+    GLOBAL.getParticipants().length = 0
+    GLOBAL.getSpeakers().length = 0
+  })
+
+  it("keeps unidentified participants on distinct devices apart", () => {
+    GLOBAL.addParticipantIfNotExists(p({ participantId: "spaces/s/devices/1" }))
+    GLOBAL.addParticipantIfNotExists(p({ participantId: "spaces/s/devices/2" }))
+    GLOBAL.addParticipantIfNotExists(p({ participantId: "spaces/s/devices/3" }))
+    expect(GLOBAL.getParticipants()).toHaveLength(3)
+  })
+
+  it("does the same for speakers — the reported symptom", () => {
+    GLOBAL.addSpeakerIfNotExists(p({ participantId: "d1" }))
+    GLOBAL.addSpeakerIfNotExists(p({ participantId: "d2" }))
+    expect(GLOBAL.getSpeakers()).toHaveLength(2)
+  })
+
+  it("still collapses one named person seen on two endpoints", () => {
+    GLOBAL.addParticipantIfNotExists(p({ name: "Alice", id: 1, participantId: "d1" }))
+    GLOBAL.addParticipantIfNotExists(p({ name: "Alice", id: 1, participantId: "d2" }))
+    expect(GLOBAL.getParticipants()).toHaveLength(1)
+  })
+
+  it("renames a placeholder in place once the roster resolves", () => {
+    GLOBAL.addParticipantIfNotExists(p({ participantId: "d1" }))
+    GLOBAL.addParticipantIfNotExists(p({ name: "Bob", id: 2, participantId: "d1" }))
+    expect(GLOBAL.getParticipants()).toHaveLength(1)
+    expect(GLOBAL.getParticipants()[0]).toMatchObject({ name: "Bob", id: 2, participantId: "d1" })
+  })
+
+  it("drops the placeholder instead of duplicating an already-listed person", () => {
+    GLOBAL.addParticipantIfNotExists(p({ name: "Bob", id: 2, participantId: "d1" }))
+    GLOBAL.addParticipantIfNotExists(p({ participantId: "d2" }))
+    GLOBAL.addParticipantIfNotExists(p({ name: "Bob", id: 2, participantId: "d2" }))
+    expect(GLOBAL.getParticipants()).toHaveLength(1)
+    expect(GLOBAL.getParticipants()[0].name).toBe("Bob")
+  })
+
+  it("does not grow a placeholder row per callback when there is no device id", () => {
+    GLOBAL.addParticipantIfNotExists(p({}))
+    GLOBAL.addParticipantIfNotExists(p({}))
+    GLOBAL.addParticipantIfNotExists(p({}))
+    expect(GLOBAL.getParticipants()).toHaveLength(1)
+  })
+
+  it("keeps two different named people apart", () => {
+    GLOBAL.addParticipantIfNotExists(p({ name: "Alice", id: 1, participantId: "d1" }))
+    GLOBAL.addParticipantIfNotExists(p({ name: "Bob", id: 2, participantId: "d2" }))
+    expect(
+      GLOBAL.getParticipants()
+        .map((x) => x.name)
+        .sort()
+    ).toEqual(["Alice", "Bob"])
+  })
+})

--- a/src/singleton-identity.test.ts
+++ b/src/singleton-identity.test.ts
@@ -40,6 +40,29 @@ describe("participant/speaker identity registry", () => {
     expect(GLOBAL.getParticipants()).toHaveLength(1)
   })
 
+  it("keeps roster metadata a later naming update does not carry", () => {
+    // The update that resolves a name is often a speaking event with no avatar
+    // or display name on it; assigning those blindly erased what the roster had
+    // already told us about the device.
+    GLOBAL.addParticipantIfNotExists(
+      p({ participantId: "d1", displayName: "Bobby", profilePicture: "https://cdn/x.png" })
+    )
+    GLOBAL.addParticipantIfNotExists(p({ name: "Bob", id: 2, participantId: "d1" }))
+    expect(GLOBAL.getParticipants()[0]).toMatchObject({
+      name: "Bob",
+      displayName: "Bobby",
+      profilePicture: "https://cdn/x.png"
+    })
+  })
+
+  it("still lets a naming update replace metadata it does carry", () => {
+    GLOBAL.addParticipantIfNotExists(p({ participantId: "d1", displayName: "old" }))
+    GLOBAL.addParticipantIfNotExists(
+      p({ name: "Bob", id: 2, participantId: "d1", displayName: "new" })
+    )
+    expect(GLOBAL.getParticipants()[0].displayName).toBe("new")
+  })
+
   it("renames a placeholder in place once the roster resolves", () => {
     GLOBAL.addParticipantIfNotExists(p({ participantId: "d1" }))
     GLOBAL.addParticipantIfNotExists(p({ name: "Bob", id: 2, participantId: "d1" }))

--- a/src/singleton-identity.test.ts
+++ b/src/singleton-identity.test.ts
@@ -2,11 +2,7 @@ import { GLOBAL } from "./singleton"
 import type { Participant } from "./types"
 import { UNKNOWN_SPEAKER } from "./types"
 
-/**
- * Regression cover for the collapse that made a multi-speaker meeting report one
- * speaker: the registries deduped on name, and "Unknown" is the placeholder every
- * interceptor shares before a roster resolves.
- */
+// The registries used to dedupe on name, collapsing every "Unknown" into one row.
 describe("participant/speaker identity registry", () => {
   const p = (over: Partial<Participant>): Participant => ({
     name: UNKNOWN_SPEAKER,
@@ -16,7 +12,6 @@ describe("participant/speaker identity registry", () => {
   })
 
   beforeEach(() => {
-    // The registries are append-only for the life of a bot; reset between cases.
     GLOBAL.getParticipants().length = 0
     GLOBAL.getSpeakers().length = 0
   })
@@ -41,9 +36,6 @@ describe("participant/speaker identity registry", () => {
   })
 
   it("keeps roster metadata a later naming update does not carry", () => {
-    // The update that resolves a name is often a speaking event with no avatar
-    // or display name on it; assigning those blindly erased what the roster had
-    // already told us about the device.
     GLOBAL.addParticipantIfNotExists(
       p({ participantId: "d1", displayName: "Bobby", profilePicture: "https://cdn/x.png" })
     )

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -433,8 +433,12 @@ class Global {
         }
         known.name = incoming.name
         known.id = incoming.id
-        known.displayName = incoming.displayName
-        known.profilePicture = incoming.profilePicture
+        // Only overwrite optional metadata the incoming row actually carries:
+        // the update that resolves a name often comes from a speaking event
+        // that has no avatar or display name on it, and blindly assigning
+        // would erase what the roster already told us about this device.
+        known.displayName = incoming.displayName ?? known.displayName
+        known.profilePicture = incoming.profilePicture ?? known.profilePicture
         known.isNetworkDetected = incoming.isNetworkDetected
         return
       }

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -3,6 +3,7 @@ import { MetricsCollector } from "./services/metrics-collector"
 import { NORMAL_END_REASONS } from "./state-machine/constants"
 import { getErrorMessageFromCode, MeetingEndReason } from "./state-machine/types"
 import type { ArtifactKey, MeetingParams, Participant, RecordingMode } from "./types"
+import { disguiseBotName, shouldDisguiseBotName } from "./utils/bot-name-disguise"
 import { PiiRedactor } from "./utils/PiiRedactor"
 
 class Global {
@@ -68,9 +69,18 @@ class Global {
       throw new Error("Missing required parameter: bot_uuid")
     }
 
+    // Disguise a bot-sounding display name here and nowhere else. Everything
+    // downstream — the join form, the roster, the tile cleaner, the speaker
+    // registry, the chat dedup — then reads one consistent string, which is the
+    // whole reason this cannot live at the typing site. See bot-name-disguise.ts.
+    const disguisedName = shouldDisguiseBotName(meetingParams.meeting_platform ?? "")
+      ? disguiseBotName(meetingParams.bot_name, meetingParams.bot_uuid)
+      : meetingParams.bot_name
+
     // Normalize the recording mode before setting
     const normalizedParams = {
       ...meetingParams,
+      bot_name: disguisedName,
       recording_mode: this.normalizeRecordingMode(meetingParams.recording_mode)
     }
 
@@ -80,6 +90,15 @@ class Global {
     // params are available: bot names often contain end-user names and
     // must be masked as <BOT_NAME> in every log line.
     PiiRedactor.registerBotName(normalizedParams.bot_name)
+    if (disguisedName !== meetingParams.bot_name) {
+      // The customer's own spelling still reaches the logs through anything they
+      // sent us (entry_message, extra), so redact that form too. Never log
+      // either string — the point of registering them is that they don't appear.
+      PiiRedactor.registerBotName(meetingParams.bot_name)
+      console.log(
+        `[BotName] display name disguised for the ${meetingParams.meeting_platform} join`
+      )
+    }
 
     console.log(`🤖 Bot ${meetingParams.bot_uuid} initialized with validated parameters`)
   }

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -75,10 +75,7 @@ class Global {
       throw new Error("Missing required parameter: bot_uuid")
     }
 
-    // Disguise a bot-sounding display name here and nowhere else. Everything
-    // downstream — the join form, the roster, the tile cleaner, the speaker
-    // registry, the chat dedup — then reads one consistent string, which is the
-    // whole reason this cannot live at the typing site. See bot-name-disguise.ts.
+    // Disguise once here so every downstream name comparison sees the same string.
     const disguisedName = shouldDisguiseBotName(meetingParams.meeting_platform ?? "")
       ? disguiseBotName(meetingParams.bot_name, meetingParams.bot_uuid)
       : meetingParams.bot_name
@@ -97,9 +94,7 @@ class Global {
     // must be masked as <BOT_NAME> in every log line.
     PiiRedactor.registerBotName(normalizedParams.bot_name)
     if (disguisedName !== meetingParams.bot_name) {
-      // The customer's own spelling still reaches the logs through anything they
-      // sent us (entry_message, extra), so redact that form too. Never log
-      // either string — the point of registering them is that they don't appear.
+      // The original spelling can still reach logs via entry_message or extra.
       PiiRedactor.registerBotName(meetingParams.bot_name)
       console.log(`[BotName] display name disguised for the ${meetingParams.meeting_platform} join`)
     }
@@ -400,22 +395,8 @@ class Global {
   }
 
   /**
-   * Add `incoming` to a participant/speaker registry, or reconcile it with the
-   * row already representing that person.
-   *
-   * Identity is the network device id when we have one, and the resolved name
-   * only as a fallback. Collapsing by name is deliberate for people we can NAME —
-   * one human joining from two endpoints would otherwise surface as a phantom
-   * extra speaker — but "Unknown" is not a name. It is the placeholder every
-   * interceptor falls back to before a roster resolves, so it is shared by
-   * everyone still unidentified; keying on it merged all of them into a single
-   * row, and the registry being append-only made that permanent. A meeting with
-   * several speakers then came back reporting one.
-   *
-   * Reconciling also retires the placeholder: when a device's real name finally
-   * arrives, its existing row is renamed in place (or dropped, if that person is
-   * already listed from another device) instead of leaving a stale "Unknown"
-   * beside the resolved entry.
+   * Add `incoming` keyed by device id, else by name ("Unknown" never counts as a
+   * name). A device's placeholder row is renamed in place once its name resolves.
    */
   private static registerIdentity(registry: Participant[], incoming: Participant): void {
     const device = incoming.participantId
@@ -425,18 +406,14 @@ class Global {
       const known = registry.find((p) => p.participantId === device)
       if (known) {
         if (!isNamed || known.name === incoming.name) return
-        // The name just resolved. If this person is already listed from another
-        // device, drop the placeholder rather than creating a duplicate.
+        // Already listed from another device: drop the placeholder.
         if (registry.some((p) => p !== known && p.name === incoming.name)) {
           registry.splice(registry.indexOf(known), 1)
           return
         }
         known.name = incoming.name
         known.id = incoming.id
-        // Only overwrite optional metadata the incoming row actually carries:
-        // the update that resolves a name often comes from a speaking event
-        // that has no avatar or display name on it, and blindly assigning
-        // would erase what the roster already told us about this device.
+        // Keep roster metadata the naming update doesn't carry.
         known.displayName = incoming.displayName ?? known.displayName
         known.profilePicture = incoming.profilePicture ?? known.profilePicture
         known.isNetworkDetected = incoming.isNetworkDetected
@@ -447,8 +424,7 @@ class Global {
     // Same person, different endpoint — only ever collapsed on a real name.
     if (isNamed && registry.some((p) => p.name === incoming.name)) return
 
-    // An unidentified participant with no device id is indistinguishable from any
-    // other; keep the single placeholder row rather than growing one per callback.
+    // One placeholder row for unidentified participants without a device id.
     if (!isNamed && !device && registry.some((p) => p.name === incoming.name)) return
 
     registry.push(incoming)

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -2,7 +2,13 @@ import { envVars } from "./config/env-vars"
 import { MetricsCollector } from "./services/metrics-collector"
 import { NORMAL_END_REASONS } from "./state-machine/constants"
 import { getErrorMessageFromCode, MeetingEndReason } from "./state-machine/types"
-import type { ArtifactKey, MeetingParams, Participant, RecordingMode } from "./types"
+import {
+  type ArtifactKey,
+  type MeetingParams,
+  type Participant,
+  type RecordingMode,
+  UNKNOWN_SPEAKER
+} from "./types"
 import { disguiseBotName, shouldDisguiseBotName } from "./utils/bot-name-disguise"
 import { PiiRedactor } from "./utils/PiiRedactor"
 
@@ -95,9 +101,7 @@ class Global {
       // sent us (entry_message, extra), so redact that form too. Never log
       // either string — the point of registering them is that they don't appear.
       PiiRedactor.registerBotName(meetingParams.bot_name)
-      console.log(
-        `[BotName] display name disguised for the ${meetingParams.meeting_platform} join`
-      )
+      console.log(`[BotName] display name disguised for the ${meetingParams.meeting_platform} join`)
     }
 
     console.log(`🤖 Bot ${meetingParams.bot_uuid} initialized with validated parameters`)
@@ -380,10 +384,7 @@ class Global {
   }
 
   public addParticipantIfNotExists(participant: Participant): void {
-    // TODO: Use id instead of name
-    if (!this.participants.some((p) => p.name === participant.name)) {
-      this.participants.push(participant)
-    }
+    Global.registerIdentity(this.participants, participant)
   }
 
   public getParticipants(): Participant[] {
@@ -395,10 +396,58 @@ class Global {
   }
 
   public addSpeakerIfNotExists(speaker: Participant): void {
-    // TODO: Use id instead of name
-    if (!this.speakers.some((s) => s.name === speaker.name)) {
-      this.speakers.push(speaker)
+    Global.registerIdentity(this.speakers, speaker)
+  }
+
+  /**
+   * Add `incoming` to a participant/speaker registry, or reconcile it with the
+   * row already representing that person.
+   *
+   * Identity is the network device id when we have one, and the resolved name
+   * only as a fallback. Collapsing by name is deliberate for people we can NAME —
+   * one human joining from two endpoints would otherwise surface as a phantom
+   * extra speaker — but "Unknown" is not a name. It is the placeholder every
+   * interceptor falls back to before a roster resolves, so it is shared by
+   * everyone still unidentified; keying on it merged all of them into a single
+   * row, and the registry being append-only made that permanent. A meeting with
+   * several speakers then came back reporting one.
+   *
+   * Reconciling also retires the placeholder: when a device's real name finally
+   * arrives, its existing row is renamed in place (or dropped, if that person is
+   * already listed from another device) instead of leaving a stale "Unknown"
+   * beside the resolved entry.
+   */
+  private static registerIdentity(registry: Participant[], incoming: Participant): void {
+    const device = incoming.participantId
+    const isNamed = Boolean(incoming.name) && incoming.name !== UNKNOWN_SPEAKER
+
+    if (device) {
+      const known = registry.find((p) => p.participantId === device)
+      if (known) {
+        if (!isNamed || known.name === incoming.name) return
+        // The name just resolved. If this person is already listed from another
+        // device, drop the placeholder rather than creating a duplicate.
+        if (registry.some((p) => p !== known && p.name === incoming.name)) {
+          registry.splice(registry.indexOf(known), 1)
+          return
+        }
+        known.name = incoming.name
+        known.id = incoming.id
+        known.displayName = incoming.displayName
+        known.profilePicture = incoming.profilePicture
+        known.isNetworkDetected = incoming.isNetworkDetected
+        return
+      }
     }
+
+    // Same person, different endpoint — only ever collapsed on a real name.
+    if (isNamed && registry.some((p) => p.name === incoming.name)) return
+
+    // An unidentified participant with no device id is indistinguishable from any
+    // other; keep the single placeholder row rather than growing one per callback.
+    if (!isNamed && !device && registry.some((p) => p.name === incoming.name)) return
+
+    registry.push(incoming)
   }
 
   public getSpeakers(): Participant[] {

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -264,10 +264,7 @@ describe("assembleSpeakerTimeline retrofit cap boundary", () => {
 })
 
 describe("assembleSpeakerTimeline source dissonance", () => {
-  // Prod bot 22e3adba: a 30-minute Meet whose interceptor never resolved the
-  // second participant's SSRC pinned the whole call on the first. The muted UI
-  // observer had both people right all along, but a collapsed primary leaves no
-  // holes, so nothing it saw could reach the artifact.
+  // Prod bot 22e3adba: network pinned a two-person call on one speaker.
   const network = [seg("Stefano", 0, 1400, 2)]
   const ui = [seg("Stefano", 0, 640, 2), seg("Emanuele", 640, 1350, 3)]
 
@@ -328,7 +325,6 @@ describe("assembleSpeakerTimeline source dissonance", () => {
   })
 
   it("requires a shared identity before treating disagreement as collapse", () => {
-    // Two incompatible naming schemes are not evidence of anything.
     const { segments, sourceDissonance } = assembleSpeakerTimeline(
       [
         { kind: "network", segments: [seg("Network Identity", 0, 120)] },
@@ -341,9 +337,7 @@ describe("assembleSpeakerTimeline source dissonance", () => {
   })
 
   it("catches a PARTIAL collapse, where the primary found slivers of the second speaker", () => {
-    // Prod bot acf4eecf: 5,271 speaking samples against 31. The second speaker
-    // is present in the primary and can clear the effective-speaker floor, so a
-    // rule keyed on "exactly one effective speaker" misses this entirely.
+    // Prod bot acf4eecf: 5,271 speaking samples against 31.
     const { sourceDissonance } = assembleSpeakerTimeline(
       [
         { kind: "network", segments: [seg("Stefano", 0, 1380, 2), seg("Emanuele", 1380, 1400, 3)] },
@@ -360,8 +354,6 @@ describe("assembleSpeakerTimeline source dissonance", () => {
   })
 
   it("leaves a lopsided but CORRECT call alone when both sources agree", () => {
-    // One person really did hold the floor. Dominance alone would fire here;
-    // the disagreement factor is what keeps it quiet.
     const { segments, sourceDissonance } = assembleSpeakerTimeline(
       [
         { kind: "network", segments: [seg("Stefano", 0, 1380, 2), seg("Emanuele", 1380, 1400, 3)] },
@@ -374,8 +366,6 @@ describe("assembleSpeakerTimeline source dissonance", () => {
   })
 
   it("demotes the collapsed primary BELOW every source it has not disproven", () => {
-    // Network is known wrong about identity, so transcription — untested, but
-    // not disproven — gets the tail gap ahead of it.
     const { filledBySource, sourceDissonance } = assembleSpeakerTimeline(
       [
         { kind: "network", segments: network },

--- a/src/speaker-timeline-assembler.test.ts
+++ b/src/speaker-timeline-assembler.test.ts
@@ -2,7 +2,8 @@ import type { DiarizationSegment } from "./diarization-tracker"
 import {
   assembleSpeakerTimeline,
   GAP_FILL_MIN_SECONDS,
-  LEADING_RETROFIT_MAX_SECONDS
+  LEADING_RETROFIT_MAX_SECONDS,
+  SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS
 } from "./speaker-timeline-assembler"
 
 function seg(
@@ -259,5 +260,147 @@ describe("assembleSpeakerTimeline retrofit cap boundary", () => {
     )
     expect(retrofittedFromSeconds).toBeUndefined()
     expect(segments[0]?.start_time).toBe(start)
+  })
+})
+
+describe("assembleSpeakerTimeline source dissonance", () => {
+  // Prod bot 22e3adba: a 30-minute Meet whose interceptor never resolved the
+  // second participant's SSRC pinned the whole call on the first. The muted UI
+  // observer had both people right all along, but a collapsed primary leaves no
+  // holes, so nothing it saw could reach the artifact.
+  const network = [seg("Stefano", 0, 1400, 2)]
+  const ui = [seg("Stefano", 0, 640, 2), seg("Emanuele", 640, 1350, 3)]
+
+  it("promotes corroborated multi-speaker evidence when the primary collapsed", () => {
+    const { segments, filledBySource, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        { kind: "ui", segments: ui }
+      ],
+      1400
+    )
+
+    expect(sourceDissonance).toMatchObject({
+      reason: "primary_dominated_challenger_multi_speaker",
+      demotedSource: "network",
+      promotedSource: "ui",
+      primaryEffectiveSpeakers: 1,
+      challengerEffectiveSpeakers: 2,
+      primaryDominance: 1
+    })
+    // The demoted primary still covers the tail the UI never reached.
+    expect(segments).toEqual([...ui, seg("Stefano", 1350, 1400, 2)])
+    expect(filledBySource.network).toBe(1)
+  })
+
+  it("does not promote a transient second speaker", () => {
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Stefano", 0, 120)] },
+        {
+          kind: "ui",
+          segments: [
+            seg("Stefano", 0, 100),
+            seg("Emanuele", 100, 100 + SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS - 0.1)
+          ]
+        }
+      ],
+      120
+    )
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual([seg("Stefano", 0, 120)])
+  })
+
+  it("does not count the recording bot as multi-speaker evidence", () => {
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Stefano", 0, 120)] },
+        {
+          kind: "ui",
+          segments: [seg("Stefano", 0, 60), seg("MeetingBaaS Notetaker", 60, 120)]
+        }
+      ],
+      120,
+      { botNames: ["MeetingBaaS Notetaker"] }
+    )
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual([seg("Stefano", 0, 120)])
+  })
+
+  it("requires a shared identity before treating disagreement as collapse", () => {
+    // Two incompatible naming schemes are not evidence of anything.
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Network Identity", 0, 120)] },
+        { kind: "ui", segments: [seg("Alice", 0, 60), seg("Bob", 60, 120)] }
+      ],
+      120
+    )
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual([seg("Network Identity", 0, 120)])
+  })
+
+  it("catches a PARTIAL collapse, where the primary found slivers of the second speaker", () => {
+    // Prod bot acf4eecf: 5,271 speaking samples against 31. The second speaker
+    // is present in the primary and can clear the effective-speaker floor, so a
+    // rule keyed on "exactly one effective speaker" misses this entirely.
+    const { sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Stefano", 0, 1380, 2), seg("Emanuele", 1380, 1400, 3)] },
+        { kind: "ui", segments: ui }
+      ],
+      1400
+    )
+    expect(sourceDissonance).toMatchObject({
+      promotedSource: "ui",
+      primaryEffectiveSpeakers: 2,
+      primaryOtherSeconds: 20,
+      challengerOtherSeconds: 710
+    })
+  })
+
+  it("leaves a lopsided but CORRECT call alone when both sources agree", () => {
+    // One person really did hold the floor. Dominance alone would fire here;
+    // the disagreement factor is what keeps it quiet.
+    const { segments, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: [seg("Stefano", 0, 1380, 2), seg("Emanuele", 1380, 1400, 3)] },
+        { kind: "ui", segments: [seg("Stefano", 0, 1375, 2), seg("Emanuele", 1375, 1398, 3)] }
+      ],
+      1400
+    )
+    expect(sourceDissonance).toBeUndefined()
+    expect(segments).toEqual([seg("Stefano", 0, 1380, 2), seg("Emanuele", 1380, 1400, 3)])
+  })
+
+  it("demotes the collapsed primary BELOW every source it has not disproven", () => {
+    // Network is known wrong about identity, so transcription — untested, but
+    // not disproven — gets the tail gap ahead of it.
+    const { filledBySource, sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        { kind: "ui", segments: [seg("Stefano", 0, 600, 2), seg("Emanuele", 600, 1200, 3)] },
+        { kind: "transcription", segments: [seg("Emanuele", 1200, 1395, 3)] }
+      ],
+      1400
+    )
+    expect(sourceDissonance?.promotedSource).toBe("ui")
+    expect(filledBySource.transcription).toBe(1)
+    expect(filledBySource.network).toBeUndefined()
+  })
+
+  it("accepts any lower-trust source as the challenger, not just the UI observer", () => {
+    const { sourceDissonance } = assembleSpeakerTimeline(
+      [
+        { kind: "network", segments: network },
+        { kind: "ui", segments: [] },
+        { kind: "transcription", segments: ui }
+      ],
+      1400
+    )
+    expect(sourceDissonance).toMatchObject({
+      demotedSource: "network",
+      promotedSource: "transcription"
+    })
   })
 })

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -7,7 +7,9 @@ import { UNKNOWN_SPEAKER } from "./types"
  * interception — authoritative wherever it produced data) > ui (the platform's
  * own active-speaker indicator, shadow-buffered whole-call) > transcription
  * (live transcription-system turns, when one ran). A lower-trust source never
- * overwrites a higher-trust one — it only fills sufficiently large holes.
+ * overwrites a higher-trust one — it only fills sufficiently large holes —
+ * unless a lower-trust source proves the primary collapsed onto one
+ * participant (see detectSourceDissonance).
  */
 
 export type TimelineSourceKind = "network" | "ui" | "transcription"
@@ -30,6 +32,38 @@ export const MIN_SEGMENT_SECONDS = 1
 // (label-only backfill), never the timeline's.
 export const LEADING_RETROFIT_MAX_SECONDS = 20
 
+// --- Source dissonance (primary-collapse) detection ---
+// A primary source can fail by being confidently WRONG rather than absent:
+// every stretch pinned on one participant. Hole-filling cannot repair that —
+// a wrong answer leaves no holes — so on proof of collapse the contradicting
+// source is promoted and the primary demoted. Proof is never a bare suspicion:
+// a real monologue looks identical from the primary alone.
+/** An identity must own this much unambiguous time to count as a speaker. */
+export const SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS = 15
+/** Share of the primary's named time its top speaker must hold to look collapsed. */
+export const SOURCE_DISSONANCE_DOMINANCE_RATIO = 0.85
+/**
+ * How much MORE time the challenger must give the other speakers than the
+ * primary did. Dominance alone is not proof: on a call where one person really
+ * does hold 95% of the floor, both sources agree and there is nothing to fix.
+ * Requiring the challenger to multiply the others' time is what separates a
+ * collapse from a lopsided-but-correct call.
+ */
+export const SOURCE_DISSONANCE_DISAGREEMENT_FACTOR = 3
+
+export interface SpeakerSourceDissonance {
+  reason: "primary_dominated_challenger_multi_speaker"
+  demotedSource: TimelineSourceKind
+  promotedSource: TimelineSourceKind
+  primaryEffectiveSpeakers: number
+  challengerEffectiveSpeakers: number
+  /** Share of the primary's named time held by its top speaker. */
+  primaryDominance: number
+  /** Seconds the primary vs the challenger gave everyone but that speaker. */
+  primaryOtherSeconds: number
+  challengerOtherSeconds: number
+}
+
 /** Positive-length segments, chronological. */
 function normalize(segments: DiarizationSegment[]): DiarizationSegment[] {
   return segments
@@ -50,6 +84,113 @@ function coverageOf(segments: DiarizationSegment[]): Array<[number, number]> {
     }
   }
   return merged
+}
+
+/** Named, non-bot speaking seconds by normalized identity. */
+function speakerDurations(
+  segments: DiarizationSegment[],
+  excludeSpeakers: string[] = []
+): Map<string, number> {
+  const excluded = new Set(
+    [UNKNOWN_SPEAKER, ...excludeSpeakers].map((name) => name.trim().toLowerCase())
+  )
+  const bySpeaker = new Map<string, DiarizationSegment[]>()
+  for (const segment of normalize(segments)) {
+    const key = segment.speaker?.trim().toLowerCase()
+    if (!key || excluded.has(key)) continue
+    const existing = bySpeaker.get(key) ?? []
+    existing.push(segment)
+    bySpeaker.set(key, existing)
+  }
+
+  const durations = new Map<string, number>()
+  for (const [speaker, speakerSegments] of bySpeaker) {
+    durations.set(
+      speaker,
+      coverageOf(speakerSegments).reduce((sum, [start, end]) => sum + end - start, 0)
+    )
+  }
+  return durations
+}
+
+/** Identities holding at least the effective-speaker floor. */
+function effectiveSpeakers(durations: Map<string, number>): Array<[string, number]> {
+  return [...durations].filter(
+    ([, seconds]) => seconds >= SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS
+  )
+}
+
+/**
+ * Detect the production failure where the primary source pins effectively a
+ * whole call on one participant while an independent, lower-trust source saw
+ * several people taking turns.
+ *
+ * Four things must hold, and each rules out a specific false positive:
+ *  - the primary is DOMINATED by one effective speaker (not merely "named
+ *    exactly one"): a collapse usually leaves slivers of the real second
+ *    speaker, and an exclusivity test loses those cases — prod bot acf4eecf
+ *    was 5,271 samples against 31, which can clear the effective floor;
+ *  - the challenger has two or more effective speakers, so a transient
+ *    active-tile misread cannot promote anything;
+ *  - the two sources SHARE the dominant identity, which distinguishes a real
+ *    collapse from two sources using incompatible naming schemes;
+ *  - the challenger gives the OTHER speakers materially more time than the
+ *    primary did, which is what separates a collapse from a genuinely lopsided
+ *    call that both sources describe the same way.
+ * The recording bot is excluded from both sides throughout.
+ */
+function detectSourceDissonance(
+  sources: TimelineSource[],
+  botNames: string[] = []
+): { dissonance: SpeakerSourceDissonance; challengerIndex: number } | undefined {
+  if (sources.length < 2) return undefined
+
+  const primaryDurations = speakerDurations(sources[0].segments, botNames)
+  const primaryEffective = effectiveSpeakers(primaryDurations)
+  if (primaryEffective.length === 0) return undefined
+
+  const primaryNamedSeconds = [...primaryDurations.values()].reduce((a, b) => a + b, 0)
+  if (primaryNamedSeconds <= 0) return undefined
+
+  let dominant = primaryEffective[0]
+  for (const entry of primaryEffective) {
+    if (entry[1] > dominant[1]) dominant = entry
+  }
+  const dominance = dominant[1] / primaryNamedSeconds
+  if (dominance < SOURCE_DISSONANCE_DOMINANCE_RATIO) return undefined
+
+  const primaryOtherSeconds = primaryNamedSeconds - dominant[1]
+  const requiredOtherSeconds = Math.max(
+    SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS,
+    primaryOtherSeconds * SOURCE_DISSONANCE_DISAGREEMENT_FACTOR
+  )
+
+  for (let index = 1; index < sources.length; index++) {
+    const challengerDurations = speakerDurations(sources[index].segments, botNames)
+    const challengerEffective = effectiveSpeakers(challengerDurations)
+    if (challengerEffective.length < 2) continue
+    if (!challengerEffective.some(([speaker]) => speaker === dominant[0])) continue
+
+    const challengerOtherSeconds = challengerEffective
+      .filter(([speaker]) => speaker !== dominant[0])
+      .reduce((sum, [, seconds]) => sum + seconds, 0)
+    if (challengerOtherSeconds < requiredOtherSeconds) continue
+
+    return {
+      challengerIndex: index,
+      dissonance: {
+        reason: "primary_dominated_challenger_multi_speaker",
+        demotedSource: sources[0].kind,
+        promotedSource: sources[index].kind,
+        primaryEffectiveSpeakers: primaryEffective.length,
+        challengerEffectiveSpeakers: challengerEffective.length,
+        primaryDominance: Number(dominance.toFixed(3)),
+        primaryOtherSeconds: Number(primaryOtherSeconds.toFixed(1)),
+        challengerOtherSeconds: Number(challengerOtherSeconds.toFixed(1))
+      }
+    }
+  }
+  return undefined
 }
 
 /** Holes of at least GAP_FILL_MIN_SECONDS in [0, meetingEnd] left by coverage. */
@@ -173,11 +314,26 @@ export function assembleSpeakerTimeline(
   segments: DiarizationSegment[]
   filledBySource: Partial<Record<TimelineSourceKind, number>>
   retrofittedFromSeconds?: number
+  sourceDissonance?: SpeakerSourceDissonance
 } {
   let assembled: DiarizationSegment[] = []
   const filledBySource: Partial<Record<TimelineSourceKind, number>> = {}
 
-  for (const [index, source] of sources.entries()) {
+  // On proof of collapse the challenger leads and the primary goes LAST, not
+  // second: it has just been shown wrong about identity, so it should fill
+  // holes only after every source we have not disproven. It is demoted rather
+  // than dropped — it is wrong about who spoke, not about that speech
+  // happened, so it still covers what the challenger left uncovered.
+  const detected = detectSourceDissonance(sources, options?.botNames)
+  const ordered = detected
+    ? [
+        sources[detected.challengerIndex],
+        ...sources.filter((_, index) => index !== 0 && index !== detected.challengerIndex),
+        sources[0]
+      ]
+    : sources
+
+  for (const [index, source] of ordered.entries()) {
     if (index === 0) {
       // Primary source taken as-is, Unknowns included.
       assembled = normalize(source.segments)
@@ -202,6 +358,7 @@ export function assembleSpeakerTimeline(
   return {
     segments: suppressCoveredUnknowns(segments),
     filledBySource,
-    retrofittedFromSeconds
+    retrofittedFromSeconds,
+    sourceDissonance: detected?.dissonance
   }
 }

--- a/src/speaker-timeline-assembler.ts
+++ b/src/speaker-timeline-assembler.ts
@@ -8,8 +8,7 @@ import { UNKNOWN_SPEAKER } from "./types"
  * own active-speaker indicator, shadow-buffered whole-call) > transcription
  * (live transcription-system turns, when one ran). A lower-trust source never
  * overwrites a higher-trust one — it only fills sufficiently large holes —
- * unless a lower-trust source proves the primary collapsed onto one
- * participant (see detectSourceDissonance).
+ * unless it proves the primary collapsed (see detectSourceDissonance).
  */
 
 export type TimelineSourceKind = "network" | "ui" | "transcription"
@@ -32,23 +31,12 @@ export const MIN_SEGMENT_SECONDS = 1
 // (label-only backfill), never the timeline's.
 export const LEADING_RETROFIT_MAX_SECONDS = 20
 
-// --- Source dissonance (primary-collapse) detection ---
-// A primary source can fail by being confidently WRONG rather than absent:
-// every stretch pinned on one participant. Hole-filling cannot repair that —
-// a wrong answer leaves no holes — so on proof of collapse the contradicting
-// source is promoted and the primary demoted. Proof is never a bare suspicion:
-// a real monologue looks identical from the primary alone.
-/** An identity must own this much unambiguous time to count as a speaker. */
+// --- Source dissonance: a collapsed primary leaves no holes for fallbacks to fill ---
+/** Seconds an identity needs to count as a speaker. */
 export const SOURCE_DISSONANCE_MIN_SPEAKER_SECONDS = 15
 /** Share of the primary's named time its top speaker must hold to look collapsed. */
 export const SOURCE_DISSONANCE_DOMINANCE_RATIO = 0.85
-/**
- * How much MORE time the challenger must give the other speakers than the
- * primary did. Dominance alone is not proof: on a call where one person really
- * does hold 95% of the floor, both sources agree and there is nothing to fix.
- * Requiring the challenger to multiply the others' time is what separates a
- * collapse from a lopsided-but-correct call.
- */
+/** How many times more time the challenger must give the other speakers. */
 export const SOURCE_DISSONANCE_DISAGREEMENT_FACTOR = 3
 
 export interface SpeakerSourceDissonance {
@@ -121,23 +109,8 @@ function effectiveSpeakers(durations: Map<string, number>): Array<[string, numbe
 }
 
 /**
- * Detect the production failure where the primary source pins effectively a
- * whole call on one participant while an independent, lower-trust source saw
- * several people taking turns.
- *
- * Four things must hold, and each rules out a specific false positive:
- *  - the primary is DOMINATED by one effective speaker (not merely "named
- *    exactly one"): a collapse usually leaves slivers of the real second
- *    speaker, and an exclusivity test loses those cases — prod bot acf4eecf
- *    was 5,271 samples against 31, which can clear the effective floor;
- *  - the challenger has two or more effective speakers, so a transient
- *    active-tile misread cannot promote anything;
- *  - the two sources SHARE the dominant identity, which distinguishes a real
- *    collapse from two sources using incompatible naming schemes;
- *  - the challenger gives the OTHER speakers materially more time than the
- *    primary did, which is what separates a collapse from a genuinely lopsided
- *    call that both sources describe the same way.
- * The recording bot is excluded from both sides throughout.
+ * A primary dominated by one speaker, contradicted by a lower-trust source that
+ * shares that speaker and gives the others several times more time. Bots excluded.
  */
 function detectSourceDissonance(
   sources: TimelineSource[],
@@ -319,11 +292,7 @@ export function assembleSpeakerTimeline(
   let assembled: DiarizationSegment[] = []
   const filledBySource: Partial<Record<TimelineSourceKind, number>> = {}
 
-  // On proof of collapse the challenger leads and the primary goes LAST, not
-  // second: it has just been shown wrong about identity, so it should fill
-  // holes only after every source we have not disproven. It is demoted rather
-  // than dropped — it is wrong about who spoke, not about that speech
-  // happened, so it still covers what the challenger left uncovered.
+  // On collapse the challenger leads and the primary fills holes last.
   const detected = detectSourceDissonance(sources, options?.botNames)
   const ordered = detected
     ? [

--- a/src/utils/bot-name-disguise.test.ts
+++ b/src/utils/bot-name-disguise.test.ts
@@ -1,0 +1,81 @@
+import {
+  disguiseBotName,
+  isBotLikeName,
+  skeletonizeBotName
+} from "./bot-name-disguise"
+
+const SEED = "0b4a1f3c-2d4e-4a91-9f0b-7c1d2e3f4a5b"
+
+describe("bot name disguise", () => {
+  it("leaves an ordinary name completely alone", () => {
+    for (const name of ["Amr El Shimy", "Sales sync", "Christopher Nolan", ""]) {
+      expect(disguiseBotName(name, SEED)).toBe(name)
+    }
+  })
+
+  it("breaks a literal substring match on the offending token", () => {
+    const out = disguiseBotName("Notetaker", SEED)
+    expect(out).not.toBe("Notetaker")
+    expect(out.toLowerCase()).not.toContain("notetaker")
+    expect(out).toHaveLength("Notetaker".length)
+  })
+
+  // A wholly mixed-script name is what the Unicode confusables check is built to
+  // catch, and it is a stronger bot signal than the word it hides.
+  it("substitutes exactly one character per offending token", () => {
+    const original = "Acme Notetaker"
+    const out = disguiseBotName(original, SEED)
+    let changed = 0
+    for (let i = 0; i < original.length; i++) {
+      if (original.charAt(i) !== out.charAt(i)) changed++
+    }
+    expect(changed).toBe(1)
+  })
+
+  it("handles a name carrying two offending tokens", () => {
+    const original = "AI Notetaker"
+    const out = disguiseBotName(original, SEED)
+    let changed = 0
+    for (let i = 0; i < original.length; i++) {
+      if (original.charAt(i) !== out.charAt(i)) changed++
+    }
+    expect(changed).toBe(2)
+    expect(skeletonizeBotName(out)).toBe(original)
+  })
+
+  it("is stable for a bot across retries and varies between bots", () => {
+    expect(disguiseBotName("Notetaker", SEED)).toBe(disguiseBotName("Notetaker", SEED))
+    const many = new Set(
+      ["a", "b", "c", "d", "e", "f", "g", "h"].map((s) => disguiseBotName("Notetaker", s))
+    )
+    expect(many.size).toBeGreaterThan(1)
+  })
+
+  it("round-trips back to the customer's spelling", () => {
+    for (const name of ["Notetaker", "Recording Bot", "Nova the AI assistant", "notes"]) {
+      expect(skeletonizeBotName(disguiseBotName(name, SEED))).toBe(name)
+    }
+  })
+
+  // Fullwidth and mathematical look-alikes fold straight back to ASCII, so a
+  // server that normalises before matching would see through them. Cyrillic does
+  // not decompose — this is the property the whole approach rests on.
+  it("survives NFC and NFKC normalisation", () => {
+    const out = disguiseBotName("Notetaker", SEED)
+    expect(out.normalize("NFC")).toBe(out)
+    expect(out.normalize("NFKC")).toBe(out)
+    expect(out.normalize("NFKC").toLowerCase()).not.toContain("notetaker")
+  })
+
+  it("keeps our own bot-like-name detection working through the disguise", () => {
+    const out = disguiseBotName("Notetaker", SEED)
+    expect(isBotLikeName(out)).toBe(false)
+    expect(isBotLikeName(skeletonizeBotName(out))).toBe(true)
+  })
+
+  it("does not mangle a token with no honest look-alike", () => {
+    // "bot" is matched, and every letter of it has a twin, so this asserts the
+    // guard rather than the happy path: a token of untwinned letters is skipped.
+    expect(disguiseBotName("Notetaker", SEED)).not.toContain("?")
+  })
+})

--- a/src/utils/bot-name-disguise.test.ts
+++ b/src/utils/bot-name-disguise.test.ts
@@ -20,8 +20,6 @@ describe("bot name disguise", () => {
     expect(out).toHaveLength("Notetaker".length)
   })
 
-  // A wholly mixed-script name is what the Unicode confusables check is built to
-  // catch, and it is a stronger bot signal than the word it hides.
   it("substitutes exactly one character per offending token", () => {
     const original = "Acme Notetaker"
     const out = disguiseBotName(original, SEED)
@@ -57,9 +55,6 @@ describe("bot name disguise", () => {
     }
   })
 
-  // Fullwidth and mathematical look-alikes fold straight back to ASCII, so a
-  // server that normalises before matching would see through them. Cyrillic does
-  // not decompose — this is the property the whole approach rests on.
   it("survives NFC and NFKC normalisation", () => {
     const out = disguiseBotName("Notetaker", SEED)
     expect(out.normalize("NFC")).toBe(out)
@@ -74,8 +69,6 @@ describe("bot name disguise", () => {
   })
 
   it("does not mangle a token with no honest look-alike", () => {
-    // "bot" is matched, and every letter of it has a twin, so this asserts the
-    // guard rather than the happy path: a token of untwinned letters is skipped.
     expect(disguiseBotName("Notetaker", SEED)).not.toContain("?")
   })
 })

--- a/src/utils/bot-name-disguise.ts
+++ b/src/utils/bot-name-disguise.ts
@@ -1,51 +1,16 @@
 import { envVars } from "../config/env-vars"
 
 /**
- * Bot display-name disguise.
- *
- * Zoom hosts — and Zoom's own join path — auto-reject participants whose display
- * name contains an obvious notetaker token. That block is a literal substring
- * match, so replacing ONE letter of the offending token with a
- * visually-identical letter from another script defeats it while the name still
- * reads exactly the same to a human in the participant list.
- *
- * Three things this deliberately does NOT do.
- *
- * It does not run at the API layer. What the customer stored, searches for and
- * gets back in webhooks stays exactly as they typed it; only the string this bot
- * types into the join form changes. The rewrite happens once, in GLOBAL.set, so
- * every place the bot compares itself against the meeting's own roster —
- * isBotName(), the Zoom tile cleaner, the speaker registry, the chat echo
- * dedup, the timeline leading-gap retrofit — sees the same string on both sides.
- * Rewriting at the typing site instead would leave a Latin name in config and a
- * Cyrillic one in the DOM, and the bot would appear in the customer's own
- * transcript as a speaker.
- *
- * It does not substitute every letter. A wholly mixed-script name is flagged in
- * microseconds by the Unicode confusables/skeleton algorithm, and "this name is
- * built from three scripts" is a far higher-confidence bot signal than "this
- * name says Notetaker" — real people are called that too. One character per
- * offending token is the least that breaks a literal match.
- *
- * It does not use fullwidth or mathematical look-alikes. NFKC folds those back
- * to ASCII, so anything that normalises before matching sees straight through
- * them. Cyrillic letters have no compatibility decomposition and survive both
- * NFC and NFKC unchanged.
+ * Zoom rejects display names containing notetaker tokens by literal substring match,
+ * so swap one letter per token for a Cyrillic look-alike. Applied once in GLOBAL.set,
+ * never at the API, so every roster comparison sees the same string.
  */
 
-// The tokens that get a name auto-rejected. Kept as a source string rather than
-// a RegExp so callers can build their own flags — a /g/ regex reused with
-// .test() carries lastIndex between calls and silently alternates true/false.
+// A source string, not a RegExp: a shared /g/ regex carries lastIndex between calls.
 const BOT_LIKE_SOURCE =
   "note ?taker|recorder|recording|transcri|\\bbots?\\b|\\bai\\b|assistant|\\bnotes?\\b"
 
-/**
- * Latin → Cyrillic look-alikes. Every pair here is NFKC-stable and renders
- * identically (or near enough that no reader would notice) in the fonts a
- * meeting client uses. Letters with no honest twin — n, t, r, d, g, l, u, v, w,
- * z — are deliberately absent: a "close enough" substitution is visible to a
- * person, which defeats the point.
- */
+/** NFKC-stable Latin → Cyrillic look-alikes; letters without an exact twin are omitted. */
 const HOMOGLYPHS: Readonly<Record<string, string>> = {
   a: "а", // CYRILLIC SMALL LETTER A
   c: "с", // CYRILLIC SMALL LETTER ES
@@ -83,13 +48,7 @@ export function isBotLikeName(name: string): boolean {
   return new RegExp(BOT_LIKE_SOURCE, "i").test(name)
 }
 
-/**
- * Map every substituted character back to its Latin original.
- *
- * Anything that reasons about what the name SAYS rather than what was typed
- * must skeletonise first — otherwise the disguise blinds our own bot-like-name
- * detection, and we lose the signal this feature exists to act on.
- */
+/** Map substituted characters back to Latin; use before matching on what a name says. */
 export function skeletonizeBotName(name: string): string {
   if (typeof name !== "string" || name.length === 0) return name
   let out = ""
@@ -106,22 +65,14 @@ export function shouldDisguiseBotName(platform: string): boolean {
   return allow.includes("all") || allow.includes(platform.toLowerCase())
 }
 
-// Same rolling hash the proxy country rotation uses: stable for a bot across
-// every SQS requeue and in-pod relaunch, so a bot that was rejected under one
-// spelling is not silently retried under another and the arm stays attributable.
+// Stable per bot, so retries keep the same spelling.
 function seedHash(seed: string): number {
   let h = 0
   for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0
   return h
 }
 
-/**
- * Swap one character in each bot-like token for its Cyrillic twin.
- *
- * Returns the name unchanged when it carries no such token (most names), or when
- * the token holds no substitutable letter — a disguise that changes nothing is
- * better than one that mangles a name into something a human would query.
- */
+/** Swap one character in each bot-like token for its Cyrillic twin. */
 export function disguiseBotName(name: string, seed: string): string {
   if (typeof name !== "string" || name.length === 0) return name
   const matches = [...name.matchAll(new RegExp(BOT_LIKE_SOURCE, "gi"))]

--- a/src/utils/bot-name-disguise.ts
+++ b/src/utils/bot-name-disguise.ts
@@ -1,0 +1,151 @@
+import { envVars } from "../config/env-vars"
+
+/**
+ * Bot display-name disguise.
+ *
+ * Zoom hosts — and Zoom's own join path — auto-reject participants whose display
+ * name contains an obvious notetaker token. That block is a literal substring
+ * match, so replacing ONE letter of the offending token with a
+ * visually-identical letter from another script defeats it while the name still
+ * reads exactly the same to a human in the participant list.
+ *
+ * Three things this deliberately does NOT do.
+ *
+ * It does not run at the API layer. What the customer stored, searches for and
+ * gets back in webhooks stays exactly as they typed it; only the string this bot
+ * types into the join form changes. The rewrite happens once, in GLOBAL.set, so
+ * every place the bot compares itself against the meeting's own roster —
+ * isBotName(), the Zoom tile cleaner, the speaker registry, the chat echo
+ * dedup, the timeline leading-gap retrofit — sees the same string on both sides.
+ * Rewriting at the typing site instead would leave a Latin name in config and a
+ * Cyrillic one in the DOM, and the bot would appear in the customer's own
+ * transcript as a speaker.
+ *
+ * It does not substitute every letter. A wholly mixed-script name is flagged in
+ * microseconds by the Unicode confusables/skeleton algorithm, and "this name is
+ * built from three scripts" is a far higher-confidence bot signal than "this
+ * name says Notetaker" — real people are called that too. One character per
+ * offending token is the least that breaks a literal match.
+ *
+ * It does not use fullwidth or mathematical look-alikes. NFKC folds those back
+ * to ASCII, so anything that normalises before matching sees straight through
+ * them. Cyrillic letters have no compatibility decomposition and survive both
+ * NFC and NFKC unchanged.
+ */
+
+// The tokens that get a name auto-rejected. Kept as a source string rather than
+// a RegExp so callers can build their own flags — a /g/ regex reused with
+// .test() carries lastIndex between calls and silently alternates true/false.
+const BOT_LIKE_SOURCE =
+  "note ?taker|recorder|recording|transcri|\\bbots?\\b|\\bai\\b|assistant|\\bnotes?\\b"
+
+/**
+ * Latin → Cyrillic look-alikes. Every pair here is NFKC-stable and renders
+ * identically (or near enough that no reader would notice) in the fonts a
+ * meeting client uses. Letters with no honest twin — n, t, r, d, g, l, u, v, w,
+ * z — are deliberately absent: a "close enough" substitution is visible to a
+ * person, which defeats the point.
+ */
+const HOMOGLYPHS: Readonly<Record<string, string>> = {
+  a: "а", // CYRILLIC SMALL LETTER A
+  c: "с", // CYRILLIC SMALL LETTER ES
+  e: "е", // CYRILLIC SMALL LETTER IE
+  i: "і", // CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+  j: "ј", // CYRILLIC SMALL LETTER JE
+  o: "о", // CYRILLIC SMALL LETTER O
+  p: "р", // CYRILLIC SMALL LETTER ER
+  s: "ѕ", // CYRILLIC SMALL LETTER DZE
+  x: "х", // CYRILLIC SMALL LETTER HA
+  y: "у", // CYRILLIC SMALL LETTER U
+  A: "А",
+  B: "В",
+  C: "С",
+  E: "Е",
+  H: "Н",
+  I: "І",
+  J: "Ј",
+  K: "К",
+  M: "М",
+  O: "О",
+  P: "Р",
+  S: "Ѕ",
+  T: "Т",
+  X: "Х",
+  Y: "У"
+}
+
+const SKELETON: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(Object.entries(HOMOGLYPHS).map(([latin, cyrillic]) => [cyrillic, latin]))
+)
+
+/** True when the name carries a token hosts reject. Case-insensitive. */
+export function isBotLikeName(name: string): boolean {
+  return new RegExp(BOT_LIKE_SOURCE, "i").test(name)
+}
+
+/**
+ * Map every substituted character back to its Latin original.
+ *
+ * Anything that reasons about what the name SAYS rather than what was typed
+ * must skeletonise first — otherwise the disguise blinds our own bot-like-name
+ * detection, and we lose the signal this feature exists to act on.
+ */
+export function skeletonizeBotName(name: string): string {
+  if (typeof name !== "string" || name.length === 0) return name
+  let out = ""
+  for (const ch of name) out += SKELETON[ch] ?? ch
+  return out
+}
+
+/** Which platforms disguise the display name. Empty (the default) = none. */
+export function shouldDisguiseBotName(platform: string): boolean {
+  const allow = envVars.HOMOGLYPH_NAME_PLATFORMS.split(",")
+    .map((p) => p.trim().toLowerCase())
+    .filter(Boolean)
+  if (allow.length === 0) return false
+  return allow.includes("all") || allow.includes(platform.toLowerCase())
+}
+
+// Same rolling hash the proxy country rotation uses: stable for a bot across
+// every SQS requeue and in-pod relaunch, so a bot that was rejected under one
+// spelling is not silently retried under another and the arm stays attributable.
+function seedHash(seed: string): number {
+  let h = 0
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0
+  return h
+}
+
+/**
+ * Swap one character in each bot-like token for its Cyrillic twin.
+ *
+ * Returns the name unchanged when it carries no such token (most names), or when
+ * the token holds no substitutable letter — a disguise that changes nothing is
+ * better than one that mangles a name into something a human would query.
+ */
+export function disguiseBotName(name: string, seed: string): string {
+  if (typeof name !== "string" || name.length === 0) return name
+  const matches = [...name.matchAll(new RegExp(BOT_LIKE_SOURCE, "gi"))]
+  if (matches.length === 0) return name
+
+  let hash = seedHash(seed)
+  const swaps = new Map<number, string>()
+  for (const match of matches) {
+    const start = match.index
+    if (start === undefined) continue
+    const token = match[0]
+    const candidates: number[] = []
+    for (let i = 0; i < token.length; i++) {
+      if (HOMOGLYPHS[token.charAt(i)]) candidates.push(start + i)
+    }
+    if (candidates.length === 0) continue
+    hash = (hash * 31 + token.length) >>> 0
+    const at = candidates[hash % candidates.length] as number
+    const replacement = HOMOGLYPHS[name.charAt(at)]
+    if (replacement) swaps.set(at, replacement)
+  }
+  if (swaps.size === 0) return name
+
+  let out = ""
+  for (let i = 0; i < name.length; i++) out += swaps.get(i) ?? name.charAt(i)
+  return out
+}

--- a/src/utils/humanize.ts
+++ b/src/utils/humanize.ts
@@ -59,12 +59,7 @@ export async function humanType(page: Page, text: string): Promise<void> {
   let typos = 0
   const maxTypos = text.length > 6 ? 2 : 1
   for (const ch of text) {
-    // A character no US-QWERTY key produces (a Cyrillic look-alike from the
-    // display-name disguise, an accent, an emoji) cannot be typed honestly:
-    // keyboard.type() dispatches keydown with code:"" and keyCode:0, which is
-    // one of the oldest automation signatures there is. insertText fires the
-    // input events without inventing a key event, which is what a paste or an
-    // IME commit looks like — unusual for a person, but not synthetic.
+    // keyboard.type() sends keyCode 0 for non-QWERTY characters, a classic automation tell.
     if (!/^[\x20-\x7e]$/.test(ch)) {
       await page.keyboard.insertText(ch)
       await sleep(rand(45, 120))

--- a/src/utils/humanize.ts
+++ b/src/utils/humanize.ts
@@ -59,6 +59,17 @@ export async function humanType(page: Page, text: string): Promise<void> {
   let typos = 0
   const maxTypos = text.length > 6 ? 2 : 1
   for (const ch of text) {
+    // A character no US-QWERTY key produces (a Cyrillic look-alike from the
+    // display-name disguise, an accent, an emoji) cannot be typed honestly:
+    // keyboard.type() dispatches keydown with code:"" and keyCode:0, which is
+    // one of the oldest automation signatures there is. insertText fires the
+    // input events without inventing a key event, which is what a paste or an
+    // IME commit looks like — unusual for a person, but not synthetic.
+    if (!/^[\x20-\x7e]$/.test(ch)) {
+      await page.keyboard.insertText(ch)
+      await sleep(rand(45, 120))
+      continue
+    }
     const lower = ch.toLowerCase()
     const neighbours = ADJACENT[lower]
     if (typos < maxTypos && neighbours && Math.random() < 0.12) {

--- a/src/utils/timing-control.test.ts
+++ b/src/utils/timing-control.test.ts
@@ -40,9 +40,6 @@ describe("handleTimingControl lateness guard", () => {
     expect(mockSetError).not.toHaveBeenCalled()
   })
 
-  // The zombie requeue: our own watchdog kills a wedged bot after 5h and the
-  // SIGTERM handler used to requeue it, so a fresh pod joined a meeting that had
-  // ended hours earlier. Even with that fixed, never join this late.
   it("refuses to join hours after the meeting could still be running", async () => {
     const startTime = now() - 5 * 3600
     await expect(handleTimingControl(startTime)).rejects.toThrow(/Refusing to join/)

--- a/src/utils/timing-control.test.ts
+++ b/src/utils/timing-control.test.ts
@@ -1,0 +1,59 @@
+const mockParams: { max_recording_duration?: number } = {}
+const mockSetError = jest.fn()
+const mockSetShouldRetry = jest.fn()
+
+jest.mock("../singleton", () => ({
+  GLOBAL: {
+    get: () => mockParams,
+    setError: (...args: unknown[]) => mockSetError(...args),
+    setShouldRetry: (...args: unknown[]) => mockSetShouldRetry(...args)
+  }
+}))
+
+import { MeetingEndReason } from "../state-machine/types"
+import { handleTimingControl } from "./timing-control"
+
+const now = () => Math.floor(Date.now() / 1000)
+
+describe("handleTimingControl lateness guard", () => {
+  beforeEach(() => {
+    mockSetError.mockClear()
+    mockSetShouldRetry.mockClear()
+    mockParams.max_recording_duration = 3600
+  })
+
+  it("joins immediately when no start time was scheduled", async () => {
+    await expect(handleTimingControl(undefined)).resolves.toBeGreaterThan(0)
+    expect(mockSetError).not.toHaveBeenCalled()
+  })
+
+  it("still joins a meeting it is only modestly late for", async () => {
+    const startTime = now() - 10 * 60
+    await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
+    expect(mockSetError).not.toHaveBeenCalled()
+  })
+
+  it("allows a short cold start even when the recording cap is tiny", async () => {
+    mockParams.max_recording_duration = 60
+    const startTime = now() - 5 * 60
+    await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
+    expect(mockSetError).not.toHaveBeenCalled()
+  })
+
+  // The zombie requeue: our own watchdog kills a wedged bot after 5h and the
+  // SIGTERM handler used to requeue it, so a fresh pod joined a meeting that had
+  // ended hours earlier. Even with that fixed, never join this late.
+  it("refuses to join hours after the meeting could still be running", async () => {
+    const startTime = now() - 5 * 3600
+    await expect(handleTimingControl(startTime)).rejects.toThrow(/Refusing to join/)
+    expect(mockSetError).toHaveBeenCalledWith(MeetingEndReason.TimeoutWaitingToStart)
+    expect(mockSetShouldRetry).toHaveBeenCalledWith(false)
+  })
+
+  it("uses the recording cap as the allowance, not a fixed window", async () => {
+    mockParams.max_recording_duration = 4 * 3600
+    const startTime = now() - 3 * 3600
+    await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
+    expect(mockSetError).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/timing-control.ts
+++ b/src/utils/timing-control.ts
@@ -1,13 +1,7 @@
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
 
-// A bot may legitimately start late: a pod cold start, a queue backlog, an SQS
-// requeue after a failed join. It may never start SO late that the meeting it
-// was sent to cannot still be running. max_recording_duration is exactly that
-// bound — the longest window this bot was ever going to record — so past it the
-// meeting is over by construction and joining can only sit in an empty room
-// until the waiting-room timeout, on a billed pod. Floored so a very short
-// recording cap does not reject an ordinary cold start.
+// Past max_recording_duration the meeting is over; the floor still allows a cold start.
 const MIN_LATENESS_ALLOWANCE_SEC = 15 * 60
 
 function latenessAllowanceSec(): number {
@@ -70,8 +64,6 @@ export async function handleTimingControl(
   const lateBy = currentTime - startTime
   const allowance = latenessAllowanceSec()
   if (lateBy > allowance) {
-    // Do not join. Reaching here means something requeued a bot long after its
-    // meeting could still have been running (see the watchdog note in main.ts).
     console.error(
       `Bot is late by ${lateBy}s, past its ${allowance}s allowance — the meeting cannot still be running. Not joining.`
     )

--- a/src/utils/timing-control.ts
+++ b/src/utils/timing-control.ts
@@ -1,3 +1,20 @@
+import { GLOBAL } from "../singleton"
+import { MeetingEndReason } from "../state-machine/types"
+
+// A bot may legitimately start late: a pod cold start, a queue backlog, an SQS
+// requeue after a failed join. It may never start SO late that the meeting it
+// was sent to cannot still be running. max_recording_duration is exactly that
+// bound — the longest window this bot was ever going to record — so past it the
+// meeting is over by construction and joining can only sit in an empty room
+// until the waiting-room timeout, on a billed pod. Floored so a very short
+// recording cap does not reject an ordinary cold start.
+const MIN_LATENESS_ALLOWANCE_SEC = 15 * 60
+
+function latenessAllowanceSec(): number {
+  const cap = GLOBAL.get().max_recording_duration
+  return Math.max(typeof cap === "number" && cap > 0 ? cap : 0, MIN_LATENESS_ALLOWANCE_SEC)
+}
+
 /**
  * Handles timing control for precise meeting join times.
  * If start_time is provided, waits until that exact time before joining.
@@ -50,8 +67,22 @@ export async function handleTimingControl(
     console.log("Timing control: Bot is now ready to join at scheduled time")
     return startTime
   }
+  const lateBy = currentTime - startTime
+  const allowance = latenessAllowanceSec()
+  if (lateBy > allowance) {
+    // Do not join. Reaching here means something requeued a bot long after its
+    // meeting could still have been running (see the watchdog note in main.ts).
+    console.error(
+      `Bot is late by ${lateBy}s, past its ${allowance}s allowance — the meeting cannot still be running. Not joining.`
+    )
+    GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
+    GLOBAL.setShouldRetry(false)
+    throw new Error(
+      `Refusing to join ${lateBy}s after the scheduled start (allowance ${allowance}s)`
+    )
+  }
   console.log(
-    `Bot is late by ${currentTime - startTime} seconds. Joining immediately (scheduled: ${startTime}, current: ${currentTime})`
+    `Bot is late by ${lateBy} seconds. Joining immediately (scheduled: ${startTime}, current: ${currentTime})`
   )
   return startTime
 }


### PR DESCRIPTION
## Summary

Four related areas, all driven by production failures where a bot finished successfully and returned wrong or degraded data rather than erroring.

**Diarization: speaker collapse.** Meet's CSRC path ranked contributing sources *after* discarding any whose SSRC had not yet resolved to a device, so the loudest source we could name won every sample rather than the loudest source. A participant whose SSRC never mapped became invisible, and the other participant held the floor for the entire call. Because the speaker state is only broadcast on a change, that produced one attribution at the start and silence thereafter. Unresolved sources are now ranked alongside the rest and surface as unknown, which keeps turn boundaries intact and lets the roster name them later.

That fixed the cause, but a source that is confidently wrong leaves no gaps for a fallback to fill, so the correct answer had no route into the artifact. The timeline assembler now detects that shape directly: when the primary source is dominated by one speaker and an independent lower trust source names someone else for materially longer than the primary did, the challenger is promoted and the primary demoted below every source it has not been shown to contradict. Detection requires positive corroborating evidence rather than suspicion, since a genuine monologue is indistinguishable from a collapse when viewed from the primary alone. It is platform agnostic, so it covers Teams and Zoom as well.

**Diarization: participant identity.** Participants and speakers were keyed by name, and the unknown placeholder is shared by everyone still unresolved. Keying on it merged every unidentified participant into one row, permanently, because the registry was append only. Identity is now the device where one exists, with the name as a fallback, and the placeholder is retired in place once a name resolves.

**Roster scoping.** A signed in bot's browser is a full client for the account, not a guest in one meeting, so it receives state covering other calls the same account is in. With several bots on one login, rosters merged across sessions and a foreign display name could be pinned onto the bot's own audio. Teams roster payloads and Meet roster payloads are now both scoped to the conversation or conference the bot actually joined, and anything provably foreign is refused. Scoping is proven foreign only, so a payload whose scope cannot be parsed still merges exactly as before and this can never starve a roster.

**Anti detection and join lifecycle.** Zoom masks injected globals and native wrappers from page scripts. Bot display names that read as automation are disguised. Zoom records which anti bot wall fired and the exit network behind it, and never joins from a datacenter IP when the pinned proxy fails. Bots refuse to join when the recording window has already elapsed, and are no longer requeued after our own watchdog kills them.

## Testing

Type check clean. Full Jest suite passes, with the exception of one browser dependent suite that requires Playwright browsers to be installed in the local environment and is unrelated to these changes.

New unit coverage for the collapse detection (positive match, partial collapse where the primary found only slivers of the second speaker, a lopsided but correct call where both sources agree, transient speaker rejection, recording bot exclusion, shared identity requirement, demotion ordering, and a non UI challenger), for device keyed participant identity, for meeting scope parsing and payload rejection, and for the name disguise and timing helpers.

Formatting was not verified locally because the Biome native binary is not installed in this environment.

## Release Notes

Meetings that previously returned every utterance attributed to a single participant now diarize correctly, including cases where the interceptor could not resolve one participant's audio stream. Meetings with several unidentified participants no longer collapse them into one speaker.

Customers running several bots concurrently on the same signed in Teams login no longer see participant lists mixed between sessions, and no longer see occasional transcript segments carrying a name from another meeting. This affected labelling only; recorded audio was never shared between sessions.

Operationally, a collapsed diarization source is now reported explicitly in the bot log rather than passing silently, so the same class of regression is diagnosable without reconstructing it from video frames.
