### PR TITLE
feat(chat): retry Teams chat input and report bot.chat_status event

### DIFF
--- a/src/chat-manager.ts
+++ b/src/chat-manager.ts
@@ -316,7 +316,20 @@ export class ChatManager {
           if (btn) { btn.click(); return true }
           return false
         })
-        await page.waitForSelector(inputSelectors.join(", "), { timeout: 2000 })
+        // Teams lazy-loads the chat panel; a single 2s wait loses the race on
+        // a meaningful share of meetings (the input only mounts seconds later).
+        // Wait patiently — bounded retries, same budget the panel-open path uses.
+        for (let attempt = 0; attempt < 5; attempt++) {
+          try {
+            await page.waitForSelector(inputSelectors.join(', '), { timeout: 2000 })
+            break
+          } catch {
+            if (attempt === 4) {
+              return { success: false, error: 'Chat input not found', status: 400 }
+            }
+            await page.waitForTimeout(1000)
+          }
+        }
       }
 
       // Find which selector matches
@@ -418,4 +431,40 @@ export class ChatManager {
       }
     })
   }
+}
+
+export type ChatAvailabilityReason =
+  | "organizer_disabled"
+  | "panel_not_attached"
+  | "send_failed"
+  | null
+
+/**
+ * Report once per meeting, right after joining, whether the bot can actually
+ * use chat — based on the entry-message attempt and the chat-panel attach
+ * outcome. Lets integrators disable chat-dependent UX (slash commands, chat
+ * panels) at runtime instead of discovering a dead chat after the meeting.
+ * Fire-and-forget.
+ */
+export function reportChatStatus(available: boolean, reason: ChatAvailabilityReason): void {
+  if (envVars.SERVERLESS) return
+
+  const params = GLOBAL.get()
+  axios({
+    method: "POST",
+    url: "/bot-process/chat-status",
+    data: {
+      bot_id: params.bot_id,
+      bot_uuid: params.bot_uuid,
+      available,
+      reason
+    }
+  }).catch((error) => {
+    if (error instanceof Error) {
+      console.warn(
+        "[ChatManager] Failed to report chat status (continuing):",
+        error.message
+      )
+    }
+  })
 }

--- a/src/meeting/chatObserver.ts
+++ b/src/meeting/chatObserver.ts
@@ -70,4 +70,15 @@ export class ChatObserver {
     }
     return false
   }
+
+  /**
+   * How the chat-panel attach went ("ready" / "disabled" / "failed"). Only
+   * meaningful for Teams; other platforms report "unknown".
+   */
+  public getPanelAttachOutcome(): "ready" | "disabled" | "failed" | "unknown" {
+    if (this.observer instanceof TeamsChatObserver) {
+      return this.observer.panelAttachOutcome
+    }
+    return "unknown"
+  }
 }

--- a/src/meeting/teams/chatObserver.ts
+++ b/src/meeting/teams/chatObserver.ts
@@ -190,6 +190,23 @@ export class TeamsChatObserver {
             return false
           }
 
