### PR TITLE
fix(teams): hold unverified rosters, report watchdog kills, and use an explicit join deadline

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,8 +78,12 @@ process.on("SIGTERM", async () => {
           "Bot was stopped after outliving its recording window"
         )
       }
-      GLOBAL.claimRecovery()
-      await handleFailedRecording()
+      if (GLOBAL.claimRecovery()) {
+        GLOBAL.setShouldRetry(false)
+        await handleFailedRecording({ terminal: true })
+      } else {
+        console.log("[SIGTERM] Recovery claimed concurrently — that handler reports the outcome")
+      }
     } else if (!GLOBAL.isServerless()) {
       GLOBAL.setShouldRetry(true)
       if (shouldAttemptRetry(GLOBAL.getRetryCount())) {
@@ -179,7 +183,7 @@ async function handleSuccessfulRecording(): Promise<void> {
 /**
  * Handle failed recording
  */
-async function handleFailedRecording(): Promise<void> {
+async function handleFailedRecording(opts: { terminal?: boolean } = {}): Promise<void> {
   console.error("Recording did not complete successfully")
 
   const endReason = GLOBAL.getEndReason()
@@ -214,12 +218,12 @@ async function handleFailedRecording(): Promise<void> {
 
   // The Zoom anti-bot wall is probabilistic (keys on exit-IP reputation), so mark
   // it retryable — each requeue lands a fresh exit IP, cycling past burned ones.
-  if (endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) {
+  if (!opts.terminal && endReason === MeetingEndReason.ZoomAnonymousJoinNotAllowed) {
     console.log("[Retry] Zoom anti-bot wall — marking retryable to cycle exit IP")
     GLOBAL.setShouldRetry(true)
   }
 
-  const shouldRetry = shouldAttemptRetry(currentRetryCount)
+  const shouldRetry = !opts.terminal && shouldAttemptRetry(currentRetryCount)
 
   if (shouldRetry) {
     console.log(

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
   requeueToSQS,
   shouldAttemptRetry
 } from "./utils/retry-handler"
+import { NORMAL_END_REASONS } from "./state-machine/constants"
 
 // sqs-consumer's watchdog drops WATCHDOG_KILL_SENTINEL before SIGTERMing a bot that
 // outlived its recording window; requeuing it would relaunch into a dead meeting.
@@ -69,6 +70,16 @@ process.on("SIGTERM", async () => {
       console.log("[SIGTERM] Recording finalized — preserving artifacts (not requeuing)")
     } else if (watchdogKill) {
       console.log("[SIGTERM] Watchdog kill — artifacts preserved, requeue deliberately skipped")
+      // Report it as terminal, or the backend never learns the bot ended.
+      const endReason = GLOBAL.getEndReason()
+      if (!endReason || NORMAL_END_REASONS.includes(endReason)) {
+        GLOBAL.setError(
+          MeetingEndReason.Internal,
+          "Bot was stopped after outliving its recording window"
+        )
+      }
+      GLOBAL.claimRecovery()
+      await handleFailedRecording()
     } else if (!GLOBAL.isServerless()) {
       GLOBAL.setShouldRetry(true)
       if (shouldAttemptRetry(GLOBAL.getRetryCount())) {

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -526,8 +526,11 @@ export function teamsBrowserInterceptionLogic(
         participantsToArray(body.participants?.value) ||
         participantsToArray(body.participants)
       if (explicit?.length) return explicit
-      const generic = participantsToArray(body.value) || (Array.isArray(body) ? body : null)
-      return generic?.some(looksLikeParticipant) ? generic : null
+      for (const candidate of [body.roster, body.value, Array.isArray(body) ? body : null]) {
+        const list = participantsToArray(candidate)
+        if (list?.some(looksLikeParticipant)) return list
+      }
+      return null
     }
 
     function looksLikeParticipant(pp: any): boolean {

--- a/src/meeting/teams/network-interception/browser-bundle.ts
+++ b/src/meeting/teams/network-interception/browser-bundle.ts
@@ -9,13 +9,18 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: browser-side bundle over untyped Teams/WebRTC internals. */
 
 // Type-only: erased, so the stringified bundle stays self-contained.
-import type { RosterScopeResolver, TeamsInterceptorScope } from "./meeting-scope"
+import type {
+  OwnRosterExtractor,
+  RosterScopeResolver,
+  TeamsInterceptorScope
+} from "./meeting-scope"
 import type { SpeakerSetResolver, SpeakerTimelineRung } from "./speaker-timeline"
 
 /** Arguments are passed in, not imported: this function is stringified into the page. */
 export function teamsBrowserInterceptionLogic(
   resolveSpeakingSet: SpeakerSetResolver,
   resolveRosterScope: RosterScopeResolver,
+  extractOwnRoster: OwnRosterExtractor,
   meetingScope: TeamsInterceptorScope
 ) {
   try {
@@ -194,7 +199,10 @@ export function teamsBrowserInterceptionLogic(
       rosterScopeAggregate: 0,
       rosterScopeUnplaceable: 0,
       rosterScopeUnknown: 0,
-      rosterScopeStrictRelaxed: false
+      rosterScopeStrictRelaxed: false,
+      rosterQuarantined: 0,
+      rosterVerifiedAdmitted: 0,
+      rosterAggregateExtracted: 0
     }
     const diag = (window as any).__teamsNetDiag
 
@@ -234,13 +242,27 @@ export function teamsBrowserInterceptionLogic(
         ownConversation = raw
         diag.ownConversationKnown = true
         debug("🔒 meeting scope learned from active call", raw)
+        setTimeout(drainQuarantine, 0)
       } catch {
         // Teams internals unavailable — stay permissive.
       }
     }
 
-    /** Whether a roster payload may be merged into this bot's participant map. */
-    function isInMeetingScope(url: string | undefined, body: string | undefined): boolean {
+    // Held until our meeting is known, then replayed through admission.
+    const QUARANTINE_MAX = 100
+    const quarantine: Array<() => void> = []
+
+    function drainQuarantine(): void {
+      for (const replay of quarantine.splice(0)) {
+        try {
+          replay()
+        } catch {
+          // One bad payload must not block the rest.
+        }
+      }
+    }
+
+    function rosterVerdict(url: string | undefined, body: string | undefined) {
       learnOwnConversation()
       const verdict = resolveRosterScope({
         own: ownConversation,
@@ -249,29 +271,89 @@ export function teamsBrowserInterceptionLogic(
         isAuthenticated: scope.isAuthenticated,
         strict
       })
-      // Strict-only rejections count toward the starvation escape.
-      const countTowardStrictEscape = () => {
-        if (verdict.accept || participantsByDeviceId.size > 0) return
-        droppedWhileEmpty++
-        if (droppedWhileEmpty >= STRICT_ESCAPE_AFTER) {
-          strict = false
-          diag.rosterScopeStrictRelaxed = true
-          console.warn(
-            `${LOG} ⚠️ roster still empty after dropping ${droppedWhileEmpty} strictly-scoped payloads — relaxing to proven-foreign-only`
-          )
-        }
-      }
-
       if (verdict.reason === "own-unknown") diag.rosterScopeUnknown++
-      else if (verdict.reason === "aggregate") {
-        diag.rosterScopeAggregate++
-        countTowardStrictEscape()
-      } else if (verdict.reason === "unplaceable") {
-        diag.rosterScopeUnplaceable++
-        countTowardStrictEscape()
-      }
+      else if (verdict.reason === "aggregate") diag.rosterScopeAggregate++
+      else if (verdict.reason === "unplaceable") diag.rosterScopeUnplaceable++
       if (!verdict.accept) diag.rosterScopeRejected++
-      return verdict.accept
+      return verdict
+    }
+
+    function hasOtherParticipants(): boolean {
+      for (const record of participantsByDeviceId.values()) {
+        if (!record.isCurrentUser) return true
+      }
+      return false
+    }
+
+    // Last resort, only while nobody but the bot has been recovered.
+    function countTowardStrictEscape(): void {
+      if (!strict || hasOtherParticipants()) return
+      droppedWhileEmpty++
+      if (droppedWhileEmpty < STRICT_ESCAPE_AFTER) return
+      strict = false
+      diag.rosterScopeStrictRelaxed = true
+      console.warn(
+        `${LOG} ⚠️ no participant besides the bot after dropping ${droppedWhileEmpty} roster payloads — relaxing to proven-foreign-only`
+      )
+      setTimeout(drainQuarantine, 0)
+    }
+
+    // The calling SDK's participants are scoped to the active call.
+    function activeCallParticipantIds(): Set<string> | null {
+      try {
+        const list = getActiveCall()?.participants
+        if (!list || typeof list.forEach !== "function") return null
+        const ids = new Set<string>()
+        list.forEach((participant: any) => {
+          if (typeof participant?.id === "string" && participant.id) {
+            ids.add(participant.id.toLowerCase())
+          }
+        })
+        return ids
+      } catch {
+        return null
+      }
+    }
+
+    function applyVerifiedParticipants(raw: any[]): number {
+      const ids = activeCallParticipantIds()
+      if (!ids || ids.size === 0) return 0
+      const verified = raw.filter((participant) => {
+        const id = rosterId(participant)
+        return typeof id === "string" && ids.has(id.toLowerCase())
+      })
+      if (verified.length === 0) return 0
+      diag.rosterVerifiedAdmitted += verified.length
+      applyParticipants(verified)
+      return verified.length
+    }
+
+    function admitRoster(
+      url: string | undefined,
+      text: string,
+      body: any,
+      raw: any[],
+      replay: () => void
+    ): void {
+      const verdict = rosterVerdict(url, text)
+      if (verdict.accept) {
+        applyParticipants(raw)
+        return
+      }
+      if (verdict.reason === "foreign") return
+
+      if (verdict.reason === "aggregate") {
+        const own = rosterArrayOf(extractOwnRoster(body, ownConversation))
+        if (own) {
+          diag.rosterAggregateExtracted++
+          applyParticipants(own)
+          return
+        }
+      } else if (verdict.reason === "own-unknown" && quarantine.length < QUARANTINE_MAX) {
+        diag.rosterQuarantined++
+        quarantine.push(replay)
+      }
+      if (applyVerifiedParticipants(raw) === 0) countTowardStrictEscape()
     }
 
     // ===== TEAMS INTERNAL CALLING SDK (best-effort) =====
@@ -407,13 +489,12 @@ export function teamsBrowserInterceptionLogic(
     function handleRosterUpdate(eventDataObject: any): void {
       try {
         const decodedBody = decodeWebSocketBody(eventDataObject.body)
+        const raw = Object.values<any>(decodedBody?.participants || {})
+        if (raw.length === 0) return
         // The trouter socket is per user, so it carries other meetings' deltas too.
-        if (!isInMeetingScope(eventDataObject?.url, JSON.stringify(decodedBody))) {
-          debug("🔒 rejected out-of-scope roster frame", eventDataObject?.url)
-          return
-        }
-        const rawParticipants = Object.values<any>(decodedBody.participants || {})
-        applyParticipants(rawParticipants)
+        admitRoster(eventDataObject?.url, JSON.stringify(decodedBody), decodedBody, raw, () =>
+          handleRosterUpdate(eventDataObject)
+        )
       } catch (error) {
         console.error(`${LOG} ❌ Error handling roster update:`, error)
       }
@@ -437,26 +518,37 @@ export function teamsBrowserInterceptionLogic(
       return null
     }
 
+    // A generic list only counts as a roster if its entries look like call participants.
+    function rosterArrayOf(body: any): any[] | null {
+      if (!body || typeof body !== "object") return null
+      const explicit =
+        participantsToArray(body.roster?.participants) ||
+        participantsToArray(body.participants?.value) ||
+        participantsToArray(body.participants)
+      if (explicit?.length) return explicit
+      const generic = participantsToArray(body.value) || (Array.isArray(body) ? body : null)
+      return generic?.some(looksLikeParticipant) ? generic : null
+    }
+
+    function looksLikeParticipant(pp: any): boolean {
+      return (
+        !!pp &&
+        typeof pp === "object" &&
+        !!rosterId(pp) &&
+        !!rosterName(pp) &&
+        (pp.details != null || pp.endpoints != null || pp.state != null || pp.meetingRole != null)
+      )
+    }
+
     function tryHttpRoster(url: string, text: string): void {
       try {
         if (!text || text.indexOf("displayName") === -1) return
-        if (!isInMeetingScope(url, text)) {
-          debug("🔒 rejected out-of-scope roster payload", url)
-          return
-        }
         const body = JSON.parse(text)
-        // The HTTP snapshot nests the roster as { roster: { participants: {mri: {...}} } };
-        // other endpoints use top-level participants / value. Handle all as object-or-array.
-        const raw =
-          participantsToArray(body?.roster?.participants) ||
-          participantsToArray(body?.participants) ||
-          participantsToArray(body?.value) ||
-          participantsToArray(body?.participants?.value) ||
-          (Array.isArray(body) ? body : null)
-        if (raw && raw.length) {
-          diag.httpRosterHits++
-          applyParticipants(raw)
-        }
+        // Only a real roster is scope-checked, so unrelated responses never reach the escape.
+        const raw = rosterArrayOf(body)
+        if (!raw) return
+        diag.httpRosterHits++
+        admitRoster(url, text, body, raw, () => tryHttpRoster(url, text))
       } catch {
         // not JSON — ignore
       }
@@ -916,6 +1008,7 @@ export function teamsBrowserInterceptionLogic(
 
     function pollReceivers(): void {
       if ((window as any).__teamsNetworkInterceptorStopped) return
+      learnOwnConversation()
 
       const speakingParticipantIds = new Set<string>()
       let mappedCsrcThisPoll = false

--- a/src/meeting/teams/network-interception/index.ts
+++ b/src/meeting/teams/network-interception/index.ts
@@ -5,7 +5,12 @@ import path from "node:path"
 import type { Page } from "@playwright/test"
 import { GLOBAL } from "../../../singleton"
 import { teamsBrowserInterceptionLogic } from "./browser-bundle"
-import { deriveMeetingScope, resolveRosterScope, type TeamsInterceptorScope } from "./meeting-scope"
+import {
+  deriveMeetingScope,
+  extractOwnRoster,
+  resolveRosterScope,
+  type TeamsInterceptorScope
+} from "./meeting-scope"
 import { resolveSpeakingSet } from "./speaker-timeline"
 
 export type { NetworkPayload, NetworkUser } from "./types"
@@ -63,7 +68,7 @@ export async function setupTeamsNetworkInterceptionScripts(
                     console.error("[Teams NetworkInterceptor] pako dependency not loaded");
                 }
                 // As source: the stringified bundle cannot import it.
-                (${teamsBrowserInterceptionLogic.toString()})(${resolveSpeakingSet.toString()}, ${resolveRosterScope.toString()}, ${JSON.stringify(scope)});
+                (${teamsBrowserInterceptionLogic.toString()})(${resolveSpeakingSet.toString()}, ${resolveRosterScope.toString()}, ${extractOwnRoster.toString()}, ${JSON.stringify(scope)});
             } catch (e) {
                 console.error("[Teams NetworkInterceptor] Initialization error:", e);
             }

--- a/src/meeting/teams/network-interception/meeting-scope.test.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.test.ts
@@ -1,4 +1,9 @@
-import { deriveMeetingScope, findConversationIds, resolveRosterScope } from "./meeting-scope"
+import {
+  deriveMeetingScope,
+  extractOwnRoster,
+  findConversationIds,
+  resolveRosterScope
+} from "./meeting-scope"
 
 const OURS = "19:meeting_ndc4mjy5ndqtnwe2os00@thread.v2"
 const THEIRS = "19:meeting_zjjkzwrmnzytytc2os00@thread.v2"
@@ -113,11 +118,11 @@ describe("resolveRosterScope", () => {
     })
   })
 
-  it("accepts the aggregate once strict scoping has relaxed", () => {
+  it("never merges an aggregate wholesale, even once relaxed", () => {
     const body = JSON.stringify({ calls: [{ threadId: OURS }, { threadId: THEIRS }] })
     expect(resolveRosterScope({ own: OURS, body, ...signedInRelaxed })).toEqual({
-      accept: true,
-      reason: "match"
+      accept: false,
+      reason: "aggregate"
     })
   })
 
@@ -158,10 +163,22 @@ describe("resolveRosterScope", () => {
     ).toBe(true)
   })
 
-  it("accepts everything until our own conversation is identified", () => {
+  it("holds a signed-in roster until our own conversation is identified", () => {
     expect(
       resolveRosterScope({ own: null, url: `/conversations/${THEIRS}/roster`, ...signedIn })
-    ).toEqual({ accept: true, reason: "own-unknown" })
+    ).toEqual({ accept: false, reason: "own-unknown" })
+  })
+
+  it("keeps accepting unscoped rosters for anonymous or relaxed sessions", () => {
+    const input = { own: null, url: `/conversations/${THEIRS}/roster` }
+    expect(resolveRosterScope({ ...input, ...anon })).toEqual({
+      accept: true,
+      reason: "own-unknown"
+    })
+    expect(resolveRosterScope({ ...input, ...signedInRelaxed })).toEqual({
+      accept: true,
+      reason: "own-unknown"
+    })
   })
 
   it("extracts our conversation from a raw call threadId", () => {
@@ -185,5 +202,31 @@ describe("resolveRosterScope", () => {
     expect(
       rebuilt({ own: OURS, url: `/c/${THEIRS}`, isAuthenticated: true, strict: false })
     ).toEqual({ accept: false, reason: "foreign" })
+  })
+})
+
+describe("extractOwnRoster", () => {
+  it("pulls our meeting's roster out of an account-scoped aggregate", () => {
+    const ours = { threadId: OURS, participants: { "8:orgid:a": { displayName: "A" } } }
+    const body = {
+      calls: [ours, { threadId: THEIRS, participants: { "8:orgid:b": { displayName: "B" } } }]
+    }
+    expect(extractOwnRoster(body, OURS)).toBe(ours)
+  })
+
+  it("refuses a roster that also names another meeting", () => {
+    const body = { calls: [{ threadId: OURS, participants: { x: { threadId: THEIRS } } }] }
+    expect(extractOwnRoster(body, OURS)).toBeNull()
+  })
+
+  it("returns nothing until our own conversation is known", () => {
+    expect(extractOwnRoster({ calls: [{ threadId: OURS, participants: {} }] }, null)).toBeNull()
+  })
+
+  it("is self-contained, so it survives being stringified into the page", () => {
+    // biome-ignore lint/security/noGlobalEval: asserting the stringify contract
+    const rebuilt = eval(`(${extractOwnRoster.toString()})`) as typeof extractOwnRoster
+    const ours = { threadId: OURS, participants: {} }
+    expect(rebuilt({ calls: [ours, { threadId: THEIRS, participants: {} }] }, OURS)).toEqual(ours)
   })
 })

--- a/src/meeting/teams/network-interception/meeting-scope.ts
+++ b/src/meeting/teams/network-interception/meeting-scope.ts
@@ -104,7 +104,10 @@ export function resolveRosterScope(input: {
   }
 
   const ownIds = idsIn(input.own)
-  if (ownIds.length !== 1) return { accept: true, reason: "own-unknown" }
+  if (ownIds.length !== 1) {
+    // Signed-in and strict: held until our meeting is known (the caller quarantines it).
+    return { accept: !(input.isAuthenticated && input.strict), reason: "own-unknown" }
+  }
   const ownId = ownIds[0]
 
   const seen: string[] = []
@@ -121,10 +124,59 @@ export function resolveRosterScope(input: {
 
   if (seen.indexOf(ownId) === -1) return { accept: false, reason: "foreign" }
 
-  if (seen.length > 1 && input.isAuthenticated && input.strict) {
-    // Our participants also arrive call-scoped; `strict` lets a starved session relax.
+  if (seen.length > 1 && input.isAuthenticated) {
+    // Never merged wholesale, relaxed or not; the caller extracts our own part.
     return { accept: false, reason: "aggregate" }
   }
 
   return { accept: true, reason: "match" }
 }
+
+// Deepest roster sub-object naming ONLY our conversation, or null.
+// SELF-CONTAINED: stringified into the page.
+export function extractOwnRoster(body: unknown, own: string | null): unknown {
+  const CONVERSATION = /19:[^@"'\\/\s]+@thread\.[a-z0-9]+/gi
+  const idsIn = (text: string): string[] => {
+    let decoded = text
+    try {
+      decoded = decodeURIComponent(text)
+    } catch {
+      // Malformed percent-encoding — the raw pass still applies.
+    }
+    const found: string[] = []
+    for (const candidate of decoded === text ? [text] : [text, decoded]) {
+      for (const match of candidate.match(CONVERSATION) || []) {
+        const lower = match.toLowerCase()
+        if (found.indexOf(lower) === -1) found.push(lower)
+      }
+    }
+    return found
+  }
+
+  if (!own) return null
+  const ownIds = idsIn(own)
+  if (ownIds.length !== 1) return null
+  const ownId = ownIds[0]
+
+  const isOwnRoster = (node: Record<string, unknown>): boolean => {
+    if (!("participants" in node) && !("roster" in node)) return false
+    try {
+      const ids = idsIn(JSON.stringify(node))
+      return ids.length === 1 && ids[0] === ownId
+    } catch {
+      return false
+    }
+  }
+
+  const visit = (node: unknown, depth: number): unknown => {
+    if (!node || typeof node !== "object" || depth > 8) return null
+    for (const child of Object.values(node as Record<string, unknown>)) {
+      const found = visit(child, depth + 1)
+      if (found) return found
+    }
+    return !Array.isArray(node) && isOwnRoster(node as Record<string, unknown>) ? node : null
+  }
+  return visit(body, 0)
+}
+
+export type OwnRosterExtractor = typeof extractOwnRoster

--- a/src/utils/timing-control.test.ts
+++ b/src/utils/timing-control.test.ts
@@ -1,25 +1,23 @@
-const mockParams: { max_recording_duration?: number } = {}
 const mockSetError = jest.fn()
 const mockSetShouldRetry = jest.fn()
 
 jest.mock("../singleton", () => ({
   GLOBAL: {
-    get: () => mockParams,
+    get: () => ({}),
     setError: (...args: unknown[]) => mockSetError(...args),
     setShouldRetry: (...args: unknown[]) => mockSetShouldRetry(...args)
   }
 }))
 
 import { MeetingEndReason } from "../state-machine/types"
-import { handleTimingControl } from "./timing-control"
+import { handleTimingControl, JOIN_DEADLINE_AFTER_START_SEC } from "./timing-control"
 
 const now = () => Math.floor(Date.now() / 1000)
 
-describe("handleTimingControl lateness guard", () => {
+describe("handleTimingControl join deadline", () => {
   beforeEach(() => {
     mockSetError.mockClear()
     mockSetShouldRetry.mockClear()
-    mockParams.max_recording_duration = 3600
   })
 
   it("joins immediately when no start time was scheduled", async () => {
@@ -27,30 +25,24 @@ describe("handleTimingControl lateness guard", () => {
     expect(mockSetError).not.toHaveBeenCalled()
   })
 
-  it("still joins a meeting it is only modestly late for", async () => {
-    const startTime = now() - 10 * 60
+  it("still joins a scheduled meeting it is well past fifteen minutes late for", async () => {
+    // The old allowance was max(max_recording_duration, 15min): with no cap, 15m01s late
+    // was permanently rejected even though the meeting was running.
+    const startTime = now() - (15 * 60 + 1)
     await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
     expect(mockSetError).not.toHaveBeenCalled()
   })
 
-  it("allows a short cold start even when the recording cap is tiny", async () => {
-    mockParams.max_recording_duration = 60
-    const startTime = now() - 5 * 60
-    await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
-    expect(mockSetError).not.toHaveBeenCalled()
-  })
-
-  it("refuses to join hours after the meeting could still be running", async () => {
+  it("joins hours late, since lateness alone cannot prove the meeting ended", async () => {
     const startTime = now() - 5 * 3600
+    await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
+    expect(mockSetShouldRetry).not.toHaveBeenCalled()
+  })
+
+  it("refuses a relaunch past the join deadline, without retrying", async () => {
+    const startTime = now() - (JOIN_DEADLINE_AFTER_START_SEC + 60)
     await expect(handleTimingControl(startTime)).rejects.toThrow(/Refusing to join/)
     expect(mockSetError).toHaveBeenCalledWith(MeetingEndReason.TimeoutWaitingToStart)
     expect(mockSetShouldRetry).toHaveBeenCalledWith(false)
-  })
-
-  it("uses the recording cap as the allowance, not a fixed window", async () => {
-    mockParams.max_recording_duration = 4 * 3600
-    const startTime = now() - 3 * 3600
-    await expect(handleTimingControl(startTime)).resolves.toBe(startTime)
-    expect(mockSetError).not.toHaveBeenCalled()
   })
 })

--- a/src/utils/timing-control.ts
+++ b/src/utils/timing-control.ts
@@ -1,13 +1,9 @@
 import { GLOBAL } from "../singleton"
 import { MeetingEndReason } from "../state-machine/types"
 
-// Past max_recording_duration the meeting is over; the floor still allows a cold start.
-const MIN_LATENESS_ALLOWANCE_SEC = 15 * 60
-
-function latenessAllowanceSec(): number {
-  const cap = GLOBAL.get().max_recording_duration
-  return Math.max(typeof cap === "number" && cap > 0 ? cap : 0, MIN_LATENESS_ALLOWANCE_SEC)
-}
+// No meeting-end time reaches the bot, so lateness can't prove a meeting ended (the waiting
+// room timeout handles that). This only stops a relaunch past the longest meeting we record.
+export const JOIN_DEADLINE_AFTER_START_SEC = 12 * 60 * 60
 
 /**
  * Handles timing control for precise meeting join times.
@@ -62,15 +58,14 @@ export async function handleTimingControl(
     return startTime
   }
   const lateBy = currentTime - startTime
-  const allowance = latenessAllowanceSec()
-  if (lateBy > allowance) {
+  if (lateBy > JOIN_DEADLINE_AFTER_START_SEC) {
     console.error(
-      `Bot is late by ${lateBy}s, past its ${allowance}s allowance — the meeting cannot still be running. Not joining.`
+      `Bot is late by ${lateBy}s, past the ${JOIN_DEADLINE_AFTER_START_SEC}s join deadline. Not joining.`
     )
     GLOBAL.setError(MeetingEndReason.TimeoutWaitingToStart)
     GLOBAL.setShouldRetry(false)
     throw new Error(
-      `Refusing to join ${lateBy}s after the scheduled start (allowance ${allowance}s)`
+      `Refusing to join ${lateBy}s after the scheduled start (deadline ${JOIN_DEADLINE_AFTER_START_SEC}s)`
     )
   }
   console.log(


### PR DESCRIPTION
## Summary

Follow-up to the roster scoping and diarization work, addressing review findings.

**Watchdog terminations are now reported as terminal.** When the consumer's watchdog killed a bot that outlived its recording window before the recording finalized, the bot uploaded its logs, skipped the requeue and exited without telling anyone, so it stayed nonterminal. It now goes through the same failure handling as every other terminal failure: `recording_failed` is emitted and the backend is notified. The kill is recorded as an internal error rather than a normal end reason.

**Teams roster admission for signed-in sessions.** Four gaps are closed.

- A signed-in session whose meeting is not yet known, as with short join links, no longer accepts every roster it sees. Those rosters are held and replayed once the meeting is identified, so participants from other calls on the same account cannot be merged in the meantime.
- Account-scoped aggregate payloads are never merged wholesale, even after strict scoping relaxes. Only the part that names this meeting and nothing else is taken.
- Participants from payloads that cannot be placed are admitted when the calling SDK's own participant list for the active call confirms them. This recovers the roster through call-scoped data instead of relaxing blindly.
- Only real roster structures are scope-checked, so unrelated responses such as profile lookups no longer count toward the starvation escape. That escape now triggers while nobody besides the bot has been recovered. Previously it could never trigger once the bot's own record existed.

**Explicit join deadline.** A scheduled bot's lateness allowance was derived from the maximum recording duration. That value measures how long to record, not when the meeting ends, and with no cap set a bot fifteen minutes and one second late was rejected permanently. No meeting end time reaches the bot, so lateness alone cannot prove a meeting is over, and the waiting room timeout already ends a join into an empty meeting. The guard is now an explicit join deadline whose only purpose is to stop a relaunch far past the longest meeting the product records.

## Testing

Type check clean. The full Jest suite passes apart from one browser-dependent suite, which needs Playwright browsers installed locally and is unrelated to these changes.

New and updated coverage:

- A signed-in roster is held while the meeting is unknown, and still accepted for anonymous or relaxed sessions.
- Aggregates are never merged wholesale.
- This meeting's roster is extracted from an aggregate. The extraction refuses a subtree that also names another meeting and survives being stringified into the page.
- Join deadline: fifteen minutes late and hours late both join, and past the deadline the bot refuses without retrying.

The watchdog path runs inside the process signal handler and has no unit coverage, so it is verified by type check only. The in-page roster admission is covered through its pure helpers; the wiring inside the injected bundle is verified by type check. Formatting was not verified locally because the Biome native binary is not installed in this environment.

## Release Notes

Bots stopped by the recording-window watchdog now report a terminal failure instead of remaining in progress.

For signed-in Teams bots, participant lists can no longer pick up people from other meetings on the same account while the bot is still identifying its meeting. Meetings whose roster only arrives in account-wide form now recover their participants.

Scheduled bots that start late now still join a meeting that is running, instead of being rejected after fifteen minutes.