+          // The pane list alone is NOT success — sending needs the CKEditor
+          // input, and Teams mounts it a beat after the panel. Wait for one of
+          // the three input selectors specifically; otherwise keep retrying
+          // (same as the panel-open case above).
+          try {
+            await this.page.waitForSelector(
+              '[aria-label="Type a message"], [placeholder="Type a message"], div[data-tid="ckeditor"][role="textbox"]',
+              { timeout: CHAT_ACTION_TIMEOUT_MS }
+            )
+          } catch {
+            console.warn(`[TeamsChatObserver] Panel open but chat input not ready, attempt ${attempt}/${MAX_CHAT_OPEN_RETRIES}`)
+            if (attempt < MAX_CHAT_OPEN_RETRIES) {
+              await this.page.waitForTimeout(CHAT_RETRY_INTERVAL_MS)
+            }
+            continue
+          }
+
           console.log("[TeamsChatObserver] Chat panel opened successfully")
           return true
         } catch {

--- a/src/meeting/teams/chatObserver.ts
+++ b/src/meeting/teams/chatObserver.ts
@@ -16,6 +16,12 @@ export class TeamsChatObserver {
   private page: Page
   private isObserving = false
   private _chatDisabled = false
+  /**
+   * Outcome of trying to attach the chat panel: "ready" (input usable),
+   * "disabled" (organizer turned chat off), "failed" (panel never became
+   * usable — reading may still work via the bind hook, sending will not).
+   */
+  public panelAttachOutcome: "ready" | "disabled" | "failed" = "failed"
 
   constructor(page: Page) {
     this.page = page
@@ -62,6 +68,7 @@ export class TeamsChatObserver {
 
     // Open the chat panel (needed for sending)
     const chatOpened = await this.openChatPanel()
+    this.panelAttachOutcome = chatOpened ? "ready" : this._chatDisabled ? "disabled" : "failed"
     if (!chatOpened) {
       console.warn("[TeamsChatObserver] Could not open chat panel, observation may be limited")
     }

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -273,7 +273,9 @@ export class InCallState extends BaseState {
     const chatObserver = this.context.chatObserver
 
     // No entry message configured: fall back to what the observer saw while
-    // attaching the panel (only Teams learns anything there).
+    // attaching the panel (only Teams learns anything there). An "unknown"
+    // outcome means the observer never came up — report it as not attached
+    // rather than staying silent.
     if (entrySendOutcome == null) {
       if (platform === "teams" && chatObserver) {
         const outcome = chatObserver.getPanelAttachOutcome()
@@ -281,7 +283,8 @@ export class InCallState extends BaseState {
           reportChatStatus(true, null)
         } else if (outcome === "disabled") {
           reportChatStatus(false, "organizer_disabled")
-        } else if (outcome === "failed") {
+        } else {
+          // "failed" and "unknown" both mean we never saw a usable panel
           reportChatStatus(false, "panel_not_attached")
         }
       }

--- a/src/state-machine/states/in-call-state.ts
+++ b/src/state-machine/states/in-call-state.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test"
 import { switchToRecordingBranding } from "../../branding"
-import { ChatManager } from "../../chat-manager"
+import { ChatManager, reportChatStatus } from "../../chat-manager"
 import { Events } from "../../events"
 import { ChatObserver } from "../../meeting/chatObserver"
 import { HtmlCleaner } from "../../meeting/htmlCleaner"
@@ -224,6 +224,8 @@ export class InCallState extends BaseState {
     }
 
     // Send entry message after chat observation is ready
+    // Single shape (strictNullChecks is off here — no discriminant narrowing).
+    let entrySendOutcome: { success: boolean; error?: string } | null = null
     if (GLOBAL.get().entry_message && this.context.playwrightPage) {
       console.log(`Sending entry message via ChatManager (platform=${platform})...`)
       try {
@@ -235,6 +237,7 @@ export class InCallState extends BaseState {
         )
         if (result.success) {
           console.log("[InCallState] Entry message sent successfully")
+          entrySendOutcome = { success: true }
           // Only the ENTRY message arms the zoom end-detection grace window.
           // Mid-meeting bot chat sends (e.g. API-triggered) must NOT re-arm it,
           // otherwise a genuine removal right after such a message could be
@@ -244,10 +247,59 @@ export class InCallState extends BaseState {
           }
         } else {
           console.error("[InCallState] Entry message failed:", (result as { error: string }).error)
+          entrySendOutcome = { success: false, error: (result as { error: string }).error }
         }
       } catch (error) {
         console.error("Failed to send entry message:", formatError(error))
+        entrySendOutcome = {
+          success: false,
+          error: error instanceof Error ? error.message : formatError(error).message,
+        }
       }
+    }
+
+    this.reportChatAvailability(platform, entrySendOutcome)
+  }
+
+  /**
+   * One-shot chat-availability signal, sent right after join. Lets integrators
+   * disable chat-dependent UX (slash commands, chat panels) at runtime instead
+   * of discovering a dead chat after the meeting.
+   */
+  private reportChatAvailability(
+    platform: string,
+    entrySendOutcome: { success: boolean; error?: string } | null
+  ): void {
+    const chatObserver = this.context.chatObserver
+
+    // No entry message configured: fall back to what the observer saw while
+    // attaching the panel (only Teams learns anything there).
+    if (entrySendOutcome == null) {
+      if (platform === "teams" && chatObserver) {
+        const outcome = chatObserver.getPanelAttachOutcome()
+        if (outcome === "ready") {
+          reportChatStatus(true, null)
+        } else if (outcome === "disabled") {
+          reportChatStatus(false, "organizer_disabled")
+        } else if (outcome === "failed") {
+          reportChatStatus(false, "panel_not_attached")
+        }
+      }
+      return
+    }
+
+    if (entrySendOutcome.success) {
+      reportChatStatus(true, null)
+      return
+    }
+
+    const errorText = entrySendOutcome.error ?? ""
+    if (chatObserver?.isChatDisabled()) {
+      reportChatStatus(false, "organizer_disabled")
+    } else if (errorText.includes("Chat input not found")) {
+      reportChatStatus(false, "panel_not_attached")
+    } else {
+      reportChatStatus(false, "send_failed")
     }
   }
 


### PR DESCRIPTION
## What

1. **Send retry**: `sendViaTeams` now waits patiently for the CKEditor (5 x 2s + 1s pauses) instead of a single 2s `waitForSelector` — Teams lazy-loads the chat input seconds after join, and the single-shot wait lost that race on a meaningful share of meetings.
2. **Runtime chat-availability signal**: one-shot `bot.chat_status` webhook right after join — `{ available, reason }` where reason is `organizer_disabled` / `panel_not_attached` / `send_failed` — so integrators can disable chat-dependent UX (slash commands) at runtime instead of discovering a dead chat after the meeting. Reported from the entry-message attempt, or the chat-panel attach outcome when no entry message is configured.

## Context (self-hosted integrator report)

806 completed bots between Sept 2 and Sept 9: **88/603 on Teams (14.6%)** vs 1/199 on Meet and 0/4 on Zoom, stable every day. Symptom: entry message never posted, zero `bot.chat_message` webhooks, no errors anywhere — recording itself fine. Proof it's not a meeting setting: two bots in the same meeting at the same time, one with chat and one without (per-session Teams build variance). Affected bots show a longer `in_call_not_recording -> in_call_recording` gap — the panel attach losing its race.

The API side (new `/bot-process/chat-status` route + `bot.chat_status` SVIX event) lands in Meeting-BaaS/meeting-baas-v2.

## Known related gap (not addressed here)

The read path's bind hook matches `Function.prototype.name === "onMessageReceived"` exactly — a Teams build where that name differs yields zero received messages. Needs live-build validation before changing.

## Test plan

- `tsc --skipLibCheck --noEmit` clean (bot tsconfig has strictNullChecks off — avoided discriminant narrowing accordingly)
- `biome lint` clean on changed files
- Manual: Teams meeting with entry message → expect `bot.chat_status` {available:true}; a chat-disabled meeting → {available:false, reason:organizer_disabled}